### PR TITLE
@stratusjs/idx 0.3.8 @stratusjs/idx 0.1.2

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.7",
+  "version": "0.3.9-beta.0",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -28,6 +28,6 @@
     "@stratusjs/angularjs": "^0.2.8",
     "@stratusjs/angularjs-extras": "^0.2.5",
     "@stratusjs/runtime": "^0.10.3",
-    "@stratusjs/swiper": "^0.1.1"
+    "@stratusjs/swiper": "^0.1.2"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.6-beta.0",
+  "version": "0.3.6",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.6",
+  "version": "0.3.7-beta.0",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.7-beta.0",
+  "version": "0.3.7",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -111,7 +111,7 @@
 
 
 					<div class="mls-service-container">
-						<div class="mls-service" data-ng-if="::model.data.ListingKey || ::model.data.ListingId">
+						<div class="mls-service" data-ng-if="::model.data.ListingId || model.data.ListingKey">
 							<span data-ng-bind="getMLSName()"></span>#
 							<span data-ng-bind="::model.data.ListingId || model.data.ListingKey"></span>
 						</div>

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -26,7 +26,6 @@
             <stratus-swiper-carousel
                     data-init-now="model.completed"
                     data-slides="images"
-                    data-autoplay="true"
             ></stratus-swiper-carousel>
             <!-- autoplay="true" -->
             <!-- pagination='{"clickable":true,"render":"numberBullet"}' -->

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -709,7 +709,7 @@ Stratus.Components.IdxPropertyDetails = {
                 Idx.refreshUrlOptions($scope.defaultListOptions)
                 if ($scope.options.pageTitle) {
                     // Update the page title
-                    Idx.setPageTitle(data.UnparsedAddress)
+                    Idx.setPageTitle($scope.getStreetAddress())
                 }
             }
         })

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -20,7 +20,7 @@
             <div ng-if="collection.completed && !collection.pending && collection.models.length === 0" class="no-results">
                 There are no listings that fit your search. Perhaps try less specific or different criteria.
             </div>
-			<div data-ng-repeat="property in collection.models | limitTo:options.perPage:(options.page-1)*options.perPage" id="{{::elementId}}_{{::property._id}}"
+			<div data-ng-repeat="property in collection.models | limitTo:query.perPage:(query.page-1)*query.perPage" id="{{::elementId}}_{{::property._id}}"
                  class="property-container" data-ng-cloak
             >
 				<md-card class="property-item">
@@ -78,15 +78,15 @@
 	<div class="pager-container clearfix">
 		<div class="pager-section" ng-if="collection.meta.data.totalPages >= 2">
 			<div class="pager-count" data-ng-if="collection.meta.data.totalRecords">
-				<span data-ng-bind="options.page"></span>/<span data-ng-bind="collection.meta.data.totalPages"></span> Pages
+				<span data-ng-bind="query.page"></span>/<span data-ng-bind="collection.meta.data.totalPages"></span> Pages
 				<span class="pager-totals">
-                ( <!--<span data-ng-bind="(options.page-1)*options.perPage+1"></span>-<span data-ng-bind="(options.page*options.perPage)|min:collection.meta.data.totalRecords"></span> of --><span data-ng-bind="collection.meta.data.totalRecords"></span> properties )
+                ( <!--<span data-ng-bind="(query.page-1)*query.perPage+1"></span>-<span data-ng-bind="(query.page*query.perPage)|min:collection.meta.data.totalRecords"></span> of --><span data-ng-bind="collection.meta.data.totalRecords"></span> properties )
                 </span>
 			</div>
-			<a class="pager-button {{options.page > 1 && collection.completed ? '' : 'disabled'}}" data-ng-click="pagePrevious($event)">
+			<a class="pager-button {{query.page > 1 && collection.completed ? '' : 'disabled'}}" data-ng-click="pagePrevious($event)">
 				<i class="arrow small left"></i>
 			</a>
-			<a class="pager-button {{options.page < collection.meta.data.totalPages && collection.completed ? '' : 'disabled'}}" data-ng-click="pageNext($event)">
+			<a class="pager-button {{query.page < collection.meta.data.totalPages && collection.completed ? '' : 'disabled'}}" data-ng-click="pageNext($event)">
 				<i class="arrow small right"></i>
 			</a>
 		</div>

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -169,7 +169,6 @@ Stratus.Components.IdxPropertyList = {
         ): Promise<Collection> =>
             $q((resolve: any) => {
                 query = query || {}
-                console.log('set to search ', query)
                 updateUrl = updateUrl === false ? updateUrl : true
 
                 // If refreshing, reset to page 1
@@ -215,7 +214,6 @@ Stratus.Components.IdxPropertyList = {
                 // Keep the Search widgets up to date
                 $scope.refreshSearchWidgetOptions()
 
-                console.log('will search ', $scope.query)
                 // Grab the new property listings
                 resolve(Idx.fetchProperties($scope, 'collection', $scope.query, refresh))
             })

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -90,7 +90,10 @@ Stratus.Components.IdxPropertyList = {
             /** type {string|null} */
             $scope.detailsTemplate = $attrs.detailsTemplate || null
 
-            $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) : {}
+            // TODO added backwards compatible options <--> query parameter until the next version
+            $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) :
+                $attrs.options && isJSON($attrs.options) ? JSON.parse($attrs.options) : {}
+            // $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) : {}
 
             $scope.query.order = $scope.query.order || null // will be set by Service
             $scope.query.page = $scope.query.page || null // will be set by Service

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -9,26 +9,6 @@
 					   autocomplete="off"
 				>
 			</md-input-container>
