### PR TITLE
@stratusjs/angularjs-extras @stratusjs/calendar fix publishing mistakes

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@stratusjs/angularjs-extras",
-  "version": "0.0.1",
+  "name": "@stratusjs/calendar",
+  "version": "0.0.3",
   "description": "AngularJS Calendar component and iCAL service to be used as an add on to StratusJS. Makes use of fullcalendar and iCAL",
   "scripts": {},
   "repository": {
@@ -35,7 +35,7 @@
     "@fullcalendar/moment-timezone": "^4.2.0",
     "@fullcalendar/timegrid": "^4.1.0",
     "@stratusjs/angularjs": "^0.2.11",
-    "@stratusjs/angularjs-extras": "^0.4.0",
+    "@stratusjs/angularjs-extras": "^0.4.1",
     "@stratusjs/runtime": "^0.10.6",
     "ical.js": "^1.3.0"
   },


### PR DESCRIPTION
This caused a mistake of publishing the calendar package to @stratusjs/angularjs-extras 0.0.1 version