### PR TITLE
@stratusjs/angularjs-extras 0.3.3 @stratusjs/idx 0.3.18 @stratusjs/runtime 0.10.6 @stratusjs/swiper 0.1.7

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -34,7 +34,7 @@
     "@fullcalendar/timegrid": "^4.1.0",
     "@stratusjs/angularjs": "^0.2.11",
     "@stratusjs/core": "^0.2.5",
-    "@stratusjs/runtime": "^0.10.3",
+    "@stratusjs/runtime": "^0.10.5",
     "ical.js": "^1.3.0",
     "moment": "^2.24.0",
     "moment-range": "^4.0.2",

--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -34,7 +34,7 @@
     "@fullcalendar/timegrid": "^4.1.0",
     "@stratusjs/angularjs": "^0.2.11",
     "@stratusjs/core": "^0.2.5",
-    "@stratusjs/runtime": "^0.10.5",
+    "@stratusjs/runtime": "^0.10.6",
     "ical.js": "^1.3.0",
     "moment": "^2.24.0",
     "moment-range": "^4.0.2",

--- a/packages/angularjs-extras/src/directives/src.js
+++ b/packages/angularjs-extras/src/directives/src.js
@@ -90,6 +90,8 @@
           $scope.group = {
             method: Stratus.Internals.LoadImage,
             el: $element,
+            // Could be replaced with spy: $element.data('spy') ? $document[0].querySelector($element.data('spy')) : $element
+            // TODO need spy examples to test with
             spy: $element.data('spy') ? jQuery($element.data('spy')) : $element
           }
           Stratus.Internals.OnScroll()

--- a/packages/angularjs-extras/src/directives/src.js
+++ b/packages/angularjs-extras/src/directives/src.js
@@ -22,6 +22,7 @@
       restrict: 'A',
       scope: {
         src: '@src',
+        stratusSrcLoad: '@stratusSrcLoad',
         stratusSrc: '@stratusSrc',
         style: '@style'
       },
@@ -45,18 +46,43 @@
           $scope.register()
         })
 
+        /**
+         * Sets the image src/css background on a tag
+         * @param {string} tagType
+         * @param {string} src
+         */
+        $scope.setSrc = function(tagType, src) {
+          if (tagType === 'img') {
+            $element.attr('src', src)
+          } else {
+            $element.css('background-image', `url(${src})`)
+          }
+        }
+
         // Group Registration
         $scope.registered = false
         $scope.register = function () {
           // find background image in CSS if there is no src (e.g. for div)
           let backgroundImage = null
-          if ($element.prop('tagName').toLowerCase() !== 'img') {
+          const type = $element.prop('tagName').toLowerCase()
+          if (type !== 'img') {
             backgroundImage = $element.css('background-image') || null
             if (backgroundImage) {
               backgroundImage = backgroundImage.slice(4, -1).replace(/"/g, '')
             }
           }
           const src = $attr.stratusSrc || $attr.src || backgroundImage
+
+          // Prevent Progressive loading if set to false
+          if(
+            $attr.stratusSrcLoad === 'false' ||
+            $attr.stratusSrcLoad === false
+          ) {
+            // Requested to not progressive load
+            // Set it's suggested image and exit
+            $scope.setSrc(type, src)
+            return true
+          }
 
           // Get Extension
           let ext = src ? src.match(/\.([0-9a-z]+)(\?.*)?$/i) : null
@@ -69,6 +95,8 @@
             return ext === value
           })
           if (!_.size($scope.filter)) {
+            // Set it's suggested image and exit
+            $scope.setSrc(type, src)
             return true
           }
 

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -28,6 +28,6 @@
     "@stratusjs/angularjs": "^0.2.11",
     "@stratusjs/angularjs-extras": "^0.3.0",
     "@stratusjs/runtime": "^0.10.4",
-    "@stratusjs/swiper": "^0.1.6"
+    "@stratusjs/swiper": "^0.1.7"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -28,6 +28,6 @@
     "@stratusjs/angularjs": "^0.2.11",
     "@stratusjs/angularjs-extras": "^0.3.3",
     "@stratusjs/runtime": "^0.10.6",
-    "@stratusjs/swiper": "^0.1.17"
+    "@stratusjs/swiper": "^0.1.7"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -26,8 +26,8 @@
   "homepage": "https://github.com/Sitetheory/stratus#readme",
   "dependencies": {
     "@stratusjs/angularjs": "^0.2.11",
-    "@stratusjs/angularjs-extras": "^0.3.0",
-    "@stratusjs/runtime": "^0.10.4",
-    "@stratusjs/swiper": "^0.1.7"
+    "@stratusjs/angularjs-extras": "^0.3.3",
+    "@stratusjs/runtime": "^0.10.6",
+    "@stratusjs/swiper": "^0.1.17"
   }
 }

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -197,7 +197,7 @@
         <div class="secondary-image-container">
             <!-- TODO MLSL requires listrac: data-ng-click="return cms.obj.listtrac.track('lead');"-->
             <a class="btn btn-alt btn-contact" data-ng-show="::contactUrl || Idx.sharedValues.contactUrl"
