### PR TITLE
@stratusjs/idx 0.3.3 @stratusjs/swiper 0.0.4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,11 +88,15 @@ const location = {
   preserve: {
     core: [
       'packages/angularjs/src/**/*.js',
-      'packages/angularjs-extras/src/**/*.js'
+      'packages/angularjs-extras/src/**/*.js',
+      'packages/idx/src/**/*.js',
+      'packages/swiper/src/**/*.js'
     ],
     min: [
       'packages/angularjs/src/**/*.min.js',
-      'packages/angularjs-extras/src/**/*.min.js'
+      'packages/angularjs-extras/src/**/*.min.js',
+      'packages/idx/src/**/*.min.js',
+      'packages/swiper/src/**/*.min.js'
     ]
   },
   less: {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.3-beta.0",
+  "version": "0.3.2.beta.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -27,7 +27,7 @@
   "dependencies": {
     "@stratusjs/angularjs": "^0.2.4",
     "@stratusjs/angularjs-extras": "^0.2.2",
-    "@stratusjs/runtime": "^0.10.0",
+    "@stratusjs/runtime": "^0.10.1",
     "@stratusjs/swiper": "^0.0.2"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.2.beta.1",
+  "version": "0.3.3-beta.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -28,6 +28,6 @@
     "@stratusjs/angularjs": "^0.2.4",
     "@stratusjs/angularjs-extras": "^0.2.2",
     "@stratusjs/runtime": "^0.10.1",
-    "@stratusjs/swiper": "^0.0.2"
+    "@stratusjs/swiper": "^0.0.3"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.3-beta.1",
+  "version": "0.3.3",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -28,6 +28,6 @@
     "@stratusjs/angularjs": "^0.2.4",
     "@stratusjs/angularjs-extras": "^0.2.2",
     "@stratusjs/runtime": "^0.10.1",
-    "@stratusjs/swiper": "^0.0.3"
+    "@stratusjs/swiper": "^0.0.4"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.2",
+  "version": "0.3.3-beta.0",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/src/member/details.component.ts
+++ b/packages/idx/src/member/details.component.ts
@@ -30,7 +30,7 @@ const packageName = 'idx'
 const moduleName = 'member'
 const componentName = 'details'
 // There is not a very consistent way of pathing in Stratus at the moment
-const localDir = `/${boot.bundle}node_modules/@stratusjs/${packageName}/src/${moduleName}/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.IdxMemberDetails = {
     bindings: {

--- a/packages/idx/src/member/list.component.ts
+++ b/packages/idx/src/member/list.component.ts
@@ -30,7 +30,7 @@ const packageName = 'idx'
 const moduleName = 'member'
 const componentName = 'list'
 // There is not a very consistent way of pathing in Stratus at the moment
-const localDir = `/${boot.bundle}node_modules/@stratusjs/${packageName}/src/${moduleName}/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.IdxMemberList = {
     bindings: {

--- a/packages/idx/src/member/search.component.ts
+++ b/packages/idx/src/member/search.component.ts
@@ -27,7 +27,7 @@ const packageName = 'idx'
 const moduleName = 'member'
 const componentName = 'search'
 // There is not a very consistent way of pathing in Stratus at the moment
-const localDir = `/${boot.bundle}node_modules/@stratusjs/${packageName}/src/${moduleName}/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.IdxMemberSearch = {  // FIXME should be just MemberSearch or IdxMemberSearch
     bindings: {

--- a/packages/idx/src/property/details-sub-section.component.ts
+++ b/packages/idx/src/property/details-sub-section.component.ts
@@ -21,7 +21,7 @@ const packageName = 'idx'
 const moduleName = 'property'
 const componentName = 'details-sub-section'
 // There is not a very consistent way of pathing in Stratus at the moment
-const localDir = `/${boot.bundle}node_modules/@stratusjs/${packageName}/src/${moduleName}/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.IdxPropertyDetailsSubSection = {
     bindings: {

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -17,7 +17,7 @@
 			<stratus-carousel init-now="model.completed" images="{{::getSlideshowImages()}}"></stratus-carousel>
 		</div>
 		<div class="gallery-fallback">
-			<img data-ng-if="!model.data.Images" data-ng-src="/content/property/stratus/components/images/no-image.jpg">
+			<img data-ng-if="!model.data.Images" data-ng-src="{{::localDir}}images/no-image.jpg">
 		</div>
 
 
@@ -204,9 +204,10 @@
 			</a>
 			<div class="image-dimmer"></div>
 			<!-- parallax-content disabled, cannot use height altering on the entire widget -->
+            <!-- FIXME {} can't be used in inline styles as it won't resolve before the page loads (or may not exist) -->
 			<div class="" style="background: url('{{model.data.Images[0].MediaURL}}') no-repeat center center; background-size: cover;">
-				<img data-ng-if="model.data.Images && model.data.Images.length > 0" data-ng-src="/content/property/stratus/components/images/stratus-property-shapeholder.png" alt="{{::model.data.UnparsedAddress}}"/>
-				<img data-ng-if="!model.data.Images" data-ng-src="/content/property/stratus/components/images/no-image-simple.jpg">
+				<img data-ng-if="model.data.Images && model.data.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="{{::model.data.UnparsedAddress}}"/>
+				<img data-ng-if="!model.data.Images" data-ng-src="{{::localDir}}images/no-image-simple.jpg">
 			</div>
 		</div>
 
@@ -223,7 +224,7 @@
 					<div class="schematics-image floorplan-image">
 						<a href="">
 							<data-md-tooltip>Click to enlarge</data-md-tooltip>
-							<img src="/content/property/stratus/components/images/temporary-floorplan.png" alt="Site Plan"/>
+							<img data-ng-src="{{::localDir}}images/temporary-floorplan.png" alt="Site Plan"/>
 						</a>
 					</div>
 					<h4>Floorplan</h4>
@@ -235,7 +236,7 @@
 					<div class="schematics-image siteplan-image">
 						<a href="">
 							<data-md-tooltip>Click to enlarge</data-md-tooltip>
-							<img src="/content/property/stratus/components/images/temporary-siteplan.png" alt="Site Plan"/>
+							<img data-ng-src="{{::localDir}}images/temporary-siteplan.png" alt="Site Plan"/>
 						</a>
 					</div>
 					<h4>Siteplan</h4>

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -70,6 +70,7 @@ Stratus.Components.IdxPropertyDetails = {
         $ctrl.uid = _.uniqueId(_.camelCase(packageName) + '_' + _.camelCase(moduleName) + '_' + _.camelCase(componentName) + '_')
         Stratus.Instances[$ctrl.uid] = $scope
         $scope.elementId = $attrs.elementId || $ctrl.uid
+        $scope.localDir = localDir
         if ($attrs.tokenUrl) {
             Idx.setTokenURL($attrs.tokenUrl)
         }
@@ -745,7 +746,10 @@ Stratus.Components.IdxPropertyDetails = {
 
         $scope.getSlideshowImages = (): { src: string }[] => {
             const images: { src: string }[] = []
-            if ($scope.model.data.Images) {
+            if (
+                $scope.model.data.Images &&
+                _.isArray($scope.model.data.Images)
+            ) {
                 $scope.model.data.Images.forEach((image: { MediaURL?: string }) => {
                     // TODO need title/description variables
                     if (Object.prototype.hasOwnProperty.call(image, 'MediaURL')) {

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -38,7 +38,7 @@ const packageName = 'idx'
 const moduleName = 'property'
 const componentName = 'details'
 // There is not a very consistent way of pathing in Stratus at the moment
-const localDir = `/${boot.deployment}@stratusjs/${packageName}/src/${moduleName}/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.IdxPropertyDetails = {
     bindings: {

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -24,8 +24,8 @@
 						<a data-ng-click="displayPropertyDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}">
 
 							<div style="background: url('{{::property.Images[0].MediaURL}}') no-repeat center center; background-size: cover;">
-								<img data-ng-if="::property.Images.length > 0" data-ng-src="/content/property/stratus/components/images/stratus-property-shapeholder.png" alt="shapeholder" />
-								<img data-ng-if="::property.Images.length === 0" data-ng-src="/content/property/stratus/components/images/no-image.jpg">
+								<img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="shapeholder" />
+								<img data-ng-if="::property.Images.length === 0" data-ng-src="{{::localDir}}images/no-image.jpg">
 							</div>
 						</a>
 					</div>

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -98,7 +98,6 @@ stratus-idx-property-list {
               position: absolute;
               right: 20px;
               top: 20px;
-              z-index: 10;
               display: table;
               margin: 0 auto 20px;
               padding: 2px 4px 2px 5px;

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -61,6 +61,7 @@ Stratus.Components.IdxPropertyList = {
         $ctrl.uid = _.uniqueId(_.camelCase(packageName) + '_' + _.camelCase(moduleName) + '_' + _.camelCase(componentName) + '_')
         Stratus.Instances[$ctrl.uid] = $scope
         $scope.elementId = $attrs.elementId || $ctrl.uid
+        $scope.localDir = localDir
         if ($attrs.tokenUrl) {
             Idx.setTokenURL($attrs.tokenUrl)
         }

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -31,8 +31,7 @@ const min = !cookie('env') ? '.min' : ''
 const packageName = 'idx'
 const moduleName = 'property'
 const componentName = 'list'
-// There is not a very consistent way of pathing in Stratus at the moment
-const localDir = `/${boot.bundle}node_modules/@stratusjs/${packageName}/src/${moduleName}/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.IdxPropertyList = {
     bindings: {

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -24,7 +24,7 @@ const packageName = 'idx'
 const moduleName = 'property'
 const componentName = 'search'
 // There is not a very consistent way of pathing in Stratus at the moment
-const localDir = `/${boot.bundle}node_modules/@stratusjs/${packageName}/src/${moduleName}/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.IdxPropertySearch = {
     bindings: {

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.0.2",
+  "version": "0.0.2-beta.0",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.0.2-beta.0",
+  "version": "0.0.3",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {
@@ -27,7 +27,7 @@
   "dependencies": {
     "@stratusjs/angularjs": "^0.2.4",
     "@stratusjs/angularjs-extras": "^0.2.2",
-    "@stratusjs/runtime": "^0.10.0",
+    "@stratusjs/runtime": "^0.10.1",
     "swiper": "^5.0.4"
   }
 }

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/swiper/src/carousel.js
+++ b/packages/swiper/src/carousel.js
@@ -127,7 +127,7 @@ import Swiper from 'swiper'
 
         // noinspection JSIgnoredPromiseFromCall
         // Stratus.Internals.CssLoader(Stratus.BaseUrl + Stratus.BundlePath + 'node_modules/swiper/dist/css/swiper' + min + '.css')
-        Stratus.Internals.CssLoader(`${Stratus.BaseUrl}${Stratus.DeploymentPath}swiper/css/swiper${min}.css`)
+        Stratus.Internals.CssLoader(`${Stratus.BaseUrl}${Stratus.DeploymentPath}swiper/dist/css/swiper${min}.css`)
 
         // Hoist Attributes
         $scope.property = $attrs.property || null

--- a/packages/swiper/src/carousel.js
+++ b/packages/swiper/src/carousel.js
@@ -55,9 +55,7 @@ import Swiper from 'swiper'
   const packageName = 'swiper'
   // const moduleName = 'components'
   const componentName = 'carousel'
-// There is not a very consistent way of pathing in Stratus at the moment
-  // const localDir = `/${boot.deployment}@stratusjs/${packageName}/src/${moduleName}/`
-  const localDir = `/${boot.deployment}@stratusjs/${packageName}/src/`
+  const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/`
 
   // This component is just a simple base.
   Stratus.Components.SwiperCarousel = {

--- a/packages/swiper/src/carousel.js
+++ b/packages/swiper/src/carousel.js
@@ -127,7 +127,7 @@ import Swiper from 'swiper'
 
         // noinspection JSIgnoredPromiseFromCall
         // Stratus.Internals.CssLoader(Stratus.BaseUrl + Stratus.BundlePath + 'node_modules/swiper/dist/css/swiper' + min + '.css')
-        Stratus.Internals.CssLoader(`/${boot.deployment}swiper/css/swiper${min}.css`)
+        Stratus.Internals.CssLoader(`${Stratus.BaseUrl}${Stratus.DeploymentPath}swiper/css/swiper${min}.css`)
 
         // Hoist Attributes
         $scope.property = $attrs.property || null


### PR DESCRIPTION
- Fixed gulp min file mangling
- Corrected file pathing for local templates/css, library css, and images
- Fixed template design issues

Known Issues:
- When the swiper is minified, is is unable to use the function `camelToSnake` and breaks.