### PR TITLE
@stratusjs/idx 0.8.5

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.8.3",
+  "version": "0.8.5",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -2619,6 +2619,21 @@ const angularJsService = (
         ) {
             options.openhouses = true
         }
+        // OpenHousesOnly can work fast enough if there is more filters. Disable otherwise
+        if (
+            _.isEmpty(options.where.Neighborhood) &&
+            _.isEmpty(options.where.Location) &&
+            _.isEmpty(options.where.AgentLicense) &&
+            _.isEmpty(options.where.City) &&
+            _.isEmpty(options.where.CityRegion) &&
+            _.isEmpty(options.where.CountyOrParish) &&
+            _.isEmpty(options.where.MLSAreaMajor) &&
+            _.isEmpty(options.where.PostalCode) &&
+            _.isEmpty(options.where.UnparsedAddress)
+        ) {
+            options.openhouses = false
+            delete options.where.OpenHouseOnly
+        }
 
         return genericSearchCollection<Property>(
             $scope,

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -313,9 +313,6 @@ export interface WidgetIntegrations {
         },
         listTrac?: {
             accountId: string
-        },
-        listtracAnalytics?: { // FIXME: Need to remove this name and rename to listTrac (Sitetheory side)
-            accountId: string
         }
     },
     maps?: {
@@ -1152,21 +1149,6 @@ const angularJsService = (
                     ) {
                         sharedValues.integrations.analytics.listTrac = {
                             accountId: response.data.integrations.analytics.listTrac.accountId
-                        }
-                        ListTrac.setAccountId(sharedValues.integrations.analytics.listTrac.accountId)
-                        // FIXME we only need to load ListTrac/send an event when the the MLS is whitelisted for it
-                    }
-                } else if (Object.prototype.hasOwnProperty.call(response.data.integrations.analytics, 'listtracAnalytics')) {
-                    // FIXME this is a placeholder until Sitetheory is fixed (listtracAnalytics changed to listTrac)
-                    if (
-                        Object.prototype.hasOwnProperty.call(
-                            response.data.integrations.analytics.listtracAnalytics, 'accountId'
-                        )
-                        && _.isString(response.data.integrations.analytics.listtracAnalytics.accountId)
-                        && response.data.integrations.analytics.listtracAnalytics.accountId !== ''
-                    ) {
-                        sharedValues.integrations.analytics.listTrac = {
-                            accountId: response.data.integrations.analytics.listtracAnalytics.accountId
                         }
                         ListTrac.setAccountId(sharedValues.integrations.analytics.listTrac.accountId)
                         // FIXME we only need to load ListTrac/send an event when the the MLS is whitelisted for it

--- a/packages/idx/src/property/admin/search.filter.component.html
+++ b/packages/idx/src/property/admin/search.filter.component.html
@@ -172,6 +172,7 @@
                     </md-checkbox>
                 </div>
                 <md-checkbox
+                        data-ng-show="options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length"
                         data-ng-model="options.query.where.OpenHouseOnly"
                         aria-label="Open Houses Only"
                         data-layout="row"

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -41,6 +41,9 @@
 						<span data-ng-if="::openHouse.OpenHouseEndTime"> —
 							<span data-ng-bind="::openHouse.OpenHouseEndTime | moment:{unix:false,format:'h:mm a'}"></span>
 						</span>
+                        <span data-ng-if="::openHouse._unmapped.OpenHouseType && openHouse._unmapped.OpenHouseType === 'Virtual' && openHouse._unmapped.VirtualOpenHouseURL" aria-label="Virtual Open House">
+                            <a data-ng-href="{{::openHouse._unmapped.VirtualOpenHouseURL}}" target="_blank">Virtual Open House</a>
+                        </span>
 						<span data-ng-if="::openHouse.ShowingAgentFirstName">
 							with <span data-ng-bind="::openHouse.ShowingAgentFirstName"></span> <span data-ng-bind="::openHouse.ShowingAgentLastName"></span>
 						</span>

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -1,4 +1,3 @@
-
 <div id="{{elementId}}" data-ng-cloak>
     <div data-ng-if="model.pending" data-layout="row" data-layout-padding data-layout-margin data-layout-align="space-around center" data-layout-wrap>
         <md-progress-circular md-mode="indeterminate"></md-progress-circular>
@@ -219,7 +218,7 @@
                                         <span data-ng-if="::openHouse.OpenHouseEndTime"> —
                                             <span data-ng-bind="::openHouse.OpenHouseEndTime | moment:{unix:false,format:'h:mm a'}"></span>
                                         </span>
-                                        <span data-ng-if="::openHouse.OpenHouseStatus && openHouse.OpenHouseStatus !== 'Active'"> (<span data-ng-bind="::openHouse.OpenHouseStatus">)</span>
+                                        <span data-ng-if="::openHouse.OpenHouseStatus && openHouse.OpenHouseStatus !== 'Active'"> (<span data-ng-bind="::openHouse.OpenHouseStatus"></span>)</span>
                                         <span data-ng-if="::openHouse.ShowingAgentFirstName" aria-label="Open House Shown by Agent">
                                             <br/>
                                             with <span data-ng-bind="::openHouse.ShowingAgentFirstName"></span> <span data-ng-bind="::openHouse.ShowingAgentLastName"></span>

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -219,8 +219,11 @@
                                             <span data-ng-bind="::openHouse.OpenHouseEndTime | moment:{unix:false,format:'h:mm a'}"></span>
                                         </span>
                                         <span data-ng-if="::openHouse.OpenHouseStatus && openHouse.OpenHouseStatus !== 'Active'"> (<span data-ng-bind="::openHouse.OpenHouseStatus"></span>)</span>
+                                        <br/>
+                                        <span data-ng-if="::openHouse._unmapped.OpenHouseType && openHouse._unmapped.OpenHouseType === 'Virtual' && openHouse._unmapped.VirtualOpenHouseURL" aria-label="Virtual Open House">
+                                            <a data-ng-href="{{::openHouse._unmapped.VirtualOpenHouseURL}}" target="_blank">Virtual Open House</a>
+                                        </span>
                                         <span data-ng-if="::openHouse.ShowingAgentFirstName" aria-label="Open House Shown by Agent">
-                                            <br/>
                                             with <span data-ng-bind="::openHouse.ShowingAgentFirstName"></span> <span data-ng-bind="::openHouse.ShowingAgentLastName"></span>
                                         </span>
                                     </div>

--- a/packages/idx/src/property/search.compact.component.html
+++ b/packages/idx/src/property/search.compact.component.html
@@ -154,6 +154,7 @@
                     </div>
 
                     <md-checkbox
+                            data-ng-show="options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length"
                             class="show-open-houses font-secondary"
                             data-ng-model="options.query.where.OpenHouseOnly"
                             aria-label="Open Houses Only"

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -159,7 +159,9 @@
                         </md-checkbox>
                     </div>
 
+                    <!-- 'Openhouses Only' is only allowed when more filters are supplied due to speed restrictions -->
                     <md-checkbox
+                            data-ng-show="options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length"
                             class="show-open-houses font-secondary"
                             data-ng-model="options.query.where.OpenHouseOnly"
                             aria-label="Open Houses Only"


### PR DESCRIPTION
**@stratusjs/idx 0.8.5** published
* listTrac analytics variable renamed to listTrac to match with provided services in Sitetheory api
* Broken HTML doc fixes
* Prevent "Openhouses Only" option if no additional filters are provided
* Temporary VirtualOpenHouse labels for MLSs that require them (only MLSL at this time)