### PR TITLE
@stratusjs/swiper 0.1.6 @stratusjs/swiper 0.3.16

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.14",
+  "version": "0.3.16",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -28,6 +28,6 @@
     "@stratusjs/angularjs": "^0.2.11",
     "@stratusjs/angularjs-extras": "^0.3.0",
     "@stratusjs/runtime": "^0.10.4",
-    "@stratusjs/swiper": "^0.1.5"
+    "@stratusjs/swiper": "^0.1.6"
   }
 }

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -206,6 +206,7 @@
             <!-- parallax-content disabled, cannot use height altering on the entire widget -->
             <!-- FIXME {} can't be used in inline styles as it won't resolve before the page loads (or may not exist) -->
             <div data-ng-if="model.data.Images && model.data.Images[0]"
+                 data-stratus-src
                  style="background: url('{{::model.data.Images[0].MediaURL}}') no-repeat center center; background-size: cover;"
                  aria-label="Background Image of the Listing"
             >

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -23,7 +23,10 @@ import {MLSService} from '@stratusjs/idx/idx'
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
-// Custom Filters
+// Stratus Directives
+import 'stratus.directives.src'
+
+// Stratus Filters
 import 'stratus.filters.math'
 import 'stratus.filters.moment'
 

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -30,7 +30,10 @@
                             <div class="button btn" data-ng-href="{{::getDetailsURL(property)}}">
                                 Details
                             </div>
-                            <div class="image-wrapper" style="background: url('{{::property.Images[0].MediaURL}}') no-repeat center center; background-size: cover;">
+                            <div class="image-wrapper"
+                                 data-stratus-src
+                                 style="background: url('{{::property.Images[0].MediaURL}}') no-repeat center center; background-size: cover;"
+                            >
                                 <img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="shapeholder"/>
                                 <img data-ng-if="::property.Images.length === 0 || !property.Images" data-ng-src="{{::localDir}}images/no-image.jpg">
                             </div>

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -23,6 +23,9 @@ import {CompileFilterOptions, MLSService, WhereOptions} from '@stratusjs/idx/idx
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
+// Stratus Directives
+import 'stratus.directives.src'
+
 // Component Preload
 import '@stratusjs/idx/property/details.component'
 

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/swiper/src/carousel.component.html
+++ b/packages/swiper/src/carousel.component.html
@@ -1,19 +1,21 @@
-<div id="{{ elementId }}" class="swiper-flex" data-injection="swiper" ng-class="{'swiper-main': !gallery, 'swiper-gallery': gallery}">
-  <div class="swiper-container" ng-class="{'gallery-top': gallery}" ng-init="initSwiper()">
+<div id="{{ elementId }}" class="swiper-flex" data-injection="swiper" data-ng-class="{'swiper-main': !gallery, 'swiper-gallery': gallery}">
+  <div class="swiper-container" data-ng-class="{'gallery-top': gallery}" data-ng-init="initSwiper()">
     <div class="swiper-wrapper">
-      <div class="swiper-slide" ng-repeat="image in images track by $index" ng-transclude="slide">
-        <div ng-class="{'swiper-zoom-container': scaleHeight}">
+      <div class="swiper-slide" data-ng-repeat="image in images track by $index" data-ng-transclude="slide">
+        <div data-ng-class="{'swiper-zoom-container': scaleHeight}">
           <!--<div ng-if="::lazyLoad" class="swiper-lazy-preloader"></div>-->
-          <img class="swiper-image" ng-class="{'stretch-image': stretchWidth}"
-               ng-if="!lazyLoad"
-               ng-click="imageClick(image, $event)"
-               ng-src="{{::(image.src||image.url)}}" />
+          <img class="swiper-image" data-ng-class="{'stretch-image': stretchWidth}"
+               data-ng-if="!lazyLoad"
+               data-ng-click="imageClick(image, $event)"
+               draggable="false"
+               data-ng-src="{{::(image.src||image.url)}}" />
           <!-- swiper-lazy -->
           <img class="swiper-image" ng-class="{'stretch-image': stretchWidth}"
-               ng-if="lazyLoad"
-               ng-click="imageClick(image, $event)"
-               stratus-src
-               ng-src="{{::(image.src||image.url)}}" />
+               data-ng-if="lazyLoad"
+               data-ng-click="imageClick(image, $event)"
+               draggable="false"
+               data-stratus-src
+               data-ng-src="{{::(image.src||image.url)}}" />
           <!--
           <div class="small-label font-primary bold"
                ng-if="image.name" ng-bind="image.name">
@@ -22,9 +24,9 @@
         </div>
       </div>
     </div>
-    <div ng-show="::navigation" class="swiper-button-prev"></div>
-    <div ng-show="::navigation" class="swiper-button-next"></div>
-    <div ng-show="::pagination" class="swiper-pagination"></div>
-    <div ng-show="::scrollbar" class="swiper-scrollbar"></div>
+    <div data-ng-show="::navigation" class="swiper-button-prev"></div>
+    <div data-ng-show="::navigation" class="swiper-button-next"></div>
+    <div data-ng-show="::pagination" class="swiper-pagination"></div>
+    <div data-ng-show="::scrollbar" class="swiper-scrollbar"></div>
   </div>
 </div>

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -14,6 +14,9 @@ import {Model} from '@stratusjs/angularjs/services/model'
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
+// Stratus Directives
+import 'stratus.directives.src'
+
 // Reusable Objects
 export interface SlideImage {
     src?: string,


### PR DESCRIPTION
idx and swiper use stratus-src to lazy load Sitetheory images

Known Issue:
stratus-src seems to be having issues with swiper, probably due to the way that swiper relies on knowing the size of the image it's loading to initially set, yet stratus-src changes the image after the image already loads.
The effect: the image shown could be mucher smaller, as it was the original image size (results not consistent because load times can vary)