### PR TITLE
Angular 0.2.25: Functional Quill Buttons

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -172,6 +172,7 @@ function lintJS () {
     '!**/*.min.js',
     '!node_modules/**/*.js',
     '!dist/**/*.js',
+    '!etc/**/*.js',
     '!packages/**/*.js', // TypeScript supersedes Standard JS
     '!reports/**/*.js',
     '!umd/**/*.js'

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -48,11 +48,13 @@
     "@material-ui/system": "^4.9.14",
     "@material-ui/types": "^5.1.0",
     "@material-ui/utils": "^4.10.2",
+    "@ngstack/code-editor": "^1.0.0",
     "@stratusjs/boot": "^0.2.5",
     "@stratusjs/core": "^0.2.16",
     "@stratusjs/runtime": "^0.11.6",
     "core-js": "^3.6.5",
     "hammerjs": "^2.0.8",
+    "highlight.js": "^10.1.2",
     "lodash": "^4.17.19",
     "monaco-editor": "^0.20.0",
     "ngx-monaco-editor": "^9.0.0",

--- a/packages/angular/src/app.module.ts
+++ b/packages/angular/src/app.module.ts
@@ -102,6 +102,7 @@ import {
 // } from 'quill-html-edit-button'
 // @ts-ignore
 import ImageDropAndPaste from 'quill-image-drop-and-paste'
+import {CodeViewDialogComponent} from '@stratusjs/angular/editor/code-view-dialog.component'
 
 // Quill Registers
 Quill.register('modules/mediaLibrary', QuillInputButtonPlugin)
@@ -144,6 +145,7 @@ Quill.register('modules/imageDropAndPaste', ImageDropAndPaste)
 // External Configs
 const quillConfig: QuillConfig = {
     modules: {
+        // TODO: This requires highlight.js
         // syntax: true,
         toolbar: [
             // inline text styles
@@ -159,8 +161,6 @@ const quillConfig: QuillConfig = {
             [{ align: ['right', 'center', 'justify'] }],
             [{ indent: '-1'}, { indent: '+1' }],             // outdent/indent
 
-            // [{ direction: 'rtl' }],                          // text direction
-
             // [{ size: ['small', false, 'large', 'huge'] }],   // custom dropdown
 
             // [{ color: [] }, { background: [] }],             // dropdown with defaults from theme
@@ -173,7 +173,8 @@ const quillConfig: QuillConfig = {
                 'link',
                 // 'image',
                 'video'
-            ]
+            ],
+            [{ direction: 'rtl' }]                           // text direction
         ],
         /* *
         mediaLibrary: {
@@ -232,7 +233,7 @@ if (cookie('env')) {
         name: 'mediaLibrary',
         eventName: 'media-library'
     }
-    /* *
+    /* */
     quillConfig.modules.codeView = {
         debug: true,
         buttonHTML: '<i class="fas fa-code"></i>',
@@ -325,6 +326,7 @@ const monacoConfig: NgxMonacoEditorConfig = {
     // This determines what is accessible as a component. These must be listed in `declarations`.
     entryComponents: [
         BaseComponent,
+        CodeViewDialogComponent,
         EditorComponent,
         MediaDialogComponent,
         SelectorComponent,
@@ -335,6 +337,7 @@ const monacoConfig: NgxMonacoEditorConfig = {
     // These determine what exists as a component. These must be listed in `entryComponents`.
     declarations: [
         BaseComponent,
+        CodeViewDialogComponent,
         EditorComponent,
         MediaDialogComponent,
         SelectorComponent,

--- a/packages/angular/src/editor/code-view-dialog.component.html
+++ b/packages/angular/src/editor/code-view-dialog.component.html
@@ -1,0 +1,14 @@
+<h1 mat-dialog-title>Code View</h1>
+
+<div mat-dialog-content class="code-view-dialog-content">
+    <!-- Target Editor -->
+    <form class="dialog-form" [formGroup]='dialogCodeViewForm'>
+        <mat-form-field class="form-field">
+            <textarea matInput
+                      placeholder="Edit Code"
+                      aria-label="Edit Code"
+                      formControlName="codeViewInput">
+            </textarea>
+        </mat-form-field>
+    </form>
+</div>

--- a/packages/angular/src/editor/code-view-dialog.component.scss
+++ b/packages/angular/src/editor/code-view-dialog.component.scss
@@ -1,0 +1,12 @@
+.editor-component {
+  .code-view {
+    &-dialog {
+      &-content {
+        .form-field {
+          width: 100%;
+          min-height: 80px;
+        }
+      }
+    }
+  }
+}

--- a/packages/angular/src/editor/code-view-dialog.component.ts
+++ b/packages/angular/src/editor/code-view-dialog.component.ts
@@ -1,0 +1,147 @@
+// Angular Core
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    Inject,
+    OnInit,
+    OnChanges
+} from '@angular/core'
+import {
+    FormBuilder,
+    FormGroup
+} from '@angular/forms'
+import {
+    MAT_DIALOG_DATA,
+    MatDialog,
+    MatDialogRef
+} from '@angular/material/dialog'
+
+// RXJS
+import {
+    debounceTime,
+    finalize,
+    switchMap,
+    tap
+} from 'rxjs/operators'
+
+// External
+import _ from 'lodash'
+import {
+    Stratus
+} from '@stratusjs/runtime/stratus'
+
+// Services
+import {
+    BackendService
+} from '@stratusjs/angular/backend.service'
+import {
+    LooseObject
+} from '@stratusjs/core/misc'
+
+// Data Types
+export interface CodeViewDialogData extends LooseObject {
+    code: string
+}
+export interface Content extends LooseObject {
+    id?: number
+    route?: string
+    version?: {
+        title?: string
+    }
+}
+
+// Local Setup
+const localDir = `/assets/1/0/bundles/${boot.configuration.paths['@stratusjs/angular/*'].replace(/[^/]*$/, '')}`
+const systemDir = '@stratusjs/angular'
+const moduleName = 'code-view-dialog'
+const parentModuleName = 'editor'
+
+/**
+ * @title Dialog for Nested Tree
+ */
+@Component({
+    selector: `sa-${moduleName}`,
+    templateUrl: `${localDir}/${parentModuleName}/${moduleName}.component.html`,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CodeViewDialogComponent implements OnInit {
+
+    // Basic Component Settings
+    title = moduleName + '_component'
+    uid: string
+
+    // Dependencies
+    _: any
+
+    // Form Data
+    dialogCodeViewForm: FormGroup
+
+    // filteredParentOptions: any[]
+    // dialogParentForm: FormGroup
+    // isParentLoading = false
+    // lastParentSelectorQuery: string
+
+    constructor(
+        public dialogRef: MatDialogRef<CodeViewDialogComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: CodeViewDialogData,
+        private fb: FormBuilder,
+        private backend: BackendService,
+        private ref: ChangeDetectorRef
+    ) {
+        // Manually render upon data change
+        // ref.detach()
+    }
+
+    ngOnInit() {
+        // Initialization
+        this.uid = _.uniqueId(`sa_${moduleName}_component_`)
+        Stratus.Instances[this.uid] = this
+
+        // Dependencies
+        this._ = _
+
+        // TODO: Assess & Possibly Remove when the System.js ecosystem is complete
+        // Load Component CSS until System.js can import CSS properly.
+        Stratus.Internals.CssLoader(`${localDir}/${parentModuleName}/${moduleName}.component.css`)
+
+        // TODO: Move this to its own AutoComplete Component
+        // AutoComplete Logic
+        this.dialogCodeViewForm = this.fb.group({
+            codeViewInput: this.data.code || ''
+        })
+        this.dialogCodeViewForm
+            .get('codeViewInput')
+            .valueChanges
+            .pipe(
+                debounceTime(300),
+                tap((value: any) => {
+                    console.log('changed:', value)
+                })
+            )
+            .subscribe((response: any) => {
+                this.refresh()
+            })
+
+        // FIXME: We have to go in this roundabout way to force changes to be detected since the
+        // Dialog Sub-Components don't seem to have the right timing for ngOnInit
+        this.refresh()
+    }
+
+    public refresh() {
+        if (!this.ref) {
+            console.error('ref not available:', this)
+            return
+        }
+        this.ref.detach()
+        this.ref.detectChanges()
+        this.ref.reattach()
+    }
+
+    onCancelClick(): void {
+        this.dialogRef.close()
+        // FIXME: We have to go in this roundabout way to force changes to be detected since the
+        // Dialog Sub-Components don't seem to have the right timing for ngOnInit
+        this.refresh()
+    }
+}

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -84,6 +84,7 @@ import {
 import {
     Collection
 } from '@stratusjs/angularjs/services/collection'
+import {CodeViewDialogComponent} from '@stratusjs/angular/editor/code-view-dialog.component'
 
 // Local Setup
 const localDir = `/assets/1/0/bundles/${boot.configuration.paths['@stratusjs/angular/*'].replace(/[^/]*$/, '')}`
@@ -275,6 +276,11 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
                 // but something this simple could be used for simple UX purposes down the road.
                 // this.dataChangeLog.push(value)
 
+                // Normalize null values to empty strings to maintain consistent typing.
+                if (value === null) {
+                    value = ''
+                }
+
                 // Save the qualified change!
                 this.model.set(this.property, value)
             }
@@ -414,10 +420,12 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
 
     trigger(name: string, data: any, callee: TriggerInterface) {
         console.log('editor.trigger:', name, callee)
-        callee.trigger('editor', null, this)
         if (name === 'media-library') {
             this.openMediaDialog()
+        } else if (name === 'code-view') {
+            this.openCodeViewDialog()
         }
+        // callee.trigger('editor', null, this)
     }
 
     public openMediaDialog(): void {
@@ -425,6 +433,27 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             width: '1000px',
             data: {
                 foo: 'bar'
+            }
+        })
+        this.refresh()
+
+        const that = this
+        dialogRef.afterClosed().subscribe((result: MediaDialogData) => {
+            if (!result || _.isEmpty(result)) {
+                return
+            }
+            // TODO: Find Selected Media through click event
+            // Refresh Component
+            that.refresh()
+        })
+    }
+
+    public openCodeViewDialog(): void {
+        const dataControl = this.form.get('dataString')
+        const dialogRef = this.dialog.open(CodeViewDialogComponent, {
+            width: '1000px',
+            data: {
+                code: dataControl.value
             }
         })
         this.refresh()

--- a/packages/angular/src/editor/quill-input-button.plugin.ts
+++ b/packages/angular/src/editor/quill-input-button.plugin.ts
@@ -6,12 +6,18 @@ import {
     TriggerInterface
 } from '@stratusjs/angular/core/trigger.interface'
 
+// External Dependencies
+import _ from 'lodash'
+
 // Quill
 import Quill from 'quill'
 import {QuillToolbarConfig} from 'ngx-quill'
 
 // Universal Button
 class QuillInputButtonPlugin implements TriggerInterface {
+    // Local
+    uid: string
+
     // Settings
     debug = false
     buttonHTML = '<i class="fas fa-carrot"></i>'
@@ -21,6 +27,10 @@ class QuillInputButtonPlugin implements TriggerInterface {
 
     // The quill parameter should be a type of Quill, but that doesn't appear to have the container attribute
     constructor(quill: any, options: any) {
+        // Initialization
+        this.uid = _.uniqueId(`quill_input_button_`)
+        Stratus.Instances[this.uid] = this
+
         this.debug = options && options.debug
 
         // normalize options
@@ -97,7 +107,7 @@ class QuillInputButtonPlugin implements TriggerInterface {
         if (!instance) {
             return
         }
-        instance.trigger('media-library', null, this)
+        instance.trigger(this.eventName, null, this)
     }
 
     trigger(name: string, data: any, callee: TriggerInterface) {


### PR DESCRIPTION
Adds:

- Code View Dialog

Fixes:

- Nullified fields
- Universal Button
- Dialog Separation

Note: This dialogs don't save yet, but they are able
to be previewed in a dev environment.

Signed-off-by: alexgurrola <alexgurrola1@gmail.com>