### PR TITLE
@stratusjs/idx 0.9.1

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {


### PR DESCRIPTION
Temporarily reverted gulp compress settings used to publish to allow property .min.css files in this package. This does not affect future `gulp compress` or `npm publish` abilities.