-               target="_blank" data-ng-href="{{::contactUrl || Idx.sharedValues.contactUrl}}}?comments={{::getFullAddress(true)}}"
+               target="_blank" data-ng-href="{{::contactUrl || Idx.sharedValues.contactUrl}}?comments={{::getFullAddress(true)}}"
                aria-label="Contact an Agent Link"
             >
                 Contact

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -205,9 +205,10 @@
             <div class="image-dimmer"></div>
             <!-- parallax-content disabled, cannot use height altering on the entire widget -->
             <!-- FIXME {} can't be used in inline styles as it won't resolve before the page loads (or may not exist) -->
-            <div data-ng-if="model.data.Images && model.data.Images[0]"
-                 data-stratus-src
-                 style="background: url('{{::model.data.Images[0].MediaURL}}') no-repeat center center; background-size: cover;"
+            <div class="image-wrapper"
+                 data-ng-if="model.data.Images && model.data.Images[0]"
+                 data-stratus-src-load="{{::model.data.Images[0].Lazy == 'stratus-src'}}"
+                 data-stratus-src="{{::model.data.Images[0].MediaURL}}"
                  aria-label="Background Image of the Listing"
             >
                 <img data-ng-if="model.data.Images && model.data.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="{{::getStreetAddress()}}"/>

--- a/packages/idx/src/property/details.component.less
+++ b/packages/idx/src/property/details.component.less
@@ -552,6 +552,11 @@ stratus-idx-property-details {
         }
       }
     }
+    .image-wrapper {
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: cover;
+    }
     .image-dimmer {
       position: absolute;
       top: 0;

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -22,6 +22,7 @@ import {Model} from '@stratusjs/angularjs/services/model'
 import {MLSService} from '@stratusjs/idx/idx'
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
+import {SlideImage} from '@stratusjs/swiper/carousel.component'
 
 // Stratus Directives
 import 'stratus.directives.src'
@@ -1231,16 +1232,20 @@ Stratus.Components.IdxPropertyDetails = {
             }
         }
 
