### PR TITLE
@stratusjs/angularjs-extras 0.4.3 @stratusjs/idx 0.3.24

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs-extras/src/directives/src.js
+++ b/packages/angularjs-extras/src/directives/src.js
@@ -22,8 +22,9 @@
       restrict: 'A',
       scope: {
         src: '@src',
-        stratusSrcLoad: '@stratusSrcLoad',
         stratusSrc: '@stratusSrc',
+        // stratusSrcSizes: '@stratusSrcSizes', // Unused at this time
+        stratusSrcVersion: '@stratusSrcVersion',
         style: '@style'
       },
       link: function ($scope, $element, $attr) {
@@ -72,10 +73,10 @@
             }
           }
 
-          // Prevent Progressive loading if set to false
+          // Prevent Progressive loading if set to false. Will not continue any further
           if(
-            $attr.stratusSrcLoad === 'false' ||
-            $attr.stratusSrcLoad === false
+            $attr.stratusSrcVersion === 'false' ||
+            $attr.stratusSrcVersion === false
           ) {
             // Requested to not progressive load
             // Set it's suggested image and exit
@@ -90,7 +91,8 @@
           ) {
             // Requested to not progressive load
             // Set it's suggested image and exit
-            $scope.setSrc(type, $attr.src || backgroundImage)
+            // $scope.setSrc(type, $attr.src || backgroundImage)
+            // New: if set to false, don' do stratus-src at all. see https://app.asana.com/0/348823217261712/1149917100747392
             return true
           }
 

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@stratusjs/angularjs": "^0.2.11",
-    "@stratusjs/angularjs-extras": "^0.4.2",
+    "@stratusjs/angularjs-extras": "^0.4.3",
     "@stratusjs/runtime": "^0.10.7",
     "@stratusjs/swiper": "^0.1.8"
   }

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -234,7 +234,7 @@
             <!-- FIXME {} can't be used in inline styles as it won't resolve before the page loads (or may not exist) -->
             <div class="image-wrapper"
                  data-ng-if="model.data.Images && model.data.Images[0]"
-                 data-stratus-src-load="{{::model.data.Images[0].Lazy == 'stratus-src'}}"
+                 data-stratus-src-version="{{::(model.data.Images[0].Lazy == 'stratus-src' ? 'best' : 'false')}}"
                  data-stratus-src="{{::model.data.Images[0].MediaURL}}"
                  aria-label="Background Image of the Listing"
             >

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -31,7 +31,7 @@
                                 Details
                             </div>
                             <div class="image-wrapper"
-                                 data-stratus-src-load="{{::property.Images[0].Lazy == 'stratus-src'}}"
+                                 data-stratus-src-load="{{::(property.Images[0].Lazy == 'stratus-src' ? 'best' : 'false')}}"
                                  data-stratus-src="{{::property.Images[0].MediaURL}}"
                             >
                                 <img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="shapeholder"/>


### PR DESCRIPTION
@stratusjs/angularjs-extras 0.4.3
* Rename `stratus-src-load` to `stratus-src-version`
* `stratus-src="false"` will now prevent stratus-src from doing anything

@stratusjs/idx 0.3.24
* MLS Widget polishes published
* Idx List and Details updated to use `stratus-src-version`