### PR TITLE
Collection & Model: Various Improvements

### DIFF
--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.2.19",
+  "version": "0.2.21",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -88,9 +88,10 @@ export class Collection extends EventManager {
     model = Model
     models: any = []
     types: any = []
-    cache: any = {}
+    cacheRequest: any = {}
 
     // Internals
+    cache = false
     pending = false
     error = false
     completed = false
@@ -247,8 +248,8 @@ export class Collection extends EventManager {
                     // TODO: Make this into an over-writable function
 
                     // Cache reference
-                    if (prototype.method === 'GET' && !(queryHash in this.cache)) {
-                        this.cache[queryHash] = response
+                    if (this.cache && prototype.method === 'GET' && !(queryHash in this.cacheRequest)) {
+                        this.cacheRequest[queryHash] = response
                     }
 
                     // Data
@@ -314,8 +315,8 @@ export class Collection extends EventManager {
                 // Trigger Change Event
                 this.throttleTrigger('change')
             }
-            if (prototype.method === 'GET' && queryHash in this.cache) {
-                handler(this.cache[queryHash])
+            if (this.cache && prototype.method === 'GET' && queryHash in this.cacheRequest) {
+                handler(this.cacheRequest[queryHash])
                 return
             }
             if (!$http) {

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -256,7 +256,9 @@ export class Model extends ModelBase {
         // Handle Version Changes
         const version = getAnchorParams('version')
         // this.changed = !_.isEqual(this.data, this.initData)
-        if (changeSet.id || (!_.isEmpty(version) && changeSet.version && parseInt(version, 10) !== changeSet.version.id)) {
+        if (_.get(changeSet, 'id') ||
+            (!_.isEmpty(version) && parseInt(version, 10) !== _.get(changeSet, 'version.id'))
+        ) {
             // console.warn('replacing version...')
             const newUrl = setUrlParams({
                 id: this.data.id
@@ -407,6 +409,7 @@ export class Model extends ModelBase {
                     if (!this.error) {
                         this.changed = false
                         this.saving = false
+                        this.handleChanges()
                         this.recv = _.cloneDeep(this.data)
                         this.patch = {}
                     }

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -9,8 +9,8 @@ import {Stratus} from '@stratusjs/runtime/stratus'
 // Stratus Core
 import {
     getAnchorParams,
-    getUrlParams, LooseObject,
-    patch,
+    getUrlParams,
+    LooseObject,
     setUrlParams,
     strcmp,
     ucfirst
@@ -163,6 +163,7 @@ export class Model extends ModelBase {
         //     _.extend(this.data, attributes)
         // }
 
+        // TODO: Analyze possibility for options.received to be replaced with a !this.isNew()
         // Handle Data Flagged as Received from XHR
         this.recv = options.received ? _.cloneDeep(this.data) : {}
 
@@ -232,21 +233,6 @@ export class Model extends ModelBase {
         // as we change values in comparison to the native setTimeout() watcher
         // in the ModelBase.
         $rootScope.$watch(() => this.data, (newData: LooseObject, priorData: LooseObject) => this.handleChanges(), true)
-    }
-
-    flatten(data: LooseObject, flatData?: LooseObject, chain?: string): LooseObject {
-        flatData = flatData || {}
-        const delimiter = chain ? '.' : ''
-        chain = chain || ''
-        _.forEach(data, (value: any, key: string|number) => {
-            const location = `${chain}${delimiter}${key}`
-            if (typeof value === 'object' && value) {
-                this.flatten(value, flatData, location)
-                return
-            }
-            flatData[location] = value
-        })
-        return flatData
     }
 
     // sanitizePatch(patchData: LooseObject) {
@@ -560,6 +546,8 @@ export class Model extends ModelBase {
     // Attribute Functions
 
     toJSON(options?: any) {
+        // Ensure Patch only Saves on Persistent Models
+        options.patch = (options.patch && !this.isNew())
         let data = super.toJSON(options)
         const metaData = this.meta.get('api')
         if (metaData) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/core",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "This is the core package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/core/src/misc.ts
+++ b/packages/core/src/misc.ts
@@ -203,6 +203,21 @@ export function endsWith(target: any, search: any) {
         target.substr(target.length - search.length, target.length).toLowerCase() === search.toLowerCase())
 }
 
+export function flatten(data: LooseObject, flatData?: LooseObject, chain?: string): LooseObject {
+    flatData = flatData || {}
+    const delimiter = chain ? '.' : ''
+    chain = chain || ''
+    _.forEach(data, (value: any, key: string|number) => {
+        const location = `${chain}${delimiter}${key}`
+        if (typeof value === 'object' && value) {
+            flatten(value, flatData, location)
+            return
+        }
+        flatData[location] = value
+    })
+    return flatData
+}
+
 // This is a new simplified Patch Function to allow Difference between Object and Nested Arrays
 // Note: We are currently using LooseObject because the tree below outputs as such
 export function patch(newData: LooseObject, priorData: LooseObject, ignoreKeys?: Array<string>): LooseObject {


### PR DESCRIPTION
Changes:

- Disable Cache by Default on Collections
- Force Full Payload on New Model Save
- Force Model.handleChanges() trigger after XHR Complete
- AngularJS 0.2.21: Bump Package Version
- Core 0.2.14: Move Model.Flatten() to Misc

Fixes:

- ID and Version Change Detection when persisting a new entity
- Saving of a new entity (we want the whole model, not just the patch for initial saves)
- List Caches giving inaccurate results (especially during pagination of changing entities)