### PR TITLE
@stratusjs/idx 0.12.1

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -30,8 +30,8 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angular": "^0.2.64",
-    "@stratusjs/angularjs": "^0.2.49",
+    "@stratusjs/angular": "^0.2.69",
+    "@stratusjs/angularjs": "^0.2.50",
     "@stratusjs/angularjs-extras": "^0.8.0",
     "@stratusjs/map": "^0.4.0",
     "@stratusjs/runtime": "^0.11.9",

--- a/packages/idx/src/disclaimer/disclaimer.component.less
+++ b/packages/idx/src/disclaimer/disclaimer.component.less
@@ -13,6 +13,7 @@ stratus-idx-disclaimer {
     font-size: 12px;
     .disclaimer-container {
       /* Individual MLS' will each have a separate .disclaimer-container */
+      margin-bottom: 15px;
       .mls-service-logo {
         /* In future, Logos will be maintained outside of the disclaimer text (not here) TODO remove this section */
         display: block;
@@ -23,8 +24,9 @@ stratus-idx-disclaimer {
     .mls-logos-container {
       .mls-service-logo {
         display: block;
+        float: left;
         max-width: 80px;
-        margin-top: 20px;
+        margin-right: 10px;
       }
     }
   }

--- a/packages/idx/src/disclaimer/disclaimer.component.less
+++ b/packages/idx/src/disclaimer/disclaimer.component.less
@@ -10,21 +10,22 @@ stratus-idx-disclaimer {
     border-top: 1px solid rgba(0, 0, 0, 0.25);
   }
   .disclaimer-outer-container {
-    /* margin-top: 20px;
-    padding-top: 20px; */
     font-size: 12px;
     .disclaimer-container {
       /* Individual MLS' will each have a separate .disclaimer-container */
       .mls-service-logo {
-        /* In future, Logos will be maintained outside of the disclaimer text (not here) */
+        /* In future, Logos will be maintained outside of the disclaimer text (not here) TODO remove this section */
         display: block;
         max-width: 80px;
         margin-top: 20px;
       }
     }
     .mls-logos-container {
-      /* In future, Logos will be consolidated all here instead of .disclaimer-container */
-      display: none;
+      .mls-service-logo {
+        display: block;
+        max-width: 80px;
+        margin-top: 20px;
+      }
     }
   }
 }

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -295,10 +295,12 @@ export interface MLSService {
         OpenHouse: Date | null
     }
     analyticsEnabled: string[]
-    logo?: string
-    logoSmall?: string
-    logoMedium?: string
-    logoLarge?: string
+    logo: {
+        default?: string
+        small?: string
+        medium?: string
+        large?: string
+    }
 }
 
 export interface WidgetContact {
@@ -1122,6 +1124,14 @@ const angularJsService = (
                     service.analyticsEnabled === null
                 ) {
                     service.analyticsEnabled = []
+                }
+                if (
+                    !Object.prototype.hasOwnProperty.call(service, 'logo') ||
+                    service.logo === null
+                ) {
+                    service.logo = {
+                        default: null
+                    }
                 }
                 session.services[service.id] = service
                 session.lastCreated = new Date(service.created)// The object is a String being converted to Date
@@ -2128,7 +2138,8 @@ const angularJsService = (
                         name: session.services[serviceId].name,
                         disclaimer: session.services[serviceId].disclaimer,
                         fetchTime: session.services[serviceId].fetchTime,
-                        analyticsEnabled: session.services[serviceId].analyticsEnabled
+                        analyticsEnabled: session.services[serviceId].analyticsEnabled,
+                        logo: session.services[serviceId].logo
                     })
                 }
             })