-        $scope.getSlideshowImages = (): { src: string }[] => {
-            const images: { src: string }[] = []
+        $scope.getSlideshowImages = (): SlideImage[] => {
+            const images: SlideImage[] = []
             if (
                 $scope.model.data.Images &&
                 _.isArray($scope.model.data.Images)
             ) {
-                $scope.model.data.Images.forEach((image: { MediaURL?: string }) => {
+                $scope.model.data.Images.forEach((image: { MediaURL?: string, Lazy?: string }) => {
                     // TODO need title/description variables
                     if (Object.prototype.hasOwnProperty.call(image, 'MediaURL')) {
-                        images.push({src: image.MediaURL})
+                        const imageObject: SlideImage = {src: image.MediaURL}
+                        if (Object.prototype.hasOwnProperty.call(image, 'Lazy')) {
+                            imageObject.lazy = image.Lazy
+                        }
+                        images.push(imageObject)
                     }
                 })
             }

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -31,8 +31,8 @@
                                 Details
                             </div>
                             <div class="image-wrapper"
-                                 data-stratus-src
-                                 style="background: url('{{::property.Images[0].MediaURL}}') no-repeat center center; background-size: cover;"
+                                 data-stratus-src-load="{{::property.Images[0].Lazy == 'stratus-src'}}"
+                                 data-stratus-src="{{::property.Images[0].MediaURL}}"
                             >
                                 <img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="shapeholder"/>
                                 <img data-ng-if="::property.Images.length === 0 || !property.Images" data-ng-src="{{::localDir}}images/no-image.jpg">

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -93,6 +93,11 @@ stratus-idx-property-list {
           .property-image {
             position: relative;
             background: #000;
+            .image-wrapper {
+              background-position: center;
+              background-repeat: no-repeat;
+              background-size: cover;
+            }
             img {
               width: 100%;
             }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/runtime",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "This is the runtime package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/runtime",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "This is the runtime package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -1444,6 +1444,8 @@ Stratus.Internals.LoadImage = (obj: any) => {
                 const loadEl: any = jQuery('<img/>')
                 loadEl.attr('src', srcOriginProtocol)
                 loadEl.on('load', () => {
+                    // If the image wasn't set in the background yet, set it now
+                    el.css('background-image', 'url(' + srcOriginProtocol + ')')
                     el.addClass('loaded').removeClass('loading')
                     jQuery(this).remove() // prevent memory leaks
                 })

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -1465,9 +1465,9 @@ Stratus.Internals.LoadImage = (obj: any) => {
             el.attr('data-size', dehydrate(size))
 
             // Preload this image first. Ensures speed to display and image is valid
-            const loadEl: any = jQuery('<img/>')
-            loadEl.attr('src', srcProtocol)
-            loadEl.on('load', () => {
+            const preFetchEl: any = jQuery('<img/>')
+            preFetchEl.attr('src', srcProtocol)
+            preFetchEl.on('load', () => {
                 el.addClass('loaded').removeClass('loading')
                 if (type === 'img') {
                     el.attr('src', srcProtocol)
@@ -1476,7 +1476,7 @@ Stratus.Internals.LoadImage = (obj: any) => {
                 }
                 jQuery(this).remove() // prevent memory leaks
             })
-            loadEl.on('error', () => {
+            preFetchEl.on('error', () => {
                 // Image failed, dont try to use this url
                 // TODO: Go down in sizes before reaching the origin
                 if (cookie('env')) {

--- a/packages/swiper/README.md
+++ b/packages/swiper/README.md
@@ -26,7 +26,7 @@ And include the the library paths into your stratus `config.js` such as
 ```js
 boot.configuration.paths = {
   // Swiper Package
-  'swiper': boot.deployment + 'swiper/js/swiper.esm.browser.bundle' + boot.suffix,
+  'swiper': boot.deployment + 'swiper/js/swiper.esm.browser.bundle',
 
   // STRATUS SRC: Swiper
   '@stratusjs/swiper/*': boot.deployment + '@stratusjs/swiper/src/*' + boot.suffix,

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/swiper/src/carousel.component.html
+++ b/packages/swiper/src/carousel.component.html
@@ -1,32 +1,32 @@
 <div id="{{ elementId }}" class="swiper-flex" data-injection="swiper" data-ng-class="{'swiper-main': !gallery, 'swiper-gallery': gallery}">
-  <div class="swiper-container" data-ng-class="{'gallery-top': gallery}" data-ng-init="initSwiper()">
-    <div class="swiper-wrapper">
-      <div class="swiper-slide" data-ng-repeat="image in images track by $index" data-ng-transclude="slide">
-        <div data-ng-class="{'swiper-zoom-container': scaleHeight}">
-          <!--<div ng-if="::lazyLoad" class="swiper-lazy-preloader"></div>-->
-          <img class="swiper-image" data-ng-class="{'stretch-image': stretchWidth}"
-               data-ng-if="!lazyLoad"
-               data-ng-click="imageClick(image, $event)"
-               draggable="false"
-               data-ng-src="{{::(image.src||image.url)}}" />
-          <!-- swiper-lazy -->
-          <img class="swiper-image" ng-class="{'stretch-image': stretchWidth}"
-               data-ng-if="lazyLoad"
-               data-ng-click="imageClick(image, $event)"
-               draggable="false"
-               data-stratus-src
-               data-ng-src="{{::(image.src||image.url)}}" />
-          <!--
-          <div class="small-label font-primary bold"
-               ng-if="image.name" ng-bind="image.name">
-          </div>
-          -->
+    <div class="swiper-container" data-ng-class="{'gallery-top': gallery}" data-ng-init="initSwiper()">
+        <div class="swiper-wrapper">
+            <div class="swiper-slide" data-ng-repeat="image in images track by $index" data-ng-transclude="slide">
+                <div data-ng-class="{'swiper-zoom-container': scaleHeight}">
+                    <!--<div ng-if="::lazyLoad" class="swiper-lazy-preloader"></div>-->
+                    <img class="swiper-image" data-ng-class="{'stretch-image': stretchWidth}"
+                         data-ng-if="!lazyLoad"
+                         data-ng-click="imageClick(image, $event)"
+                         draggable="false"
+                         data-ng-src="{{::(image.src||image.url)}}"/>
+                    <!-- swiper-lazy -->
+                    <img class="swiper-image swiper-lazy" data-ng-class="{'stretch-image': stretchWidth}"
+                         data-ng-if="lazyLoad"
+                         data-ng-click="imageClick(image, $event)"
+                         draggable="false"
+                         data-ng-src="{{::(image.src||image.url)}}"/>
+                    <div data-ng-if="lazyLoad" class="swiper-lazy-preloader"></div>
+                    <!--
+                    <div class="small-label font-primary bold"
+                         ng-if="image.name" ng-bind="image.name">
+                    </div>
+                    -->
+                </div>
+            </div>
         </div>
-      </div>
+        <div data-ng-show="::navigation" class="swiper-button-prev"></div>
+        <div data-ng-show="::navigation" class="swiper-button-next"></div>
+        <div data-ng-show="::pagination" class="swiper-pagination"></div>
+        <div data-ng-show="::scrollbar" class="swiper-scrollbar"></div>
     </div>
-    <div data-ng-show="::navigation" class="swiper-button-prev"></div>
-    <div data-ng-show="::navigation" class="swiper-button-next"></div>
-    <div data-ng-show="::pagination" class="swiper-pagination"></div>
-    <div data-ng-show="::scrollbar" class="swiper-scrollbar"></div>
-  </div>
 </div>

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -8,12 +8,10 @@ import _ from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import * as angular from 'angular'
 import Swiper from 'swiper'
-
 // Stratus Dependencies
 import {Model} from '@stratusjs/angularjs/services/model'
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
-
 // Stratus Directives
 import 'stratus.directives.src'
 
@@ -23,7 +21,8 @@ export interface SlideImage {
     title?: string,
     description?: string,
     link?: string,
-    target?: string
+    target?: string,
+    lazy?: string
 }
 
 // Environment
@@ -144,6 +143,39 @@ Stratus.Components.SwiperCarousel = {
         )
 
         /**
+         * Determines the size a particular element and returns the applicable image size name to be used to load image files
+         * @param selector - An element
+         * @param columns - Number of columns within the element that is except to calculate for size
+         */
+        const getImageSizeName = (selector: Element|any, columns?: number): 'xs' | 's' | 'm' | 'l' | 'xl' | 'hq' | string => {
+            const el = Stratus.Select(selector)
+            const width = el.width() / (columns || 1)
+            // console.log('width', width, el)
+            return _.findKey(Stratus.Settings.image.size, (s: number) => {
+                const ratio: number = s / width
+                return (ratio > 0.85 && ratio < 1.15) || s > width
+            })
+        }
+
+        /**
+         * Determines the new url for the image size specified and returns proper string url
+         * @param src - Original Url to update
+         * @param sizeName - Size name to append to image url
+         */
+        const replaceImageSizeSrc = (src: 'xs' | 's' | 'm' | 'l' | 'xl' | 'hq' | string, sizeName: string): string => {
+            const srcOrigin = src
+            const srcRegex: RegExp = /^(.+?)(-[A-Z]{2})?\.(?=[^.]*$)(.+)/gi
+            const srcMatch: RegExpExecArray = srcRegex.exec(src)
+            if (srcMatch !== null) {
+                src = srcMatch[1] + '-' + sizeName + '.' + srcMatch[3]
+            } else {
+                console.error('Unable to find file name for image src:', srcOrigin)
+            }
+
+            return src
+        }
+
+        /**
          * Prep and process a list of images for Swiper's use
          * TODO later process non-image based slides
          */
@@ -152,6 +184,9 @@ Stratus.Components.SwiperCarousel = {
                 images = [images]
             }
             if (_.isArray(images)) {
+                // The main element doesn't have a size ever, so use the inner container
+                const thisEl = $element[0].querySelector('.swiper-container')
+                const sizeName = getImageSizeName(thisEl)
                 const processedImages: SlideImage[] = []
                 images.forEach(
                     (image: string | SlideImage) => {
@@ -161,6 +196,13 @@ Stratus.Components.SwiperCarousel = {
                             preppedImage.src = image
                         } else if (typeof image === 'object') {
                             if (Object.prototype.hasOwnProperty.call(image, 'src')) {
+                                if (
+                                    Object.prototype.hasOwnProperty.call(image, 'lazy')
+                                    && image.lazy === 'stratus-src'
+                                ) {
+                                    image.src = replaceImageSizeSrc(image.src, sizeName)
+                                    // console.log('image upgraded to ', image.src)
+                                }
                                 preppedImage = image
                             }
                         }

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -195,11 +195,8 @@ Stratus.Components.SwiperCarousel = {
                             // just urls were provided
                             preppedImage.src = image
                         } else if (typeof image === 'object') {
-                            if (Object.prototype.hasOwnProperty.call(image, 'src')) {
-                                if (
-                                    Object.prototype.hasOwnProperty.call(image, 'lazy')
-                                    && image.lazy === 'stratus-src'
-                                ) {
+                            if (_.has(image, 'src')) {
+                                if (_.get(image, 'lazy') === 'stratus-src') {
                                     image.src = replaceImageSizeSrc(image.src, sizeName)
                                     // console.log('image upgraded to ', image.src)
                                 }


### PR DESCRIPTION
**@stratusjs/angularjs-extras 0.3.3**
* Added `stratus-src-load` for variable Progressive image loading on certain resources
* Updated Dependencies (fixes stratus-src image loading invalid urls with ImageLoad())

**@stratusjs/idx 0.3.18**
* Fix invalid } in Contact Url
* Updated SlideImage types and provide lazy parameter
* Corrected templates to progressive stratus-src loading
* Moved CSS to LESS files

**@stratusjs/runtime 0.10.6**
* Fix Stratus.Internals.LoadImage to only upgrade image size AFTER it is prefetched and loads correctly. (fixes stratus-src loading)

**@stratusjs/swiper 0.1.7**
* 'lazy' parameter in SlideImages allows swiper to replicate stratus-src to find the large images before initializing (progressive loading disabled as it breaks swiper)
* Updated instructions. Swiper repo has an invalid minified file currently. Need to use full file
* Updated dependencies
