### PR TITLE
Add option to pass in filter options, advanced search button

### DIFF
--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -97,7 +97,7 @@
         </div>
         <div class="search-more-filters advanced-search-link" data-ng-if="advancedSearchUrl">
             <a class="open-filters-link"
-               data-ng-href="advancedSearchUrl">
+               data-ng-href="{{ advancedSearchUrl }}">
                 <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/filters.svg' }}"></md-icon>
                 <span class="btn-text"><span ng-bind="advancedSearchLinkName"></span>
             </a>

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -95,6 +95,13 @@
                 <i class="arrow small right"></i>
             </a>
         </div>
+        <div class="search-more-filters advanced-search-link" data-ng-if="advancedSearchUrl">
+            <a class="open-filters-link"
+               data-ng-href="advancedSearchUrl">
+                <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/filters.svg' }}"></md-icon>
+                <span class="btn-text"><span ng-bind="advancedSearchLinkName"></span>
+            </a>
+        </div>
     </div>
     <stratus-idx-disclaimer data-init-now="collection.completed" data-hide-on-duplicate="{{hideDisclaimer}}"></stratus-idx-disclaimer>
 </div>

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -94,14 +94,15 @@
             <a class="pager-button {{query.page < collection.meta.data.totalPages && collection.completed ? '' : 'disabled'}}" data-ng-click="pageNext($event)" aria-label="Next Page">
                 <i class="arrow small right"></i>
             </a>
+            <div class="search-more-filters advanced-search-link" data-ng-if="advancedSearchUrl">
+                <a class="open-filters-link"
+                   data-ng-href="{{ advancedSearchUrl }}">
+                    <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/filters.svg' }}"></md-icon>
+                    <span class="btn-text"><span ng-bind="advancedSearchLinkName"></span>
+                </a>
+            </div>
         </div>
-        <div class="search-more-filters advanced-search-link" data-ng-if="advancedSearchUrl">
-            <a class="open-filters-link"
-               data-ng-href="{{ advancedSearchUrl }}">
-                <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/filters.svg' }}"></md-icon>
-                <span class="btn-text"><span ng-bind="advancedSearchLinkName"></span>
-            </a>
-        </div>
+
     </div>
     <stratus-idx-disclaimer data-init-now="collection.completed" data-hide-on-duplicate="{{hideDisclaimer}}"></stratus-idx-disclaimer>
 </div>

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -68,6 +68,8 @@ export type IdxPropertyListScope = IdxListScope<Property> & {
     detailsLinkUrl: string
     detailsLinkTarget: 'popup' | '_self' | '_blank'
     detailsHideVariables?: string[]
+    advancedSearchUrl: string,
+    advancedSearchLinkName: string,
     preferredStatus: 'Closed' | 'Leased' | 'Rented'
     detailsTemplate?: string
     query: CompileFilterOptions
@@ -163,6 +165,8 @@ Stratus.Components.IdxPropertyList = {
          * TODO: Will need to allow setting a custom path of views outside the library directory.
          */
         detailsTemplate: '@',
+        advancedSearchUrl: '@',
+        advancedSearchLinkName: '@',
         /**
          * Type: string
          * Default: 'Closed'
@@ -309,6 +313,9 @@ Stratus.Components.IdxPropertyList = {
             $scope.detailsHideVariables = $attrs.detailsHideVariables && isJSON($attrs.detailsHideVariables) ?
                 JSON.parse($attrs.detailsHideVariables) : []
             $scope.detailsTemplate = $attrs.detailsTemplate || null
+            $scope.advancedSearchUrl = $attrs.advancedSearchUrl || true
+            $scope.advancedSearchLinkName = $attrs.advancedSearchLinkName || 'Advanced Search'
+
             $scope.preferredStatus = $attrs.preferredStatus || 'Closed' // Closed is most compatible
 
             $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) : {}

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -165,7 +165,17 @@ Stratus.Components.IdxPropertyList = {
          * TODO: Will need to allow setting a custom path of views outside the library directory.
          */
         detailsTemplate: '@',
+        /**
+         * Type: string
+         * Default: ''
+         * A link to another dedicated advanced search page (used when this is a module)
+         */
         advancedSearchUrl: '@',
+        /**
+         * Type: string
+         * Default: 'Advanced Search'
+         * An alternative name for the advanced search button.
+         */
         advancedSearchLinkName: '@',
         /**
          * Type: string
@@ -290,8 +300,12 @@ Stratus.Components.IdxPropertyList = {
             Idx.setTokenURL($attrs.tokenUrl)
         }
         Stratus.Internals.CssLoader(`${localDir}${$attrs.template || componentName}.component${min}.css`)
+
+        $scope.preferredStatus = 'Closed'
         $scope.displayPerRow = 2
         $scope.displayPerRowText = 'two'
+        $scope.advancedSearchUrl = ''
+        $scope.advancedSearchLinkName = 'Advanced Search'
 
         /**
          * All actions that happen first when the component loads
@@ -313,10 +327,9 @@ Stratus.Components.IdxPropertyList = {
             $scope.detailsHideVariables = $attrs.detailsHideVariables && isJSON($attrs.detailsHideVariables) ?
                 JSON.parse($attrs.detailsHideVariables) : []
             $scope.detailsTemplate = $attrs.detailsTemplate || null
-            $scope.advancedSearchUrl = $attrs.advancedSearchUrl || true
-            $scope.advancedSearchLinkName = $attrs.advancedSearchLinkName || 'Advanced Search'
-
-            $scope.preferredStatus = $attrs.preferredStatus || 'Closed' // Closed is most compatible
+            $scope.advancedSearchUrl = $attrs.advancedSearchUrl || $scope.advancedSearchUrl
+            $scope.advancedSearchLinkName = $attrs.advancedSearchLinkName || $scope.advancedSearchLinkName
+            $scope.preferredStatus = $attrs.preferredStatus || $scope.preferredStatus // Closed is most compatible
 
             $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) : {}
             // $scope.query = $attrs.query && isJSON($attrs.query) ? JSON.parse($attrs.query) : {}

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -163,7 +163,7 @@
 
         <div class="search-more-filters" data-ng-if="searchType != 'advanced' && advancedSearchUrl">
             <a class="open-filters-link"
-               data-ng-href="advancedSearchUrl">
+               data-ng-href="{{ advancedSearchUrl }}">
                 <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/filters.svg' }}"></md-icon>
                 <span class="btn-text"><span data-ng-bind="advancedSearchLinkName"></span>
             </a>

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -49,7 +49,6 @@ export type IdxPropertySearchScope = IdxSearchScope & {
     // Href to a url
     advancedSearchUrl: string
     advancedSearchLinkName: string
-    //
     advancedFiltersStatus: boolean
     openPrice: boolean
     listLinkTarget: string
@@ -132,7 +131,6 @@ Stratus.Components.IdxPropertySearch = {
             $scope.advancedSearchUrl = $attrs.advancedSearchUrl ||  $scope.advancedSearchUrl
             $scope.advancedSearchLinkName = $attrs.advancedSearchLinkName || $scope.advancedSearchLinkName
             $scope.options = $attrs.options && isJSON($attrs.options) ? JSON.parse($attrs.options) : {}
-
             $scope.filterMenu = null
             $scope.options.forRent = false
 


### PR DESCRIPTION
@apocist these components need the init-now option in order to make sure the attribute values are working when model is loaded.