### PR TITLE
@stratusjs/idx data association and service fixes

### DIFF
--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -24,6 +24,11 @@ import {cookie} from '@stratusjs/core/environment'
 // There is not a very consistent way of pathing in Stratus at the moment
 // const localDir = `/${boot.bundle}node_modules/@stratusjs/${packageName}/src/${moduleName}/`
 
+/** Allow an Object to contain any number of unspecified functions, useful in $scope */
+export interface ObjectWithFunctions {
+    [key: string]: ((...args: any) => any)
+}
+
 // Reusable Objects. Keys listed are not required, but help programmers define what exists/is possible
 export interface WhereOptions {
     // Wildcard for anything
@@ -281,7 +286,12 @@ Stratus.Services.Idx = [
                     OfficeSearch: object,
                     OfficeDetails: object
                 } */
-                const instance: any = { // FIXME theres a number of queries that need dynamic calls
+                // any
+                const instance: {
+                    [instanceName: string]: {
+                        [uid: string]: angular.IScope & any
+                    }
+                } = { // FIXME theres a number of queries that need dynamic calls
                     PropertyList: {},
                     PropertySearch: {},
                     PropertyDetails: {},
@@ -295,8 +305,12 @@ Stratus.Services.Idx = [
 
                 /** type {{List: Object<[String]>, Search: Object<[String]>}} */
                 const instanceLink: {
-                    List: object | any,
-                    Search: object | any
+                    List: {
+                        [uid: string]: string[]
+                    }
+                    Search: {
+                        [uid: string]: string[]
+                    }
                 } = {
                     List: {},
                     Search: {}
@@ -448,7 +462,7 @@ Stratus.Services.Idx = [
                  * Apply a new Page title or revert to the original; page title
                  * @param title - Page Title
                  */
-                function setPageTitle(title: string): void {
+                function setPageTitle(title?: string): void {
                     if (!defaultPageTitle) {
                         // save default title first
                         defaultPageTitle = JSON.parse(JSON.stringify($window.document.title))

--- a/packages/idx/src/property/admin/search.filter.component.html
+++ b/packages/idx/src/property/admin/search.filter.component.html
@@ -223,7 +223,7 @@
                         <label>Restrict Data Source</label>
                         <!-- TODO fetch the allowed services. Will add a option to request a token on load
                         (normally this widget waits until there is a search to perform to prevent unneeded loading) -->
-                        <md-select data-ng-model="options.service" placeholder="Restrict Data Source" multiple>
+                        <md-select data-ng-model="options.query.service" placeholder="Restrict Data Source" multiple>
                             <md-option value="0">Exclusive (personal)</md-option>
                             <md-option value="1">MLS Listings Inc</md-option>
                             <md-option value="2">SFARMLS</md-option>

--- a/packages/idx/src/property/admin/search.filter.component.html
+++ b/packages/idx/src/property/admin/search.filter.component.html
@@ -10,7 +10,7 @@
                 <div class="search-input" data-flex="33" data-flex-gt-sm="50">
                     <md-input-container class="md-block minimal">
                         <label>City</label>
-                        <input data-ng-model="options.query.City"
+                        <input data-ng-model="options.query.where.City"
                                type="text"
                                maxlength="250"
                                autocomplete="off">
@@ -20,7 +20,7 @@
                     <md-chips
                             class="area-id font-secondary"
                             aria-label="Neighborhoods to Limit"
-                            data-ng-model="options.query.MLSAreaMajor"
+                            data-ng-model="options.query.where.MLSAreaMajor"
                             data-md-enable-chip-edit="true"
                             data-md-add-on-blur="true"
                             data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
@@ -34,7 +34,7 @@
                     <md-chips
                             class="postal-code font-secondary"
                             aria-label="Postal Code(s) to Limit"
-                            data-ng-model="options.query.PostalCode"
+                            data-ng-model="options.query.where.PostalCode"
                             data-md-enable-chip-edit="true"
                             data-md-add-on-blur="true"
                             data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
@@ -53,19 +53,19 @@
                 <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                     <md-input-container class="md-block minimal">
                         <label>Min Price</label>
-                        <input stratus-string-to-number="comma" data-ng-model="options.query.ListPriceMin" type="text" maxlength="11" size="8" autocomplete="off">
+                        <input stratus-string-to-number="comma" data-ng-model="options.query.where.ListPriceMin" type="text" maxlength="11" size="8" autocomplete="off">
                     </md-input-container>
                 </div>
                 <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                     <md-input-container class="md-block minimal">
                         <label>Max Price</label>
-                        <input stratus-string-to-number="comma" data-ng-model="options.query.ListPriceMax" type="text" maxlength="11" size="8" autocomplete="off">
+                        <input stratus-string-to-number="comma" data-ng-model="options.query.where.ListPriceMax" type="text" maxlength="11" size="8" autocomplete="off">
                     </md-input-container>
                 </div>
                 <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                     <md-input-container class="md-block minimal">
                         <label>Beds</label>
-                        <md-select data-ng-model="options.query.Bedrooms">
+                        <md-select data-ng-model="options.query.where.Bedrooms">
                             <md-option></md-option>
                             <md-option data-ng-repeat="option in options.selection.Bedrooms" data-ng-value="option.value">
                                 {{option.name}}
@@ -76,7 +76,7 @@
                 <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                     <md-input-container class="md-block minimal">
                         <label>Baths</label>
-                        <md-select data-ng-model="options.query.Bathrooms">
+                        <md-select data-ng-model="options.query.where.Bathrooms">
                             <md-option></md-option>
                             <md-option data-ng-repeat="option in options.selection.Bathrooms" data-ng-value="option.value">
                                 {{option.name}}
@@ -109,28 +109,28 @@
                  data-layout-align="left"
                  aria-label="Listing Status">
                 <md-button class="md-raised font-primary"
-                           data-ng-class="{'md-primary': inArray('Active', options.query.Status)}"
-                           data-ng-click="options.query.Status = ['Active', 'Contract'];"
+                           data-ng-class="{'md-primary': inArray('Active', options.query.where.Status)}"
+                           data-ng-click="options.query.where.Status = ['Active', 'Contract'];"
                            aria-label="For Sale"
                            data-md-prevent-menu-close
                 >
                     For Sale
                 </md-button>
                 <md-button class="md-raised font-primary"
-                           data-ng-class="{'md-primary': inArray('Closed', options.query.Status)}"
-                           data-ng-click="options.query.Status = ['Closed']"
+                           data-ng-class="{'md-primary': inArray('Closed', options.query.where.Status)}"
+                           data-ng-click="options.query.where.Status = ['Closed']"
                            aria-label="Sold"
                            data-md-prevent-menu-close
                 >
                     Sold
                 </md-button>
-                <div data-ng-show="!options.forRent && inArray('Active', options.query.Status)"
+                <div data-ng-show="!options.forRent && inArray('Active', options.query.where.Status)"
                      data-layout="row"
                      data-layout-align="left">
                     <md-checkbox
                             class="show-under-contract font-secondary"
-                            data-ng-checked="inArray('Contract', options.query.Status)"
-                            data-ng-click="toggleArrayElement('Contract', options.query.Status)"
+                            data-ng-checked="inArray('Contract', options.query.where.Status)"
+                            data-ng-click="toggleArrayElement('Contract', options.query.where.Status)"
                             aria-label="Under Contract"
                             data-md-prevent-menu-close
                     >
@@ -170,8 +170,8 @@
                         data-ng-repeat="listType in ::options.selection.ListingType.All"
                         class="md-raised font-primary"
                         data-ng-show="options.forRent === listType.lease && options.selection.ListingType.group[listType.group]"
-                        data-ng-class="{'md-primary': inArray(listType.value, options.query.ListingType)}"
-                        data-ng-click="toggleArrayElement(listType.value, options.query.ListingType)"
+                        data-ng-class="{'md-primary': inArray(listType.value, options.query.where.ListingType)}"
+                        data-ng-click="toggleArrayElement(listType.value, options.query.where.ListingType)"
                         aria-label="{{::listType.name}}"
                         data-md-prevent-menu-close
                         data-ng-bind="::listType.name"
@@ -186,7 +186,7 @@
                 <md-chips
                         class="agent-license font-secondary"
                         aria-label="Agent License(s) to Search"
-                        data-ng-model="options.query.AgentLicense"
+                        data-ng-model="options.query.where.AgentLicense"
                         data-md-enable-chip-edit="true"
                         data-md-add-on-blur="true"
                         data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
@@ -209,7 +209,7 @@
                 >
                     <md-input-container class="md-block minimal">
                         <label>Sort</label>
-                        <md-select data-ng-model="options.query.Order">
+                        <md-select data-ng-model="options.query.where.Order">
                             <md-option data-ng-repeat="option in options.selection.Order" data-ng-value="option.value">
                                 {{option.name}}
                             </md-option>

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -16,6 +16,7 @@ import 'angular-sanitize'
 // Services
 import '@stratusjs/angularjs/services/model'
 import '@stratusjs/idx/idx'
+import {ObjectWithFunctions} from '@stratusjs/idx/idx'
 import '@stratusjs/idx/listTrac'
 
 // Stratus Dependencies
@@ -45,6 +46,26 @@ const componentName = 'details'
 // There is not a very consistent way of pathing in Stratus at the moment
 const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
+export type IdxPropertyDetailsScope = angular.IScope & ObjectWithFunctions & {
+    elementId: string
+    localDir: string
+    model: any
+    Idx: any
+    urlLoad: boolean
+    pageTitle: string
+    options: any // TODO ned to specify
+    defaultListOptions: object
+    disclaimerString: string
+    disclaimerHTML: any
+    images: object[]
+    contact?: object | any
+    contactUrl?: string
+    integrations?: object | any
+    minorDetails: SubSectionOptions[]
+    alternateMinorDetails: SubSectionOptions[]
+}
+
+
 Stratus.Components.IdxPropertyDetails = {
     bindings: {
         elementId: '@',
@@ -69,7 +90,7 @@ Stratus.Components.IdxPropertyDetails = {
         $attrs: angular.IAttributes,
         $location: angular.ILocationService,
         $sce: angular.ISCEService,
-        $scope: object | any, // angular.IScope breaks references so far
+        $scope: IdxPropertyDetailsScope,
         ListTrac: any,
         // tslint:disable-next-line:no-shadowed-variable
         Model: any,
@@ -1286,14 +1307,14 @@ Stratus.Components.IdxPropertyDetails = {
          * Returns the processed street address
          * (StreetNumberNumeric / StreetNumber) + StreetDirPrefix + StreetName + StreetSuffix +  StreetSuffixModifier
          * +  StreetDirSuffix + 'Unit' + UnitNumber
+         * TODO can combine with other function so its not duplicate
          */
         $scope.getStreetAddress = (): string => {
-            let address = ''
             if (
                 Object.prototype.hasOwnProperty.call($scope.model.data, 'UnparsedAddress') &&
                 $scope.model.data.UnparsedAddress !== ''
             ) {
-                address = $scope.model.data.UnparsedAddress
+                return $scope.model.data.UnparsedAddress
             } else {
                 const addressParts: string[] = []
                 if (
@@ -1324,9 +1345,8 @@ Stratus.Components.IdxPropertyDetails = {
                             addressParts.push($scope.model.data[addressPart])
                         }
                     })
-                address = addressParts.join(' ')
+                return addressParts.join(' ')
             }
-            return address
         }
 
         $scope.getFullAddress = (encode?: boolean): string => {

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -19,7 +19,7 @@ import '@stratusjs/idx/idx'
 
 // Stratus Dependencies
 import {Collection} from '@stratusjs/angularjs/services/collection' // Needed as Class
-import {CompileFilterOptions, MLSService, WhereOptions} from '@stratusjs/idx/idx'
+import {CompileFilterOptions, MLSService, ObjectWithFunctions} from '@stratusjs/idx/idx'
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
@@ -35,6 +35,28 @@ const packageName = 'idx'
 const moduleName = 'property'
 const componentName = 'list'
 const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
+
+export type IdxPropertyListScope = angular.IScope & ObjectWithFunctions & {
+    elementId: string
+    localDir: string
+    model: any
+    Idx: any
+    collection: Collection
+    urlLoad: boolean
+    searchOnLoad: boolean
+    detailsLinkPopup: boolean
+    detailsLinkUrl: string
+    detailsLinkTarget: '_self' | '_blank'
+    detailsTemplate?: string
+    query: object | any // TODO need to specify
+    orderOptions: object | any // TODO need to specify
+    googleApiKey?: string
+    contactName: string
+    contactEmail?: string
+    contactPhone: string
+    disclaimerString: string
+    disclaimerHTML: any
+}
 
 Stratus.Components.IdxPropertyList = {
     bindings: {
@@ -58,7 +80,7 @@ Stratus.Components.IdxPropertyList = {
         $attrs: angular.IAttributes,
         $q: angular.IQService,
         $mdDialog: angular.material.IDialogService,
-        $scope: object | any, // angular.IScope breaks references so far
+        $scope: IdxPropertyListScope,
         $timeout: angular.ITimeoutService,
         $window: angular.IWindowService,
         $sce: angular.ISCEService,
@@ -81,7 +103,7 @@ Stratus.Components.IdxPropertyList = {
          */
         $ctrl.$onInit = async () => {
             $scope.Idx = Idx
-            $scope.collection = new Collection({}) as Collection // set a default collection for variable safety
+            $scope.collection = new Collection({})
             /**
              * Allow query to be loaded initially from the URL
              * type {boolean}
@@ -161,7 +183,7 @@ Stratus.Components.IdxPropertyList = {
             }
         }
 
-        $scope.$watch('collection.models', (models?: []) => {
+        $scope.$watch('collection.models', () => { // models?: []
             if ($scope.collection.completed) {
                 $ctrl.processMLSDisclaimer() // TODO force reset with true?
             }
@@ -314,12 +336,12 @@ Stratus.Components.IdxPropertyList = {
          * +  StreetDirSuffix + 'Unit' + UnitNumber
          */
         $scope.getStreetAddress = (property: object | any): string => {
-            let address = ''
             if (
                 Object.prototype.hasOwnProperty.call(property, 'UnparsedAddress') &&
                 property.UnparsedAddress !== ''
             ) {
-                address = property.UnparsedAddress
+                return property.UnparsedAddress
+                // address = property.UnparsedAddress
                 // console.log('using unparsed ')
             } else {
                 const addressParts: string[] = []
@@ -351,10 +373,8 @@ Stratus.Components.IdxPropertyList = {
                             addressParts.push(property[addressPart])
                         }
                     })
-                address = addressParts.join(' ')
+                return addressParts.join(' ')
             }
-            // console.log('address',  address)
-            return address
         }
 
         /**

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -138,6 +138,7 @@ Stratus.Components.IdxPropertyList = {
                 $attrs.options && isJSON($attrs.options) ? JSON.parse($attrs.options) : {}
             // $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) : {}
 
+            $scope.query.service = $scope.query.service || []
             $scope.query.order = $scope.query.order || null // will be set by Service
             $scope.query.page = $scope.query.page || null // will be set by Service
             $scope.query.perPage = $scope.query.perPage || 25
@@ -295,6 +296,11 @@ Stratus.Components.IdxPropertyList = {
                 }
                 if ($scope.query.order && $scope.query.order.length > 0) {
                     where.Order = $scope.query.order
+                }
+
+                if (query.service) {
+                    // service does not affect URLs as it's a page specific thing
+                    $scope.query.service = query.service
                 }
 
                 // FIXME handle service

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -5,8 +5,8 @@
             <md-input-container class="md-block minimal">
                 <!-- TODO: add Address -->
                 <label>City, Neighborhood, Zip, Address</label>
-                <input data-ng-model="options.query.Location" type="text" maxlength="250"
-                       data-ng-keyup="$event.keyCode == 13 && options.query.Location && searchProperties()"
+                <input data-ng-model="options.query.where.Location" type="text" maxlength="250"
+                       data-ng-keyup="$event.keyCode == 13 && options.query.where.Location && searchProperties()"
                        autocomplete="off"
                 >
             </md-input-container>
@@ -24,19 +24,19 @@
                         <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                             <md-input-container class="md-block minimal">
                                 <label>Min Price</label>
-                                <input stratus-string-to-number="comma" data-ng-model="options.query.ListPriceMin" type="text" maxlength="11" size="8" autocomplete="off">
+                                <input stratus-string-to-number="comma" data-ng-model="options.query.where.ListPriceMin" type="text" maxlength="11" size="8" autocomplete="off">
                             </md-input-container>
                         </div>
                         <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                             <md-input-container class="md-block minimal">
                                 <label>Max Price</label>
-                                <input stratus-string-to-number="comma" data-ng-model="options.query.ListPriceMax" type="text" maxlength="11" size="8" autocomplete="off">
+                                <input stratus-string-to-number="comma" data-ng-model="options.query.where.ListPriceMax" type="text" maxlength="11" size="8" autocomplete="off">
                             </md-input-container>
                         </div>
                         <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                             <md-input-container class="md-block minimal">
                                 <label>Beds</label>
-                                <md-select data-ng-model="options.query.Bedrooms">
+                                <md-select data-ng-model="options.query.where.Bedrooms">
                                     <md-option></md-option>
                                     <md-option data-ng-repeat="option in options.selection.Bedrooms" data-ng-value="option.value">
                                         {{option.name}}
@@ -47,7 +47,7 @@
                         <div class="search-input" data-flex="50" data-flex-gt-sm="25">
                             <md-input-container class="md-block minimal">
                                 <label>Baths</label>
-                                <md-select data-ng-model="options.query.Bathrooms">
+                                <md-select data-ng-model="options.query.where.Bathrooms">
                                     <md-option></md-option>
                                     <md-option data-ng-repeat="option in options.selection.Bathrooms" data-ng-value="option.value">
                                         {{option.name}}
@@ -78,16 +78,16 @@
 
                     <div data-layout="row" data-ng-show="!options.forRent" data-layout-align="space-around center" aria-label="Listing Status">
                         <md-button class="md-raised font-primary"
-                                   data-ng-class="{'md-primary': inArray('Active', options.query.Status)}"
-                                   data-ng-click="options.query.Status = ['Active', 'Contract'];"
+                                   data-ng-class="{'md-primary': inArray('Active', options.query.where.Status)}"
+                                   data-ng-click="options.query.where.Status = ['Active', 'Contract'];"
                                    aria-label="For Sale"
                                    data-md-prevent-menu-close
                         >
                             For Sale
                         </md-button>
                         <md-button class="md-raised font-primary"
-                                   data-ng-class="{'md-primary': inArray('Closed', options.query.Status)}"
-                                   data-ng-click="options.query.Status = ['Closed']"
+                                   data-ng-class="{'md-primary': inArray('Closed', options.query.where.Status)}"
+                                   data-ng-click="options.query.where.Status = ['Closed']"
                                    aria-label="Sold"
                                    data-md-prevent-menu-close
                         >
@@ -95,11 +95,11 @@
                         </md-button>
                     </div>
 
-                    <div data-ng-show="!options.forRent && inArray('Active', options.query.Status)">
+                    <div data-ng-show="!options.forRent && inArray('Active', options.query.where.Status)">
                         <md-checkbox
                                 class="show-under-contract font-secondary"
-                                data-ng-checked="inArray('Contract', options.query.Status)"
-                                data-ng-click="toggleArrayElement('Contract', options.query.Status)"
+                                data-ng-checked="inArray('Contract', options.query.where.Status)"
+                                data-ng-click="toggleArrayElement('Contract', options.query.where.Status)"
                                 aria-label="Under Contract"
                                 data-md-prevent-menu-close
                         >
@@ -114,7 +114,7 @@
                         <div class="search-input">
                             <md-input-container class="md-block minimal">
                                 <label>Sort</label>
-                                <md-select data-ng-model="options.query.Order">
+                                <md-select data-ng-model="options.query.where.Order">
                                     <md-option data-ng-repeat="option in options.selection.Order" data-ng-value="option.value">
                                         {{option.name}}
                                     </md-option>
@@ -149,8 +149,8 @@
                                 data-ng-repeat="listType in ::options.selection.ListingType.All"
                                 class="md-raised font-primary"
                                 data-ng-show="options.forRent === listType.lease && options.selection.ListingType.group[listType.group]"
-                                data-ng-class="{'md-primary': inArray(listType.value, options.query.ListingType)}"
-                                data-ng-click="toggleArrayElement(listType.value, options.query.ListingType)"
+                                data-ng-class="{'md-primary': inArray(listType.value, options.query.where.ListingType)}"
+                                data-ng-click="toggleArrayElement(listType.value, options.query.where.ListingType)"
                                 aria-label="{{::listType.name}}"
                                 data-md-prevent-menu-close
                                 data-ng-bind="::listType.name"
@@ -158,24 +158,24 @@
                     </div>
 
                     <!-- Only Include if these were preset in a Property Filter pages and we need the ability to remove them -->
-                    <div ng-if="options.query.City.length || options.query.MLSAreaMajor.length || options.PostalCode.length">
+                    <div ng-if="options.query.where.City.length || options.query.where.MLSAreaMajor.length || options.PostalCode.length">
                         <div class="sale-status-border dotted-spaced-underline"></div>
                         <h3 data-layout-align="space-around center">Preset Filters</h3>
                         <div class="specific-filters" data-layout="row" data-layout-align="space-around center" aria-label="Specific Areas">
-                            <div class="search-input" ng-if="options.query.City.length">
+                            <div class="search-input" data-ng-if="options.query.where.City.length">
                                 <md-input-container class="md-block minimal">
                                     <label>City</label>
-                                    <input data-ng-model="options.query.City"
+                                    <input data-ng-model="options.query.where.City"
                                            type="text"
                                            maxlength="250"
                                            autocomplete="off">
                                 </md-input-container>
                             </div>
-                            <div class="search-input" ng-if="options.query.MLSAreaMajor.length">
+                            <div class="search-input" data-ng-if="options.query.where.MLSAreaMajor.length">
                                 <md-chips
                                         class="area-id font-secondary"
                                         aria-label="Neighborhoods to Limit"
-                                        data-ng-model="options.query.MLSAreaMajor"
+                                        data-ng-model="options.query.where.MLSAreaMajor"
                                         data-md-enable-chip-edit="true"
                                         data-md-add-on-blur="true"
                                         data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
@@ -185,11 +185,11 @@
                                         data-delete-hint="Press delete to remove Neighborhood"
                                 ></md-chips>
                             </div>
-                            <div class="search-input" ng-if="options.query.PostalCode.length">
+                            <div class="search-input" data-ng-if="options.query.where.PostalCode.length">
                                 <md-chips
                                         class="postal-code font-secondary"
                                         aria-label="Postal Code(s) to Limit"
-                                        data-ng-model="options.query.PostalCode"
+                                        data-ng-model="options.query.where.PostalCode"
                                         data-md-enable-chip-edit="true"
                                         data-md-add-on-blur="true"
                                         data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
@@ -207,7 +207,7 @@
                         <md-chips
                                 class="agent-license font-secondary"
                                 aria-label="Agent License(s) to Search"
-                                data-ng-model="options.query.AgentLicense"
+                                data-ng-model="options.query.where.AgentLicense"
                                 data-md-enable-chip-edit="true"
                                 data-md-add-on-blur="true"
                                 data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -13,7 +13,7 @@ import 'angular-material'
 
 // Services
 import '@stratusjs/idx/idx'
-import {ObjectWithFunctions, WhereOptions} from '@stratusjs/idx/idx'
+import {CompileFilterOptions, ObjectWithFunctions, WhereOptions} from '@stratusjs/idx/idx'
 
 // Stratus Dependencies
 import {isJSON} from '@stratusjs/core/misc'
@@ -39,7 +39,11 @@ export type IdxPropertySearchScope = angular.IScope & ObjectWithFunctions & {
     listInitialized: boolean
     listLinkUrl: string
     listLinkTarget: string
-    options: object | any // TODO need to specify
+    // options: object | any // TODO need to specify
+    options: {
+        [key: string]: object | any
+        query: CompileFilterOptions
+    }
     variableSyncing: object | any
     filterMenu?: any // angular.material.IPanelRef // disabled because we need to set reposition()
 }
@@ -107,8 +111,11 @@ Stratus.Components.IdxPropertySearch = {
             $scope.options.forRent = false
 
             // Set default queries
-            $scope.options.query = $scope.options.query || {}
-            $scope.setQuery($scope.options.query)
+            $scope.options.query = $scope.options.query || {
+                where: {}
+            }
+            // $scope.setQuery($scope.options.query)
+            $scope.setWhere($scope.options.query.where)
 
             // Set default selections TODO may need some more universally set options to be able to use
             $scope.options.selection = $scope.options.selection || {}
@@ -179,7 +186,7 @@ Stratus.Components.IdxPropertySearch = {
                 {name: 'Commercial', value: 'LeaseCommercial', group: 'Commercial', lease: true}
             ]
 
-            $scope.setQueryDefaults()
+            $scope.setWhereDefaults()
 
             // Register this Search with the Property service
             Idx.registerSearchInstance($scope.elementId, $scope, $scope.listId)
@@ -187,31 +194,33 @@ Stratus.Components.IdxPropertySearch = {
             // await $scope.variableSync() sync is moved to teh timeout above so it can still work with List widgets
         }
 
-        $scope.$watch('options.query.ListingType', () => {
+        $scope.$watch('options.query.where.ListingType', () => {
             // TODO: Consider Better solution? I just added the check to see if $scope.options.query is set
             // because there are cases where $scope.options.query is not defined (null). This happens on admin
             // edit page load  for a new record where nothing has been set on a page yet.
             // Davis: removed check for $scope.options.query.ListingType as if it's not an Array will create it
-            if ($scope.options.query && $scope.options.selection.ListingType.list) {
-                if (!Object.prototype.hasOwnProperty.call($scope.options.query, 'ListingType')) {
-                    $scope.options.query.ListingType = []
+            if ($scope.options.query && $scope.options.query.where && $scope.options.selection.ListingType.list) {
+                if (!Object.prototype.hasOwnProperty.call($scope.options.query.where, 'ListingType')) {
+                    $scope.options.query.where.ListingType = []
                 }
-                if (!_.isArray($scope.options.query.ListingType)) {
-                    $scope.options.query.ListingType = [$scope.options.query.ListingType]
+                // FIXME needs to be moved to query.where
+                if (!_.isArray($scope.options.query.where.ListingType)) {
+                    $scope.options.query.where.ListingType = [$scope.options.query.where.ListingType]
                 }
                 $scope.options.selection.ListingType.group.Residential =
-                    $scope.arrayIntersect($scope.options.selection.ListingType.list.Residential, $scope.options.query.ListingType)
+                    $scope.arrayIntersect($scope.options.selection.ListingType.list.Residential, $scope.options.query.where.ListingType)
                 $scope.options.selection.ListingType.group.Commercial =
-                    $scope.arrayIntersect($scope.options.selection.ListingType.list.Commercial, $scope.options.query.ListingType)
+                    $scope.arrayIntersect($scope.options.selection.ListingType.list.Commercial, $scope.options.query.where.ListingType)
 
                 $scope.options.forRent =
-                    $scope.arrayIntersect($scope.options.selection.ListingType.list.Lease, $scope.options.query.ListingType)
+                    $scope.arrayIntersect($scope.options.selection.ListingType.list.Lease, $scope.options.query.where.ListingType)
                 // console.log('watched ListingType', $scope.options.query.ListingType, $scope.options.selection.ListingType.group)
             }
         })
 
         /**
          * Create filter function for a query string
+         * TODO whats this used for?
          */
         const createFilterFor = (query: string) => {
             const lowercaseQuery = query.toLowerCase()
@@ -408,17 +417,32 @@ Stratus.Components.IdxPropertySearch = {
         /**
          * Update the entirety options.query in a safe manner to ensure undefined references are not produced
          */
-        $scope.setQuery = (newQuery?: WhereOptions): void => {
+        $scope.setQuery = (newQuery?: CompileFilterOptions): void => {
             newQuery = newQuery || {}
+            newQuery.where = newQuery.where || {}
             // getDefaultWhereOptions returns the set a required WhereOptions with initialized arrays
-            $scope.options.query = _.extend(Idx.getDefaultWhereOptions(), newQuery)
+            // $scope.options.query = _.extend(Idx.getDefaultWhereOptions(), newQuery)
+            $scope.options.query = _.clone(newQuery)
+            $scope.setWhere($scope.options.query.where)
         }
 
-        $scope.setQueryDefaults = (): void => {
+        /**
+         * Update the entirety options.query.where in a safe manner to ensure undefined references are not produced
+         */
+        $scope.setWhere = (newWhere?: WhereOptions): void => {
+            console.log('setWhere', _.clone(newWhere))
+            newWhere = newWhere || {}
+            // getDefaultWhereOptions returns the set a required WhereOptions with initialized arrays
+            // FIXME do we set anything outside where?
+            $scope.options.query.where = _.extend(Idx.getDefaultWhereOptions(), newWhere)
+        }
+
+        $scope.setWhereDefaults = (): void => {
             $scope.$applyAsync(() => {
-                if ($scope.options.query.ListingType.length < 1) {
-                    $scope.options.query.ListingType = $scope.options.selection.ListingType.default.Sale.Residential
-                    // console.log('updating', $scope.options.query.ListingType)
+                // FIXME needs to be moved to query.where
+                if ($scope.options.query.where.ListingType.length < 1) {
+                    $scope.options.query.where.ListingType = $scope.options.selection.ListingType.default.Sale.Residential
+                    // console.log('updating', $scope.options.query.where.ListingType)
                     $scope.selectDefaultListingType()
                 }
             })
@@ -431,17 +455,17 @@ Stratus.Components.IdxPropertySearch = {
                     listingGroup = 'Residential'
                 }
             }
-            $scope.options.query.ListingType = $scope.options.forRent ?
+            $scope.options.query.where.ListingType = $scope.options.forRent ?
                 $scope.options.selection.ListingType.default.Lease[listingGroup] :
                 $scope.options.selection.ListingType.default.Sale[listingGroup]
             if ($scope.filterMenu) {
                 $scope.filterMenu.reposition()
             }
             if ($scope.options.forRent) {
-                $scope.options.query.Status = $scope.options.selection.Status.default.Lease
+                $scope.options.query.where.Status = $scope.options.selection.Status.default.Lease
             } else {
-                $scope.options.query.Status = ($scope.options.query.Status && $scope.options.query.Status.length > 0) ?
-                    $scope.options.query.Status : $scope.options.selection.Status.default.Lease
+                $scope.options.query.where.Status = ($scope.options.query.where.Status && $scope.options.query.where.Status.length > 0) ?
+                    $scope.options.query.where.Status : $scope.options.selection.Status.default.Lease
             }
         }
 
@@ -455,10 +479,18 @@ Stratus.Components.IdxPropertySearch = {
                 listScope = Idx.getListInstance($scope.listId)
             }
             if (listScope) {
-                $scope.options.query.Page = 1
+                // $scope.options.query.where.Page = 1 // just a fall back, as it gets 'Page 2'
+                $scope.options.query.page = 1 // just a fall back, as it gets 'Page 2'
+                console.log('sending search', _.clone($scope.options.query))
+
+                /* const searchQuery: CompileFilterOptions = {
+                    where: _.clone($scope.options.query.where)
+                }*/
+                // FIXME need to ensure only where options
+                // console.log('but suppose to send', _.clone($scope.options.query))
                 listScope.searchProperties($scope.options.query, true)
             } else {
-                Idx.setUrlOptions('Search', $scope.options.query)
+                Idx.setUrlOptions('Search', $scope.options.query.where) // TODO may need to set Page and stuff?
                 $window.open($scope.listLinkUrl + '#!/' + Idx.getUrlOptionsPath(), $scope.listLinkTarget)
             }
         }

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -41,8 +41,10 @@ export type IdxPropertySearchScope = angular.IScope & ObjectWithFunctions & {
     listLinkTarget: string
     // options: object | any // TODO need to specify
     options: {
-        [key: string]: object | any
+        // [key: string]: object | any
         query: CompileFilterOptions
+        selection: object | any // TODO need to specify
+        forRent: boolean
     }
     variableSyncing: object | any
     filterMenu?: any // angular.material.IPanelRef // disabled because we need to set reposition()
@@ -94,6 +96,22 @@ Stratus.Components.IdxPropertySearch = {
             $scope.listLinkUrl = $attrs.listLinkUrl || '/property/list'
             $scope.listLinkTarget = $attrs.listLinkTarget || '_self'
 
+            $scope.options = $attrs.options && isJSON($attrs.options) ? JSON.parse($attrs.options) : {}
+
+            $scope.filterMenu = null
+            $scope.options.forRent = false
+
+            // Set default queries
+            $scope.options.query = $scope.options.query || {
+                where: {}
+            }
+            $scope.options.query.service = $scope.options.query.service || []
+
+            // $scope.setQuery($scope.options.query)
+            $scope.setWhere($scope.options.query.where)
+
+            console.log('$scope.options.query is starting at ', _.clone($scope.options.query))
+
             // If the List hasn't updated this widget after 1 second, make sure it's checked again. A workaround for
             // the race condition for now, up for suggestions
             $timeout(async () => {
@@ -103,19 +121,6 @@ Stratus.Components.IdxPropertySearch = {
                 // Sync needs to happen here so that the List and still connect with the Search widget
                 await $scope.variableSync()
             }, 1000)
-
-            $scope.options = $attrs.options && isJSON($attrs.options) ? JSON.parse($attrs.options) : {}
-
-            $scope.filterMenu = null
-            $scope.options.service = $scope.options.service || []
-            $scope.options.forRent = false
-
-            // Set default queries
-            $scope.options.query = $scope.options.query || {
-                where: {}
-            }
-            // $scope.setQuery($scope.options.query)
-            $scope.setWhere($scope.options.query.where)
 
             // Set default selections TODO may need some more universally set options to be able to use
             $scope.options.selection = $scope.options.selection || {}
@@ -276,7 +281,7 @@ Stratus.Components.IdxPropertySearch = {
                     return value
                 }
             } else {
-                console.warn('updateNestedPathValue couldn\'t find', currentPiece, 'in', currentNest, 'It may need to be initialized first')
+                console.warn('updateNestedPathValue couldn\'t find', currentPiece, 'in', _.clone(currentNest), 'It may need to be initialized first')
                 return null
             }
         }
@@ -424,6 +429,7 @@ Stratus.Components.IdxPropertySearch = {
             // $scope.options.query = _.extend(Idx.getDefaultWhereOptions(), newQuery)
             $scope.options.query = _.clone(newQuery)
             $scope.setWhere($scope.options.query.where)
+            console.log('setQuery $scope.options.query to ', _.clone($scope.options.query))
         }
 
         /**
@@ -479,8 +485,9 @@ Stratus.Components.IdxPropertySearch = {
                 listScope = Idx.getListInstance($scope.listId)
             }
             if (listScope) {
+                // $scope.options.query.service = [1]
                 // $scope.options.query.where.Page = 1 // just a fall back, as it gets 'Page 2'
-                $scope.options.query.page = 1 // just a fall back, as it gets 'Page 2'
+                // $scope.options.query.page = 1 // just a fall back, as it gets 'Page 2'
                 console.log('sending search', _.clone($scope.options.query))
 
                 /* const searchQuery: CompileFilterOptions = {

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -13,13 +13,13 @@ import 'angular-material'
 
 // Services
 import '@stratusjs/idx/idx'
+import {ObjectWithFunctions, WhereOptions} from '@stratusjs/idx/idx'
 
 // Stratus Dependencies
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 // FIXME should we be renaming the old 'stratus.directives' variables to something else now that we're @stratusjs?
 import 'stratus.directives.stringToNumber'
-import {WhereOptions} from '@stratusjs/idx/idx'
 
 // Environment
 const min = !cookie('env') ? '.min' : ''
@@ -28,6 +28,21 @@ const moduleName = 'property'
 const componentName = 'search'
 // There is not a very consistent way of pathing in Stratus at the moment
 const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
+
+export type IdxPropertySearchScope = angular.IScope & ObjectWithFunctions & {
+    elementId: string
+    localDir: string
+    model: any
+    Idx: any
+    widgetName: string
+    listId: string
+    listInitialized: boolean
+    listLinkUrl: string
+    listLinkTarget: string
+    options: object | any // TODO need to specify
+    variableSyncing: object | any
+    filterMenu?: any // angular.material.IPanelRef // disabled because we need to set reposition()
+}
 
 Stratus.Components.IdxPropertySearch = {
     bindings: {
@@ -46,7 +61,8 @@ Stratus.Components.IdxPropertySearch = {
         $q: angular.IQService,
         $mdConstant: any, // mdChips item
         $mdPanel: angular.material.IPanelService,
-        $scope: object | any, // angular.IScope breaks references so far
+        // $scope: object | any, // angular.IScope breaks references so far
+        $scope: IdxPropertySearchScope,
         $timeout: angular.ITimeoutService,
         $window: angular.IWindowService,
         Idx: any,


### PR DESCRIPTION
@stratusjs/idx
* Fixed data association between widget files (the $scope are now given strict types)
* Refactored List, Search, and Idx service to provide strict Types and properly pass on the -correct- variable types instead of assuming what is what.
*  Fixed the admin page and allowing more control of the query being passed around (https://app.asana.com/0/1154407311832843/1156345571542394/f)

Will probably need to add more variables, but for the moment, the large part is out of the way

This is not published and still has many console.logs