### PR TITLE
Remove Duplicate `displayOrderOptions` Definition and Allow Multiple Data Feeds

### DIFF
--- a/packages/idx/src/property/admin/search.filter.component.html
+++ b/packages/idx/src/property/admin/search.filter.component.html
@@ -278,21 +278,23 @@
                     </md-input-container>
                 </div>
                 <div class="search-input" data-layout="row">
-                    <md-input-container flex>
+                    <md-input-container class="md-block minimal">
                         <label>Restrict Data Source</label>
-                        <!-- Multiple fields disabled for now as pagination is broken -->
+                        <!-- Multiple fields are enabled even though there is a known paging bug, because there are use cases where someone wants to show past solds that include their own exclusives and total pages can be increased -->
                         <md-select
                                 data-ng-model="options.query.service"
                                 placeholder="Restrict Data Source"
                                 aria-label="Restricted Data Source Displayed"
                                 md-select-only-option
                                 required
+                                multiple
                         >
                             <md-option data-ng-repeat="mls in getMLSVariables()" data-ng-value="mls.id">
                                 {{mls.name}}
                             </md-option>
                         </md-select>
                     </md-input-container>
+                    <div class="disclaimer" ng-if="options.query.service.length > 1">NOTE: Our component can display multiple data sources in the same feed, but we do not fully support this yet because there is a complex logic problem with mixing the data across multiple pages (sometimes the same property appears twice). However there are cases where you may want to show all your own "Exclusive" previously sold properties along side your MLS sold properties, so since this is a limited number of properties, it could be displayed all on one page (go to the advanced tab and increase items per page to the maximum to avoid paging).</div>
                 </div>
             </div>
 

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -229,6 +229,12 @@ Stratus.Components.IdxPropertyList = {
         /**
          * Type: boolean
          * Default: true
+         * By default, it will display the sort dropdown.
+         */
+        displayOrderOptions: '@',
+        /**
+         * Type: boolean
+         * Default: true
          * Allow query to be loaded initially from the URL. Disable this for times you don't want a url to either control
          * the displayed listings (or be able to share a defined search URL).
          */
@@ -262,12 +268,6 @@ Stratus.Components.IdxPropertyList = {
          * @see Docs coming soon
          */
         hideDisclaimer: '@',
-        /**
-         * Type: boolean
-         * Default: true
-         * By default, it will display the sort dropdown.
-         */
-        displayOrderOptions: '@',
         /**
          * Type: number
          * Default: 2
@@ -405,6 +405,7 @@ Stratus.Components.IdxPropertyList = {
                 {name: 'Recently Sold', value: ['-CloseDate']},
                 {name: 'Status', value: ['Status', '-BestPrice']}
             ]
+            $scope.displayOrderOptions = (!$attrs.displayOrderOptions || $attrs.displayOrderOptions === 'false') ? false : true
 
             $scope.googleApiKey = $attrs.googleApiKey || null
             $scope.contactName = $attrs.contactName || null


### PR DESCRIPTION
I noticed there were two and that's not right