### PR TITLE
AngularJS 0.2.25: Better Model Controls

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,8 +25,17 @@ const coffee = require('gulp-coffee')
 const sourcemaps = require('gulp-sourcemaps')
 const ts = require('gulp-typescript')
 
+// TypeScript Transformers
+const keysTransformer = require('ts-transformer-keys/transformer').default
+
 // Project
-const tsProject = ts.createProject('tsconfig.json')
+const tsProject = ts.createProject('tsconfig.json', {
+  getCustomTransformers: (program) => ({
+    before: [
+      keysTransformer(program)
+    ]
+  })
+})
 
 // Helper Functions
 const nullify = function (proto) {

--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
     "tslint": "^5.20.0",
     "typescript": "^3.7.4",
     "vinyl-paths": "^3.0.1"
+  },
+  "dependencies": {
+    "ts-transformer-keys": "^0.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,12 +114,10 @@
     "systemjs": "^6.1.4",
     "terser": "^4.6.3",
     "ts-node": "^8.6.2",
+    "ts-transformer-keys": "^0.4.1",
     "tslib": "^1.10.0",
     "tslint": "^5.20.0",
     "typescript": "^3.7.4",
     "vinyl-paths": "^3.0.1"
-  },
-  "dependencies": {
-    "ts-transformer-keys": "^0.4.1"
   }
 }

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -1,6 +1,9 @@
 // Collection Service
 // ------------------
 
+// Transformers
+import { keys } from 'ts-transformer-keys'
+
 // Runtime
 import _ from 'lodash'
 import angular from 'angular'
@@ -66,6 +69,23 @@ export interface HttpPrototype {
     url: string
     data?: string
 }