-
-            <md-autocomplete
-                 md-min-length="0"
-                 md-max-length="250"
-                 md-search-text="options.query.City"
-                 md-items="item in autoCompleteCity(options.query.City)"
-                 md-item-text="item.display"
-                 md-selected-item="options.query.City"
-                 md-floating-label="Enter City"
-                 md-clear-button="true"
-                 data-ng-keyup="$event.keyCode == 13 && options.query.City && searchProperties()"
-                 autocomplete="off"
-             >
-                <md-item-template>
-                    <span>{{item.display}}</span>
-                </md-item-template>
-                <md-not-found>
-                    Nothing found
-                </md-not-found>
-            </md-autocomplete>
 		</div>
 	</div>
 

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -9,6 +9,26 @@
 					   autocomplete="off"
 				>
 			</md-input-container>
+
+            <md-autocomplete
+                 md-min-length="0"
+                 md-max-length="250"
+                 md-search-text="options.query.City"
+                 md-items="item in autoCompleteCity(options.query.City)"
+                 md-item-text="item.display"
+                 md-selected-item="options.query.City"
+                 md-floating-label="Enter City"
+                 md-clear-button="true"
+                 data-ng-keyup="$event.keyCode == 13 && options.query.City && searchProperties()"
+                 autocomplete="off"
+             >
+                <md-item-template>
+                    <span>{{item.display}}</span>
+                </md-item-template>
+                <md-not-found>
+                    Nothing found
+                </md-not-found>
+            </md-autocomplete>
 		</div>
 	</div>
 

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -176,6 +176,18 @@ Stratus.Components.IdxPropertySearch = {
         })
 
         /**
+         * Create filter function for a query string
+         */
+        const createFilterFor = (query: string) => {
+            const lowercaseQuery = query.toLowerCase()
+
+            return (hay: any) => {
+                return (hay.value.indexOf(lowercaseQuery) === 0)
+            }
+
+        }
+
+        /**
          * Update a scope nest variable from a given string path.
          * Works with updateNestedPathValue
          */
@@ -409,6 +421,28 @@ Stratus.Components.IdxPropertySearch = {
                     instance.refreshSearchWidgetOptions()
                 }
             }
+        }
+
+        /**
+         * Placeholder for future auto complete
+         */
+        $scope.autoCompleteCity = (query: string): any[] => {
+            const test = [
+                {
+                    value: 'test',
+                    display: 'Test'
+                },
+                {
+                    value: 'concord',
+                    display: 'Concord'
+                },
+                {
+                    value: 'fremont',
+                    display: 'Fremont'
+                }
+            ]
+            return query ? test.filter(createFilterFor(query)) : []
+            // return ['Test', 'Concord', 'Fremont']
         }
     },
     templateUrl: ($attrs: angular.IAttributes): string => `${localDir}${$attrs.template || componentName}.component${min}.html`

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -164,6 +164,9 @@ Stratus.Components.IdxPropertySearch = {
         }
         $scope.$watch('options.query.ListingType', () => {
             if ($scope.options.selection.ListingType.list) {
+                if (!_.isArray($scope.options.query.ListingType)) {
+                    $scope.options.query.ListingType = [$scope.options.query.ListingType]
+                }
                 $scope.options.selection.ListingType.group.Residential =
                     $scope.arrayIntersect($scope.options.selection.ListingType.list.Residential, $scope.options.query.ListingType)
                 $scope.options.selection.ListingType.group.Commercial =
@@ -279,7 +282,7 @@ Stratus.Components.IdxPropertySearch = {
                 !_.isArray(array) ||
                 !_.isArray(itemArray)
             ) {
-                console.warn('Array undefined, cannot search for', itemArray)
+                console.warn('Array undefined, cannot search for', itemArray, 'in', array)
                 // return []
                 return false
             }

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -422,28 +422,6 @@ Stratus.Components.IdxPropertySearch = {
                 }
             }
         }
-
-        /**
-         * Placeholder for future auto complete
-         */
-        $scope.autoCompleteCity = (query: string): any[] => {
-            const test = [
-                {
-                    value: 'test',
-                    display: 'Test'
-                },
-                {
-                    value: 'concord',
-                    display: 'Concord'
-                },
-                {
-                    value: 'fremont',
-                    display: 'Fremont'
-                }
-            ]
-            return query ? test.filter(createFilterFor(query)) : []
-            // return ['Test', 'Concord', 'Fremont']
-        }
     },
     templateUrl: ($attrs: angular.IAttributes): string => `${localDir}${$attrs.template || componentName}.component${min}.html`
 }

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -96,7 +96,7 @@ Stratus.Components.SwiperCarousel = {
         Stratus.Internals.CssLoader(`${localDir}${componentName}.component${min}.css`)
         $scope.initialized = false
 
-        Stratus.Internals.CssLoader(`${Stratus.BaseUrl}${Stratus.DeploymentPath}swiper/dist/css/swiper${min}.css`)
+        Stratus.Internals.CssLoader(`${Stratus.BaseUrl}${Stratus.DeploymentPath}swiper/css/swiper${min}.css`)
 
         // Hoist Attributes
         $scope.property = $attrs.property || null


### PR DESCRIPTION
- list widget use `query` parameter (options <--> query backwards compatible)
- details widget fixed to use property title in SFAR
- search widget fixed URL load of ListingType selection
- fixed  Swiper the bad css path again (not found due to env conflicts)
- fixed details.classic variable call