### PR TITLE
@stratusjs/idx 0.7.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
-language: javascript
+os: linux
+language: nodejs
 services:
   - mongodb
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 dist: xenial
+language: javascript
 services:
   - mongodb
   - mysql
-  - redis-server
-matrix:
+  - redis
+jobs:
   include:
     - language: node_js
       # EOL: 2021-04-30

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ matrix:
       cache:
         directories:
           - node_modules
-      before_install:
-        - export CHROME_BIN=chromium-browser
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start
-      before_script:
-        - npm install
-      script: node_modules/karma/bin/karma start karma.conf.js --single-run
+#      before_install:
+#        - export CHROME_BIN=chromium-browser
+#        - export DISPLAY=:99.0
+#        - sh -e /etc/init.d/xvfb start
+#      before_script:
+#        - npm install
+#      script: node_modules/karma/bin/karma start karma.conf.js --single-run
 #addons:
 #  firefox: latest
 #  sauce_connect:

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -30,10 +30,10 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angular": "^0.2.33",
+    "@stratusjs/angular": "^0.2.34",
     "@stratusjs/angularjs": "^0.2.36",
     "@stratusjs/angularjs-extras": "^0.6.7",
-    "@stratusjs/map": "^0.2.2",
+    "@stratusjs/map": "^0.2.3",
     "@stratusjs/runtime": "^0.11.7",
     "@stratusjs/swiper": "^0.1.8"
   }

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -162,8 +162,6 @@ export type IdxComponentScope = angular.IScope & ObjectWithFunctions & {
     localDir: string
     Idx: IdxService
 
-    /** @deprecated */
-    getUid(): string // FIXME this isn't returning the uid. Use elementId.
     on(emitterName: string, callback: IdxEmitter): void
     remove(): void
 }

--- a/packages/idx/src/map.component.ts
+++ b/packages/idx/src/map.component.ts
@@ -219,8 +219,6 @@ Stratus.Components.IdxMap = {
 
         $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
 
-        $scope.getUid = (): string => $scope.elementId
-
         $scope.remove = (): void => {
         }
     },

--- a/packages/idx/src/member/details.component.ts
+++ b/packages/idx/src/member/details.component.ts
@@ -208,8 +208,6 @@ Stratus.Components.IdxMemberDetails = {
 
         $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
 
-        $scope.getUid = (): string => $scope.elementId
-
         $scope.remove = (): void => {
         }
 

--- a/packages/idx/src/member/list.component.ts
+++ b/packages/idx/src/member/list.component.ts
@@ -455,8 +455,6 @@ Stratus.Components.IdxMemberList = {
 
         $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
 
-        $scope.getUid = (): string => $scope.elementId
-
         $scope.remove = (): void => {
         }
     },

--- a/packages/idx/src/member/list.component.ts
+++ b/packages/idx/src/member/list.component.ts
@@ -16,7 +16,7 @@ import 'angular-sanitize'
 // Services
 import '@stratusjs/idx/idx'
 // tslint:disable-next-line:no-duplicate-imports
-import {IdxEmitter, IdxListScope, IdxService, Member, Property} from '@stratusjs/idx/idx'
+import {IdxEmitter, IdxListScope, IdxService, Member} from '@stratusjs/idx/idx'
 
 // Stratus Dependencies
 import {Collection} from '@stratusjs/angularjs/services/collection' // Needed as Class

--- a/packages/idx/src/member/search.component.ts
+++ b/packages/idx/src/member/search.component.ts
@@ -275,8 +275,6 @@ Stratus.Components.IdxMemberSearch = {  // FIXME should be just MemberSearch or 
 
         $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
 
-        $scope.getUid = (): string => $scope.elementId
-
         $scope.remove = (): void => {
         }
 

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -69,7 +69,7 @@
 
 				<div class="details-specs-container" data-flex="100" data-flex-gt-xs="20">
 					<div class="details-specs">
-						Status: <span data-ng-bind="::model.data.MlsStatus"></span>
+						Status: <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)"></span>
 						<span data-ng-if="::model.data.BedroomsTotal > 0"><br><span data-ng-bind="::model.data.BedroomsTotal"></span> Beds</span>
                         <span data-ng-if="::model.data.BathroomsFull > 0 || model.data.BathroomsTotalInteger > 0">
                             <br><span data-ng-bind="::model.data.BathroomsFull || model.data.BathroomsTotalInteger"></span> Baths
@@ -84,7 +84,7 @@
                             <br><span data-ng-bind="::model.data.BathroomsPartial"></span> Partial Baths
                         </span>
                         <span data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'">
-                            Closed on
+                            <span data-ng-bind="::Idx.getFriendlyStatus(model.data, preferredStatus)"></span> on
                             <span data-ng-bind="::model.data.CloseDate | moment:{unix:false,format:'MMM Do YYYY'}"></span>
                         </span>
                         <span data-ng-if="::model.data.OnMarketDate">

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -44,7 +44,7 @@
                     <ul class="details-specs primary_font">
                         <li>
                             <!-- TODO need a prettier word for the status and a detail of real status -->
-                            <span data-ng-bind="::model.data.MlsStatus || model.data.StandardStatus" aria-label="Status"></span>
+                            <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)" aria-label="Status"></span>
                         </li>
                         <li data-ng-if="::model.data.BedroomsTotal > 0">
                             <span data-ng-bind="::model.data.BedroomsTotal"></span> Beds
@@ -63,7 +63,7 @@
                             <span data-ng-bind="::model.data.BathroomsPartial"></span> Partial Baths
                         </li>
                         <li data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'">
-                            Closed on
+                            <span data-ng-bind="::Idx.getFriendlyStatus(model.data, preferredStatus)"></span> on
                             <span data-ng-bind="::model.data.CloseDate | moment:{unix:false,format:'MMM Do YYYY'}"></span>
                         </li>
                         <li data-ng-if="::model.data.OnMarketDate">