+
+export interface CollectionOptions {
+    autoSave?: boolean,
+    autoSaveInterval?: number,
+    autoSaveHalt?: boolean,
+    collection?: Collection,
+    manifest?: string,
+    stagger?: boolean,
+    target?: string,
+    targetSuffix?: string,
+    type?: string
+    urlRoot?: string,
+    urlSync?: boolean,
+    watch?: boolean,
+}
+
+export const CollectionOptionKeys = keys<CollectionOptions>()
 
 export class Collection extends EventManager {
     // Base Information

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -71,18 +71,15 @@ export interface HttpPrototype {
 }
 
 export interface CollectionOptions {
-    autoSave?: boolean,
-    autoSaveInterval?: number,
-    autoSaveHalt?: boolean,
-    collection?: Collection,
-    manifest?: string,
-    stagger?: boolean,
+    cache?: boolean,
+    // decay?: number
+    direct?: boolean,
+    // infinite?: boolean,
+    // qualifier?: string,
     target?: string,
     targetSuffix?: string,
-    type?: string
+    // threshold?: number,
     urlRoot?: string,
-    urlSync?: boolean,
-    watch?: boolean,
 }
 
 export const CollectionOptionKeys = keys<CollectionOptions>()
@@ -92,15 +89,19 @@ export class Collection extends EventManager {
     name = 'Collection'
 
     // Environment
-    target?: any = null
     direct = false
+    target?: any = null
+    targetSuffix?: string = null
+    urlRoot = '/Api'
+
+    // Unsure usage
+    qualifier = '' // ng-if
+    serviceId?: number = null
+
+    // Infinite Scrolling
     infinite = false
     threshold = 0.5
-    qualifier = '' // ng-if
     decay = 0
-    urlRoot = '/Api'
-    targetSuffix?: string = null
-    serviceId?: number = null
 
     // Infrastructure
     header = new ModelBase()
@@ -123,7 +124,7 @@ export class Collection extends EventManager {
     // Methods
     throttle = _.throttle(this.fetch, 1000)
 
-    constructor(options: any) {
+    constructor(options: CollectionOptions) {
         super()
 
         if (options && typeof options === 'object') {

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -90,7 +90,7 @@ export interface ModelOptions extends ModelBaseOptions {
     stagger?: boolean,
     target?: string,
     targetSuffix?: string,
-    type?: string
+    type?: string,
     urlRoot?: string,
     urlSync?: boolean,
     watch?: boolean,

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -1,6 +1,9 @@
 // Model Service
 // -------------
 
+// Transformers
+import { keys } from 'ts-transformer-keys'
+
 // Runtime
 import _ from 'lodash'
 import angular from 'angular'
@@ -79,6 +82,9 @@ export interface HttpPrototype {
 }
 
 export interface ModelOptions extends ModelBaseOptions {
+    autoSave?: boolean,
+    autoSaveInterval?: number,
+    autoSaveHalt?: boolean,
     collection?: Collection,
     manifest?: string,
     stagger?: boolean,
@@ -86,8 +92,11 @@ export interface ModelOptions extends ModelBaseOptions {
     targetSuffix?: string,
     type?: string
     urlRoot?: string,
+    urlSync?: boolean,
     watch?: boolean,
 }
+
+export const ModelOptionKeys = keys<ModelOptions>()
 
 export class Model extends ModelBase {
     // Base Information
@@ -122,10 +131,13 @@ export class Model extends ModelBase {
     status?: any = null
 
     // Auto-Save Logic
-    autoSave = true
+    autoSave = false
     autoSaveInterval = 2500
     autoSaveHalt = true
     autoSaveTimeout: any = null
+
+    // URL Controls
+    urlSync = false
 
     // Misc
     bracket = {
@@ -265,17 +277,18 @@ export class Model extends ModelBase {
         this.saveIdle()
 
         // Handle ID or Version Changes
-        const version = getAnchorParams('version')
-        // this.changed = !_.isEqual(this.data, this.initData)
-        if (_.get(changeSet, 'id') ||
-            (!_.isEmpty(version) && parseInt(version, 10) !== _.get(changeSet, 'version.id'))
-        ) {
-            // console.warn('replacing version...')
-            const newUrl = setUrlParams({
-                id: this.data.id
-            })
-            if (newUrl !== document.location.href) {
-                window.location.replace(newUrl)
+        if (this.urlSync) {
+            const version = getAnchorParams('version')
+            const versionId = !_.isEmpty(version) ? parseInt(version, 10) : 0
+            // this.changed = !_.isEqual(this.data, this.initData)
+            if (_.get(changeSet, 'id') || (versionId && versionId !== _.get(changeSet, 'version.id'))) {
+                // console.warn('replacing version...')
+                const newUrl = setUrlParams({
+                    id: this.data.id
+                })
+                if (newUrl !== document.location.href) {
+                    window.location.replace(newUrl)
+                }
             }
         }
 

--- a/packages/angularjs/src/services/registry.ts
+++ b/packages/angularjs/src/services/registry.ts
@@ -15,7 +15,7 @@ import {cookie} from '@stratusjs/core/environment'
 import {getInjector} from '@stratusjs/angularjs/injector'
 
 // AngularJS Services
-import {Model, ModelOptions} from '@stratusjs/angularjs/services/model'
+import {Model, ModelOptionKeys, ModelOptions} from '@stratusjs/angularjs/services/model'
 import {Collection} from '@stratusjs/angularjs/services/collection'
 
 // Instantiate Injector
@@ -161,16 +161,15 @@ export class Registry {
                 const id = options.id || 'manifest'
                 if (options.decouple || !Stratus.Catalog[options.target][id]) {
                     const modelOptions: ModelOptions = {
-                        target: options.target,
-                        manifest: options.manifest,
                         stagger: true
                     }
-                    if (options.urlRoot) {
-                        modelOptions.urlRoot = options.urlRoot
-                    }
-                    if (options.targetSuffix) {
-                        modelOptions.targetSuffix = options.targetSuffix
-                    }
+                    _.forEach(ModelOptionKeys, (element) => {
+                        const optionValue = _.get(options, element)
+                        if (_.isUndefined(optionValue)) {
+                            return
+                        }
+                        _.set(modelOptions, element, optionValue)
+                    })
                     data = new Model(modelOptions, {
                         id: options.id
                     })

--- a/packages/angularjs/src/services/registry.ts
+++ b/packages/angularjs/src/services/registry.ts
@@ -16,7 +16,7 @@ import {getInjector} from '@stratusjs/angularjs/injector'
 
 // AngularJS Services
 import {Model, ModelOptionKeys, ModelOptions} from '@stratusjs/angularjs/services/model'
-import {Collection} from '@stratusjs/angularjs/services/collection'
+import {Collection, CollectionOptionKeys, CollectionOptions} from '@stratusjs/angularjs/services/collection'
 
 // Instantiate Injector
 let injector = getInjector()
@@ -186,16 +186,14 @@ export class Registry {
                 }
                 if (options.decouple ||
                     !Stratus[registry][options.target].collection) {
-                    const collectionOptions: any = {
-                        target: options.target,
-                        direct: !!options.direct
-                    }
-                    if (options.urlRoot) {
-                        collectionOptions.urlRoot = options.urlRoot
-                    }
-                    if (options.targetSuffix) {
-                        collectionOptions.targetSuffix = options.targetSuffix
-                    }
+                    const collectionOptions: CollectionOptions = {}
+                    _.forEach(CollectionOptionKeys, (element) => {
+                        const optionValue = _.get(options, element)
+                        if (_.isUndefined(optionValue)) {
+                            return
+                        }
+                        _.set(collectionOptions, element, optionValue)
+                    })
                     data = new Collection(collectionOptions)
                     if (!options.decouple) {
                         Stratus[registry][options.target].collection = data

--- a/packages/angularjs/src/services/registry.ts
+++ b/packages/angularjs/src/services/registry.ts
@@ -69,16 +69,15 @@ export class Registry {
                     target: $element
                 }
             }
-            const inputs = {
-                target: 'data-target',
-                targetSuffix: 'data-target-suffix',
-                id: 'data-id',
-                manifest: 'data-manifest',
-                decouple: 'data-decouple',
-                direct: 'data-direct',
-                api: 'data-api',
-                urlRoot: 'data-url-root'
-            }
+            const inputs = {}
+            const baseInputs = [
+                'id',
+                'decouple'
+            ]
+            _.forEach(
+                _.union(ModelOptionKeys, CollectionOptionKeys, baseInputs),
+                (option: string) => _.set(inputs, option, 'data-' + _.kebabCase(option))
+            )
             // FIXME: Sanitize function fails here in certain cases
             const options = _.forEach(inputs, (value: string, key: string, list: any) => {
                 list[key] = $element.attr ? $element.attr(value) : $element[key]


### PR DESCRIPTION
Changes (Repo):

- Add Key Transformer to TypeScript

Changes (AngularJS 0.2.25):

- Better Model Controls
- Better Collection Controls
- Dynamic Data Attributes
- Bump AngularJS Version to 0.2.25