@@ -2140,7 +2151,8 @@ const angularJsService = (
                         name: service.name,
                         disclaimer: service.disclaimer,
                         fetchTime: service.fetchTime,
-                        analyticsEnabled: service.analyticsEnabled
+                        analyticsEnabled: service.analyticsEnabled,
+                        logo: service.logo
                     })
                 }
             })

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -298,6 +298,7 @@ export interface MLSService {
     logo?: string
     logoSmall?: string
     logoMedium?: string
+    logoLarge?: string
 }
 
 export interface WidgetContact {
@@ -1301,11 +1302,14 @@ const angularJsService = (
         // TODO save collection.header.get('x-fetch-time') to MLSVariables
         const fetchTime = apiFetch.header.get('x-fetch-time')
         if (fetchTime) {
-            const oldTime = session.services[serviceId].fetchTime[modelName].getTime()
+            const oldTime = session.services[serviceId].fetchTime[modelName]
             session.services[serviceId].fetchTime[modelName] = new Date(fetchTime)
             // TODO check differences or old vs new and push emit
 
-            if (oldTime !== session.services[serviceId].fetchTime[modelName].getTime()) {
+            if (
+                !(_.isDate(oldTime) && _.isDate(session.services[serviceId].fetchTime[modelName])) ||
+                oldTime.getTime() !== session.services[serviceId].fetchTime[modelName].getTime()
+            ) {
                 // Only emit if there is a new time set
                 emitManual('fetchTimeUpdate', 'Idx', null, serviceId, modelName, session.services[serviceId].fetchTime[modelName])
             }

--- a/packages/idx/src/map/map.component.ts
+++ b/packages/idx/src/map/map.component.ts
@@ -264,7 +264,7 @@ Stratus.Components.IdxMap = {
             return $scope.googleMapsKey || Idx.getGoogleMapsKey()
         }
 
-        $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
+        $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         $scope.remove = (): void => {
         }

--- a/packages/idx/src/member/details.component.ts
+++ b/packages/idx/src/member/details.component.ts
@@ -188,7 +188,7 @@ Stratus.Components.IdxMemberDetails = {
          */
         $scope.getMLSName = (): string => Idx.getMLSVariables($scope.model.data._ServiceId)[0].name // FIXME more checks need to happen here
 
-        $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
+        $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         $scope.remove = (): void => {
         }

--- a/packages/idx/src/member/list.component.ts
+++ b/packages/idx/src/member/list.component.ts
@@ -432,7 +432,7 @@ Stratus.Components.IdxMemberList = {
                 // await $q.all(promises)
             }
 
-        $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
+        $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         $scope.remove = (): void => {
         }

--- a/packages/idx/src/member/search.component.ts
+++ b/packages/idx/src/member/search.component.ts
@@ -297,7 +297,7 @@ Stratus.Components.IdxMemberSearch = {  // FIXME should be just MemberSearch or 
             }
         }
 
-        $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
+        $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         $scope.remove = (): void => {
         }

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -1438,7 +1438,7 @@ Stratus.Components.IdxPropertyDetails = {
          */
         $scope.getMLSName = (): string => $ctrl.mlsVariables.name
 
-        $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
+        $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         $scope.remove = (): void => {
             // TODO need to kill any attached slideshows

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -14,7 +14,7 @@
         </div>
     </div>
 
-    <div class="list-container clearfix" data-ng-class="displayPerRow + '-per-row'">
+    <div class="list-container clearfix" data-ng-class="displayPerRowText + '-per-row'">
         <md-progress-linear ng-if="collection.pending" md-mode="indeterminate"></md-progress-linear>
         <div data-ng-if="collection.completed && !collection.pending && collection.models.length === 0" class="no-results">
             We didn’t find any properties that fit your criteria.<span data-ng-if="true"> You might want to try a broader search.</span>

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -80,19 +80,6 @@ stratus-idx-property-list {
     max-width: 50%;
   }
 
-  /* Property List */
-  .list-container {
-    margin: 10px -8px 0;
-
-    /* Details button */
-
-    .property-button-container {
-      .button {
-        margin: 0 auto;
-      }
-    }
-  }
-
   /* Property */
   .property-container {
     position: relative;
@@ -256,6 +243,110 @@ stratus-idx-property-list {
     }
   }
 
+  /* Property List */
+  .list-container {
+    margin: 10px -8px 0;
+
+    /* Details button */
+    .property-button-container {
+      .button {
+        margin: 0 auto;
+      }
+    }
+
+    /* Structure */
+    &.three-per-row {
+      .property-container {
+        width: 33.333%;
+
+        @media (max-width: 999px) {
+          width: 50%;
+          padding-left: 0;
+          padding-right: 0;
+        }
+
+        @media (max-width: 600px) {
+          width: 100%;
+        }
+        &:nth-child(2n),
+        &:nth-child(2n) + .property-container {
+          clear: unset;
+        }
+        &:nth-child(3n) {
+          clear: right;
+        }
+        &:nth-child(3n) + .property-container {
+          clear: left;
+        }
+
+        @media (max-width: 999px) {
+          &:nth-child(3n),
+          &:nth-child(3n) + .property-container {
+            clear: unset;
+          }
+          &:nth-child(2n) {
+            clear: right;
+          }
+          &:nth-child(2n) + .property-container {
+            clear: left;
+          }
+        }
+
+        @media (max-width: 600px) {
+          &:nth-child(2n),
+          &:nth-child(2n) + .property-container {
+            clear: unset;
+          }
+        }
+      }
+    }
+    &.four-per-row {
+      .property-container {
+        width: 25%;
+
+        @media (max-width: 959px) {
+          width: 50%;
+          padding-left: 0;
+          padding-right: 0;
+        }
+
+        @media (max-width: 600px) {
+          width: 100%;
+        }
+        &:nth-child(2n),
+        &:nth-child(2n) + .property-container {
+          clear: unset;
+        }
+        &:nth-child(4n) {
+          clear: right;
+        }
+        &:nth-child(4n) + .property-container {
+          clear: left;
+        }
+
+        @media (max-width: 959px) {
+          &:nth-child(4n),
+          &:nth-child(4n) + .property-container {
+            clear: unset;
+          }
+          &:nth-child(2n) {
+            clear: right;
+          }
+          &:nth-child(2n) + .property-container {
+            clear: left;
+          }
+        }
+
+        @media (max-width: 600px) {
+          &:nth-child(2n),
+          &:nth-child(2n) + .property-container {
+            clear: unset;
+          }
+        }
+      }
+    }
+  }
+
   /* List Pager */
   .pager-container {
     margin: 20px 0;
@@ -314,98 +405,6 @@ stratus-idx-property-list {
     padding-top: 20px;
     text-transform: none;
     letter-spacing: normal;
-  }
-
-  /* Structure */
-  &.three-per-row {
-    .property-container {
-      width: 33.333%;
-
-      @media (max-width: 999px) {
-        width: 50%;
-        padding-left: 0;
-        padding-right: 0;
-      }
-
-      @media (max-width: 600px) {
-        width: 100%;
-      }
-      &:nth-child(2n),
-      &:nth-child(2n) + .property-container {
-        clear: unset;
-      }
-      &:nth-child(3n) {
-        clear: right;
-      }
-      &:nth-child(3n) + .property-container {
-        clear: left;
-      }
-
-      @media (max-width: 999px) {
-        &:nth-child(3n),
-        &:nth-child(3n) + .property-container {
-          clear: unset;
-        }
-        &:nth-child(2n) {
-          clear: right;
-        }
-        &:nth-child(2n) + .property-container {
-          clear: left;
-        }
-      }
-
-      @media (max-width: 600px) {
-        &:nth-child(2n),
-        &:nth-child(2n) + .property-container {
-          clear: unset;
-        }
-      }
-    }
-  }
-  &.four-per-row {
-    .property-container {
-      width: 25%;
-
-      @media (max-width: 959px) {
-        width: 50%;
-        padding-left: 0;
-        padding-right: 0;
-      }
-
-      @media (max-width: 600px) {
-        width: 100%;
-      }
-      &:nth-child(2n),
-      &:nth-child(2n) + .property-container {
-        clear: unset;
-      }
-      &:nth-child(4n) {
-        clear: right;
-      }
-      &:nth-child(4n) + .property-container {
-        clear: left;
-      }
-
-      @media (max-width: 959px) {
-        &:nth-child(4n),
-        &:nth-child(4n) + .property-container {
-          clear: unset;
-        }
-        &:nth-child(2n) {
-          clear: right;
-        }
-        &:nth-child(2n) + .property-container {
-          clear: left;
-        }
-      }
-
-      @media (max-width: 600px) {
-        &:nth-child(2n),
-        &:nth-child(2n) + .property-container {
-          clear: unset;
-        }
-      }
-    }
   }
 }
 

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -306,99 +306,101 @@ stratus-idx-property-list {
     }
   }
 
-}
-/* Disclaimer */
-stratus-idx-disclaimer .disclaimer-outer-container {
-  margin-top: 20px;
-  padding-top: 20px;
-  text-transform: none;
-  letter-spacing: normal;
-}
+  /* Disclaimer - Only affects this List's disclaimer */
+  stratus-idx-disclaimer .disclaimer-outer-container {
+    margin-top: 20px;
+    padding-top: 20px;
+    text-transform: none;
+    letter-spacing: normal;
+  }
 
-/* Structure */
-.three-per-row  {
-  .property-container {
-    width: 33.333%;
-    @media (max-width:999px) {
-      width: 50%;
-      padding-left: 0;
-      padding-right: 0;
-    }
-    @media (max-width:600px) {
-      width: 100%;
-    }
-    &:nth-child(2n),
-    &:nth-child(2n) + .property-container {
-      clear: unset;
-    }
-    &:nth-child(3n) {
-      clear: right;
-    }
-    &:nth-child(3n) + .property-container {
-      clear: left;
-    }
-    @media (max-width:999px) {
-      &:nth-child(3n),
+  /* Structure */
+  &.three-per-row {
+    .property-container {
+      width: 33.333%;
+      @media (max-width:999px) {
+        width: 50%;
+        padding-left: 0;
+        padding-right: 0;
+      }
+      @media (max-width:600px) {
+        width: 100%;
+      }
+      &:nth-child(2n),
+      &:nth-child(2n) + .property-container {
+        clear: unset;
+      }
+      &:nth-child(3n) {
+        clear: right;
+      }
       &:nth-child(3n) + .property-container {
-        clear: unset;
-      }
-      &:nth-child(2n) {
-        clear: right;
-      }
-      &:nth-child(2n) + .property-container {
         clear: left;
       }
+      @media (max-width:999px) {
+        &:nth-child(3n),
+        &:nth-child(3n) + .property-container {
+          clear: unset;
+        }
+        &:nth-child(2n) {
+          clear: right;
+        }
+        &:nth-child(2n) + .property-container {
+          clear: left;
+        }
+      }
+      @media (max-width:600px) {
+        &:nth-child(2n),
+        &:nth-child(2n) + .property-container {
+          clear: unset;
+        }
+      }
     }
-    @media (max-width:600px) {
+  }
+  &.four-per-row {
+    .property-container {
+      width: 25%;
+      @media (max-width:959px) {
+        width: 50%;
+        padding-left: 0;
+        padding-right: 0;
+      }
+      @media (max-width:600px) {
+        width: 100%;
+      }
       &:nth-child(2n),
       &:nth-child(2n) + .property-container {
         clear: unset;
       }
-    }
-  }
-}
-.four-per-row {
-  .property-container {
-    width: 25%;
-    @media (max-width:959px) {
-      width: 50%;
-      padding-left: 0;
-      padding-right: 0;
-    }
-    @media (max-width:600px) {
-      width: 100%;
-    }
-    &:nth-child(2n),
-    &:nth-child(2n) + .property-container {
-      clear: unset;
-    }
-    &:nth-child(4n) {
-      clear: right;
-    }
-    &:nth-child(4n) + .property-container {
-      clear: left;
-    }
-    @media (max-width:959px) {
-      &:nth-child(4n),
+      &:nth-child(4n) {
+        clear: right;
+      }
       &:nth-child(4n) + .property-container {
-        clear: unset;
-      }
-      &:nth-child(2n) {
-        clear: right;
-      }
-      &:nth-child(2n) + .property-container {
         clear: left;
       }
-    }
-    @media (max-width:600px) {
-      &:nth-child(2n),
-      &:nth-child(2n) + .property-container {
-        clear: unset;
+      @media (max-width:959px) {
+        &:nth-child(4n),
+        &:nth-child(4n) + .property-container {
+          clear: unset;
+        }
+        &:nth-child(2n) {
+          clear: right;
+        }
+        &:nth-child(2n) + .property-container {
+          clear: left;
+        }
       }
-    }
+      @media (max-width:600px) {
+        &:nth-child(2n),
+        &:nth-child(2n) + .property-container {
+          clear: unset;
+        }
+      }
 
+    }
   }
 }
+
+
 
 
 /* Dialog box */

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -8,7 +8,6 @@ FIXME we CANNOT rely of media queries, it needs to know the sizing of the elemen
 @phone: ~"(max-width: 600px)";
 @desktop-only: ~"(min-width: 600px)";
 stratus-idx-property-list {
-
   .no-results {
     padding: 200px 40px 0;
     font-size: 24px;
@@ -16,6 +15,7 @@ stratus-idx-property-list {
     background: url('images/no-results.png') no-repeat center 80px;
     background-size: 80px;
   }
+
   /* Generic dotted underline */
   .dotted-spaced-underline {
     background-image: linear-gradient(to right, #333 25%, rgba(255, 255, 255, 0) 0%);
@@ -74,7 +74,7 @@ stratus-idx-property-list {
 
   /* Filters */
   .search-full {
-    border: 1px solid #DDD;
+    border: 1px solid #ddd;
   }
   .search-mini {
     max-width: 50%;
@@ -92,6 +92,7 @@ stratus-idx-property-list {
       }
     }
   }
+
   /* Property */
   .property-container {
     position: relative;
@@ -100,6 +101,7 @@ stratus-idx-property-list {
     text-align: center;
     float: left;
     width: 100%;
+
     @media @desktop-only {
       width: 50%;
       &:nth-child(2n) {
@@ -318,12 +320,14 @@ stratus-idx-property-list {
   &.three-per-row {
     .property-container {
       width: 33.333%;
-      @media (max-width:999px) {
+
+      @media (max-width: 999px) {
         width: 50%;
         padding-left: 0;
         padding-right: 0;
       }
-      @media (max-width:600px) {
+
+      @media (max-width: 600px) {
         width: 100%;
       }
       &:nth-child(2n),
@@ -336,7 +340,8 @@ stratus-idx-property-list {
       &:nth-child(3n) + .property-container {
         clear: left;
       }
-      @media (max-width:999px) {
+
+      @media (max-width: 999px) {
         &:nth-child(3n),
         &:nth-child(3n) + .property-container {
           clear: unset;
@@ -348,7 +353,8 @@ stratus-idx-property-list {
           clear: left;
         }
       }
-      @media (max-width:600px) {
+
+      @media (max-width: 600px) {
         &:nth-child(2n),
         &:nth-child(2n) + .property-container {
           clear: unset;
@@ -359,12 +365,14 @@ stratus-idx-property-list {
   &.four-per-row {
     .property-container {
       width: 25%;
-      @media (max-width:959px) {
+
+      @media (max-width: 959px) {
         width: 50%;
         padding-left: 0;
         padding-right: 0;
       }
-      @media (max-width:600px) {
+
+      @media (max-width: 600px) {
         width: 100%;
       }
       &:nth-child(2n),
@@ -377,7 +385,8 @@ stratus-idx-property-list {
       &:nth-child(4n) + .property-container {
         clear: left;
       }
-      @media (max-width:959px) {
+
+      @media (max-width: 959px) {
         &:nth-child(4n),
         &:nth-child(4n) + .property-container {
           clear: unset;
@@ -389,19 +398,16 @@ stratus-idx-property-list {
           clear: left;
         }
       }
-      @media (max-width:600px) {
+
+      @media (max-width: 600px) {
         &:nth-child(2n),
         &:nth-child(2n) + .property-container {
           clear: unset;
         }
       }
-
     }
   }
 }
-
-
-
 
 /* Dialog box */
 .stratus-idx-property-list-dialog {

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -748,9 +748,10 @@ Stratus.Components.IdxPropertyList = {
             }
         }
 
-        $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
+        $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         $scope.remove = (): void => {
+            // TODO need to destroy any attached widgets
         }
     },
     templateUrl: ($attrs: angular.IAttributes): string => `${localDir}${$attrs.template || componentName}.component${min}.html`

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -77,6 +77,8 @@ export type IdxPropertyListScope = IdxListScope<Property> & {
     contactPhone: string
     instancePath: string
     mapMarkers: MarkerSettings[]
+    displayPerRow: number,
+    displayPerRowText: string,
 
     getOrderName(): string
     getOrderOptions(): { [key: string]: string[] }
@@ -118,6 +120,7 @@ Stratus.Components.IdxPropertyList = {
         template: '@',
         urlLoad: '@',
         displayPerRow: '@',
+        displayPerRowText: '@',
         displayPager: '@',
         hideDisclaimer: '@',
     },
@@ -146,6 +149,8 @@ Stratus.Components.IdxPropertyList = {
             Idx.setTokenURL($attrs.tokenUrl)
         }
         Stratus.Internals.CssLoader(`${localDir}${$attrs.template || componentName}.component${min}.css`)
+        $scope.displayPerRow = 2
+        $scope.displayPerRowText = 'two'
 
         /**
          * All actions that happen first when the component loads
@@ -182,7 +187,18 @@ Stratus.Components.IdxPropertyList = {
                 25
             $scope.query.where = $attrs.queryWhere && isJSON($attrs.queryWhere) ? JSON.parse($attrs.queryWhere) : $scope.query.where || []
             $scope.query.images = $scope.query.images || {limit: 1}
-            $scope.displayPerRow = $attrs.displayPerRow || 2
+
+            // Handle row displays
+            if ($attrs.displayPerRowText && _.isString($attrs.displayPerRowText)) {
+                $scope.displayPerRowText = $attrs.displayPerRowText
+                $scope.displayPerRow = $scope.displayPerRowText === 'one' ? 1 : $scope.displayPerRowText === 'two' ? 2 :
+                    $scope.displayPerRowText === 'three' ? 3 : $scope.displayPerRowText === 'four' ? 4 : 2
+            } else if ($attrs.displayPerRow && (_.isString($attrs.displayPerRow) || _.isNumber($attrs.displayPerRow))) {
+                $scope.displayPerRow = _.isString($attrs.displayPerRow) ? parseInt($attrs.displayPerRow, 10) : $attrs.displayPerRow
+                $scope.displayPerRowText = $scope.displayPerRow === 1 ? 'one' : $scope.displayPerRow === 2 ? 'two' :
+                    $scope.displayPerRow === 3 ? 'three' : $scope.displayPerRow === 4 ? 'four' : 'two'
+            }
+
             $scope.displayPager =
                 $attrs.displayPager ? (isJSON($attrs.displayPager) ? JSON.parse($attrs.displayPager) :
                     $attrs.displayPager) : true

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -623,7 +623,7 @@ Stratus.Components.IdxPropertySearch = {
             }
         }
 
-        $scope.on = (emitterName: string, callback: IdxEmitter): void => Idx.on($scope.elementId, emitterName, callback)
+        $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         /**
          * Destroy this widget


### PR DESCRIPTION
**@stratusjs/idx 0.12.1** published
* Changed: Idx service's on Emitters now manage each event with a unqiueId and running the return method after `on()` will allow deleting events (removes watchers from repeating forever)
* Add: Service tokens now supply list of each service's logos and fetchTimes at session start
* Changed: Each Idx service disclaimer handled separately for better control
* Changed: All Idx Disclaimer logos are now to bottom for future use to allow better side by side layout
* Fix: Correctly handle the Idx's required fetchTime
* Fix: Corrected styling escaping stratus-idx-property-list, all styling has been recontained and nested within

**Known Issues**
* Stratus widgets don't remove themselves from memory when no longer on DOM. E.g. an element may be removed and deleted on DOM if it's no longer needed, however the background Instance and it's scope+watchers likely will still be running

![Screen Shot 2021-04-02 at 6 23 04 PM](https://user-images.githubusercontent.com/626727/113464391-2acdff00-93e1-11eb-8ef7-7748c3c3ef4e.png)