@@ -162,7 +162,7 @@
                 </div>
                 <div class="details-right">
                     <div class="list-price font-secondary" data-ng-if="::model.data.ClosePrice || model.data.ListPrice">
-                        <span class="list-price-label" data-ng-bind="model.data.ClosePrice ? 'Sold for' : 'Listed at'"></span>
+                        <span class="list-price-label" data-ng-bind="model.data.ClosePrice ? Idx.getFriendlyStatus(model.data, preferredStatus) + ' for' : 'Listed at'"></span>
                         <span class="list-price" data-ng-bind="'$' + (model.data.ClosePrice || model.data.ListPrice | number)"></span>
                     </div>
                     <!-- TODO need a decent way to make a title for Property listings -->

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -1471,8 +1471,6 @@ Stratus.Components.IdxPropertyDetails = {
 
         $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
 
-        $scope.getUid = (): string => $scope.elementId
-
         $scope.remove = (): void => {
             // TODO need to kill any attached slideshows
         }

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -69,6 +69,7 @@ export type IdxPropertyDetailsScope = IdxDetailsScope<Property> & {
     minorDetails: SubSectionOptions[]
     alternateMinorDetails: SubSectionOptions[]
     hideVariables: string[]
+    preferredStatus: 'Closed' | 'Leased' | 'Rented'
     instancePath: string
     mapMarkers: MarkerSettings[]
 
@@ -99,6 +100,7 @@ Stratus.Components.IdxPropertyDetails = {
         contactPhone: '@',
         contactWebsiteUrl: '@',
         hideVariables: '@',
+        preferredStatus: '@',
         options: '@',
         template: '@',
         defaultListOptions: '@'
@@ -153,6 +155,7 @@ Stratus.Components.IdxPropertyDetails = {
             // Items that the user might not what to appear on their feed here. Note that this is human chosen and may
             // not adhere to MLS rules
             $scope.hideVariables = $attrs.hideVariables && isJSON($attrs.hideVariables) ? JSON.parse($attrs.hideVariables) : []
+            $scope.preferredStatus = $attrs.preferredStatus || 'Closed'
 
             // The List's default query is needed to avoid showing the entire Query in the URL
             $scope.defaultListOptions = $attrs.defaultListOptions && isJSON($attrs.defaultListOptions) ?

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -25,7 +25,7 @@
             >
                 <md-card class="property-item" data-ng-class="{highlight: property._unmapped._highlight}">
                     <div class="property-image">
-                        <div class="property-status font-secondary" data-ng-bind="::Idx.getFriendlyStatus(property)" aria-label="Status"></div>
+                        <div class="property-status font-secondary" data-ng-bind="::Idx.getFriendlyStatus(property, preferredStatus)" aria-label="Status"></div>
                         <a data-ng-click="displayModelDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}">
                             <div class="button btn" data-ng-href="{{::getDetailsURL(property)}}">
                                 Details

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -58,6 +58,7 @@ export type IdxPropertyListScope = IdxListScope<Property> & {
     detailsLinkUrl: string
     detailsLinkTarget: '_self' | '_blank'
     detailsHideVariables?: string[]
+    preferredStatus: 'Closed' | 'Leased' | 'Rented'
     detailsTemplate?: string
     query: CompileFilterOptions
     orderOptions: object | any // TODO need to specify
@@ -93,6 +94,7 @@ Stratus.Components.IdxPropertyList = {
         detailsLinkTarget: '@',
         detailsHideVariables: '@',
         detailsTemplate: '@',
+        preferredStatus: '@',
         contactEmail: '@',
         contactName: '@',
         contactPhone: '@',
@@ -148,6 +150,7 @@ Stratus.Components.IdxPropertyList = {
             $scope.detailsHideVariables = $attrs.detailsHideVariables && isJSON($attrs.detailsHideVariables) ?
                 JSON.parse($attrs.detailsHideVariables) : []
             $scope.detailsTemplate = $attrs.detailsTemplate || null
+            $scope.preferredStatus = $attrs.preferredStatus || 'Closed' // Closed is most compatible
 
             // TODO added backwards compatible options <--> query parameter until the next version
             $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) :
@@ -565,6 +568,7 @@ Stratus.Components.IdxPropertyList = {
                     'contact-email'?: string,
                     'contact-phone'?: string,
                     'hide-variables'?: string, // a string array
+                    'preferred-status'?: string,
                     template?: string,
                     'url-load'?: boolean,
                 } = {
@@ -589,6 +593,9 @@ Stratus.Components.IdxPropertyList = {
                 }
                 if ($scope.detailsHideVariables.length > 0) {
                     templateOptions['hide-variables'] = JSON.stringify($scope.detailsHideVariables)
+                }
+                if ($scope.preferredStatus) {
+                    templateOptions['preferred-status'] = $scope.preferredStatus
                 }
                 if ($scope.detailsTemplate) {
                     templateOptions.template = $scope.detailsTemplate

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -657,8 +657,6 @@ Stratus.Components.IdxPropertyList = {
 
         $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
 
-        $scope.getUid = (): string => $scope.elementId
-
         $scope.remove = (): void => {
         }
     },

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -567,8 +567,6 @@ Stratus.Components.IdxPropertySearch = {
 
         $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
 
-        $scope.getUid = (): string => $scope.elementId
-
         /**
          * Destroy this widget
          */


### PR DESCRIPTION
**@stratusjs/idx 0.7.9** published
* Adds option to preferrably use the terms "Closed", "Sold/Leased", or "Sold/Rented"
* Remove deprecated `getUid()`
* Remove unused imports

**config**
* Travis fixes