### PR TITLE
Dynamic Install Paths & Media Selector Improvements

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angular/src/base/base.component.ts
+++ b/packages/angular/src/base/base.component.ts
@@ -37,13 +37,12 @@ import {RootComponent} from '@stratusjs/angular/core/root.component'
 import {keys} from 'ts-transformer-keys'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'base'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 /**
  * @title Basic Load

--- a/packages/angular/src/confirm-dialog/confirm-dialog.component.ts
+++ b/packages/angular/src/confirm-dialog/confirm-dialog.component.ts
@@ -7,15 +7,15 @@ import {
     MatDialogRef
 } from '@angular/material/dialog'
 import {cookie} from '@stratusjs/core/environment'
+import {Stratus} from '@stratusjs/runtime/stratus'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'confirm-dialog'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 export interface ConfirmDialogData {
     title: string

--- a/packages/angular/src/editor/code-view-dialog.component.ts
+++ b/packages/angular/src/editor/code-view-dialog.component.ts
@@ -70,7 +70,8 @@ export class CodeViewDialogComponent extends ResponsiveComponent implements OnIn
     uid: string
 
     // Dependencies
-    _: any
+    _ = _
+    Stratus = Stratus
 
     // Forms
     form: FormGroup = this.fb.group({
@@ -109,9 +110,6 @@ export class CodeViewDialogComponent extends ResponsiveComponent implements OnIn
         // Initialization
         this.uid = _.uniqueId(`sa_${_.snakeCase(moduleName)}_component_`)
         Stratus.Instances[this.uid] = this
-
-        // Dependencies
-        this._ = _
 
         // TODO: Assess & Possibly Remove when the System.js ecosystem is complete
         // Load Component CSS until System.js can import CSS properly.

--- a/packages/angular/src/editor/code-view-dialog.component.ts
+++ b/packages/angular/src/editor/code-view-dialog.component.ts
@@ -47,14 +47,13 @@ import {
 } from '@stratusjs/angular/core/responsive.component'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'code-view-dialog'
 const parentModuleName = 'editor'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 /**
  * @title Dialog for Nested Tree

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -222,6 +222,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
     _ = _
     has = has
     log = console.log
+    Stratus = Stratus
 
     // Stratus Data Connectivity
     registry = new Registry()

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -162,7 +162,6 @@ import {FroalaEditorDirective} from 'angular-froala-wysiwyg'
 // import '@stratusjs/angular/froala/plugins/menuButton'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemPackage = '@stratusjs/angular'
 const froalaPackage = 'froala-editor'
 const codeMirrorPackage = 'codemirror'
@@ -170,9 +169,9 @@ const moduleName = 'editor'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemPackage}/*`].replace(/[^\/]*$/, '')}`
-const codeMirrorDir = `${installDir}/${boot.configuration.paths[`${codeMirrorPackage}/*`].replace(/[^\/]*$/, '')}`
-const froalaDir = `${installDir}/${boot.configuration.paths[froalaPackage].replace(/js\/[^\/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemPackage}/*`].replace(/[^\/]*$/, '')}`
+const codeMirrorDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${codeMirrorPackage}/*`].replace(/[^\/]*$/, '')}`
+const froalaDir = `${Stratus.BaseUrl}${boot.configuration.paths[froalaPackage].replace(/js\/[^\/]*$/, '')}`
 
 // Utility Functions
 const has = (object: object, path: string) => _.has(object, path) && !_.isEmpty(_.get(object, path))
@@ -907,7 +906,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
         // TODO: Allow more CSS files to get pulled and mark this.styled appropriately
         /* *
         if (_.has(boot.configuration.paths, 'quill')) {
-            const quillDir = `/assets/1/0/bundles/${boot.configuration.paths.quill.replace(/[^/]*$/, '')}`
+            const quillDir = `${Stratus.BaseUrl}${boot.configuration.paths.quill.replace(/[^/]*$/, '')}`
             Stratus.Internals.CssLoader(`${quillDir}quill.core.css`)
             // Stratus.Internals.CssLoader(`${quillDir}quill.bubble.css`)
             Stratus.Internals.CssLoader(`${quillDir}quill.snow.css`)

--- a/packages/angular/src/editor/media-dialog.component.html
+++ b/packages/angular/src/editor/media-dialog.component.html
@@ -74,7 +74,7 @@
                                       && mediaEntity.mime === 'video'">
                     <ng-container *ngIf="mediaEntity.service === 'vimeo'">
                         <ng-container *ngIf="mediaEntity.meta && mediaEntity.meta.thumbnail_large; else basicVimeoButton">
-                            <!-- [src]="mediaEntity.meta.thumbnail_large || '/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-video.png'" -->
+                            <!-- [src]="mediaEntity.meta.thumbnail_large || Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeIcons/media-icon-video.png'" -->
                             <img mat-card-image
                                  class="vimeo"
                                  [src]="mediaEntity.meta.thumbnail_large"
@@ -87,7 +87,7 @@
                             <!-- TODO: make this a local file -->
                             <img mat-card-image
                                  class="vimeo basic-image"
-                                 src="/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-video.png"
+                                 [src]="Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeIcons/media-icon-video.png'"
                                  style="background: #4e4e4e;"
                                  [alt]="mediaEntity.name"
                                  [ngClass]="{'selected' : isSelected(mediaEntity)}">
@@ -107,7 +107,7 @@
                             <!-- TODO: make this a local file -->
                             <img mat-card-image
                                  class="youtube basic-image"
-                                 src="/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-video.png"
+                                 [src]="Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeIcons/media-icon-video.png'"
                                  style="background: #4e4e4e;"
                                  [alt]="mediaEntity.name"
                                  [ngClass]="{'selected' : isSelected(mediaEntity)}">
@@ -119,7 +119,7 @@
                         <!-- TODO: make this a local file -->
                         <img mat-card-image
                              class="facebook-video basic-image"
-                             src="/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-video.png"
+                             [src]="Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeIcons/media-icon-video.png'"
                              style="background: #4e4e4e;"
                              [alt]="mediaEntity.name"
                              [ngClass]="{'selected' : isSelected(mediaEntity)}">
@@ -129,7 +129,7 @@
                         <!-- TODO: make this a local file -->
                         <img mat-card-image
                              class="generic-video basic-image"
-                             src="/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-video.png"
+                             [src]="Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeIcons/media-icon-video.png'"
                              style="background: #4e4e4e;"
                              [alt]="mediaEntity.name"
                              [ngClass]="{'selected' : isSelected(mediaEntity)}">
@@ -140,7 +140,7 @@
                     <!-- TODO: make this a local file -->
                     <img mat-card-image
                          class="generic-audio"
-                         src="/assets/1/0/bundles/sitetheorymedia/images/mediaTypeGraphics/media-graphic-audio.png"
+                         [src]="Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeGraphics/media-graphic-audio.png'"
                          style="background: #4e4e4e;"
                          [alt]="mediaEntity.name"
                          [ngClass]="{'selected' : isSelected(mediaEntity)}">
@@ -150,7 +150,7 @@
                     <!-- TODO: make this a local file -->
                     <img mat-card-image
                          class="generic-pdf basic-image"
-                         src="/assets/1/0/bundles/sitetheorymedia/images/mediaTypeGraphics/media-graphic-pdf.png"
+                         [src]="Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeGraphics/media-graphic-pdf.png'"
                          [alt]="mediaEntity.name"
                          [ngClass]="{'selected' : isSelected(mediaEntity)}">
                 </ng-container>
@@ -159,7 +159,7 @@
                     <!-- TODO: make this a local file -->
                     <img mat-card-image
                          class="generic-word basic-image"
-                         src="/assets/1/0/bundles/sitetheorymedia/images/mediaTypeGraphics/media-graphic-doc.png"
+                         [src]="Stratus.BaseUrl + 'sitetheorymedia/images/mediaTypeGraphics/media-graphic-doc.png'"
                          [alt]="mediaEntity.name"
                          [ngClass]="{'selected' : isSelected(mediaEntity)}">
                 </ng-container>

--- a/packages/angular/src/editor/media-dialog.component.ts
+++ b/packages/angular/src/editor/media-dialog.component.ts
@@ -83,7 +83,8 @@ export class MediaDialogComponent extends ResponsiveComponent implements OnInit 
     uid: string
 
     // Dependencies
-    _: any
+    _ = _
+    Stratus = Stratus
 
     // TODO: Move this to its own AutoComplete Component
     // AutoComplete Data
@@ -132,9 +133,6 @@ export class MediaDialogComponent extends ResponsiveComponent implements OnInit 
         // Initialization
         this.uid = _.uniqueId(`sa_${_.snakeCase(moduleName)}_component_`)
         Stratus.Instances[this.uid] = this
-
-        // Dependencies
-        this._ = _
 
         // TODO: Assess & Possibly Remove when the System.js ecosystem is complete
         // Load Component CSS until System.js can import CSS properly.

--- a/packages/angular/src/editor/media-dialog.component.ts
+++ b/packages/angular/src/editor/media-dialog.component.ts
@@ -60,14 +60,13 @@ import {
 } from '@stratusjs/angular/core/responsive.component'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'media-dialog'
 const parentModuleName = 'editor'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 /**
  * @title Dialog for Nested Tree

--- a/packages/angular/src/media-selector/media-selector-vanilla.component.html
+++ b/packages/angular/src/media-selector/media-selector-vanilla.component.html
@@ -39,7 +39,7 @@
                     <!--<div class="image" no-flex stratus-src-->
                     <!--[ngStyle]="{'background': 'url(' + findImage(selectedModel) + ') no-repeat center center', 'background-size': 'cover'}"-->
                     <!--&gt;-->
-                    <!--<img class="shapeholder" src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">-->
+                    <!--<img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">-->
                     <!--</div>-->
 
                     <!-- This only shows the bestImage if this isn't a Video, since images for Videos are not hosted by us, thus cannot lazy load a proper size -->
@@ -70,13 +70,13 @@
                          [ngClass]="_.get(selectedModel, 'contentType.class') + '-background-color'">
 
                         <mat-icon class="content-type-icon position-center"
-                                  [svgIcon]="getSvg('/assets/1/0/bundles/' + (_.get(selectedModel, 'contentType.iconResourcePath') || _.get(selectedModel, 'iconResourcePath'))) | async">
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + (_.get(selectedModel, 'contentType.iconResourcePath') || _.get(selectedModel, 'iconResourcePath'))) | async">
                             Icon
                         </mat-icon>
                     </div>
 
                     <!-- Shapeholder -->
-                    <img class="shapeholder" src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">
+                    <img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">
 
                     <!--(click)="remove(selectedModel)"-->
                     <!--(click)="mediaDetails(selectedModel)"-->
@@ -90,7 +90,7 @@
                 <!--        to break away from the div and float to the top of the selector container-->
                 <!--        &ndash;&gt;-->
                 <!--        <mat-icon class="content-type-icon"-->
-                <!--                  [svgIcon]="getSvg('/assets/1/0/bundles/' + _.get(selectedModel, 'contentType.iconResourcePath')) | async">-->
+                <!--                  [svgIcon]="getSvg(Stratus.BaseUrl + _.get(selectedModel, 'contentType.iconResourcePath')) | async">-->
                 <!--            ContentType Icon-->
                 <!--        </mat-icon>-->
                 <!--        <span class="comment content-type-name font-body"-->

--- a/packages/angular/src/media-selector/media-selector-vanilla.component.html
+++ b/packages/angular/src/media-selector/media-selector-vanilla.component.html
@@ -6,9 +6,9 @@
     <div class="media-selected-list-header border-default border-default-bottom">
         <h3 [textContent]="'Selected ' + (type || 'Items')"></h3>
     </div>
-    <div class="media-selected-message-box">
-        Nothing has been selected.
-    </div>
+    <!--<div class="media-selected-message-box">-->
+    <!--    Nothing has been selected.-->
+    <!--</div>-->
 </ng-template>
 
 

--- a/packages/angular/src/media-selector/media-selector.component.html
+++ b/packages/angular/src/media-selector/media-selector.component.html
@@ -8,9 +8,9 @@
            [textContent]="'Selected ' + (type || 'Items')"></p>
         <!-- TODO: for styles from legacy selector, add class `selected-area` -->
         <div class="media-content media-selected-container" cdkDropListGroup>
-            <div class="selected-message-box" *ngIf="empty">
-                Nothing has been selected.
-            </div>
+            <!--<div class="selected-message-box" *ngIf="empty">-->
+            <!--    Nothing has been selected.-->
+            <!--</div>-->
             <div cdkDropList
                  [cdkDropListEnterPredicate]="enterPredicate"
                  (cdkDropListDropped)="drop($event)">

--- a/packages/angular/src/media-selector/media-selector.component.html
+++ b/packages/angular/src/media-selector/media-selector.component.html
@@ -41,7 +41,7 @@
                              }"
                              [ngStyle]="{'background': 'url(' + (_.get(selectedModel, '_thumbSrc') || _.get(selectedModel, 'bestImage.thumb') || _.get(selectedModel, 'meta.thumbnail_small')) + ') no-repeat center center', 'background-size': 'cover'}">
 
-                            <img class="shapeholder" src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">
+                            <img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">
 
                             <div class="thumb-gradient">&nbsp;</div>
 
@@ -173,7 +173,7 @@
                                 Close Library
                             </div>
                             <img class="shapeholder"
-                                 src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">
+                                 [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">
                         </div>
                     </a>
                 </div>

--- a/packages/angular/src/media-selector/media-selector.component.ts
+++ b/packages/angular/src/media-selector/media-selector.component.ts
@@ -6,7 +6,7 @@ import {
     Input,
     ViewChild
 } from '@angular/core'
-import {FormControl} from '@angular/forms'
+// import {FormControl} from '@angular/forms'
 
 // CDK
 import {
@@ -102,7 +102,7 @@ export class MediaSelectorComponent extends RootComponent { // implements OnInit
     _ = _
     has = has
     log = console.log
-    selectCtrl = new FormControl()
+    Stratus = Stratus
 
     // Stratus Data Connectivity
     registry = new Registry()
@@ -142,6 +142,7 @@ export class MediaSelectorComponent extends RootComponent { // implements OnInit
     @ViewChild(CdkDropListGroup) listGroup: CdkDropListGroup<CdkDropList>
     @ViewChild(CdkDropList) placeholder: CdkDropList
 
+    // Grid Workaround
     public targetList: CdkDropList
     public targetIndex: number
     public sourceList: CdkDropList

--- a/packages/angular/src/media-selector/media-selector.component.ts
+++ b/packages/angular/src/media-selector/media-selector.component.ts
@@ -53,13 +53,12 @@ import {Collection} from '@stratusjs/angularjs/services/collection'
 import {ViewportRuler} from '@angular/cdk/scrolling'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'media-selector'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 // Utility Functions
 const has = (object: object, path: string) => _.has(object, path) && !_.isEmpty(_.get(object, path))
@@ -175,16 +174,16 @@ export class MediaSelectorComponent extends RootComponent { // implements OnInit
         // SVG Icons
         _.forEach({
             // action buttons
-            media_selector_add: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/add.svg',
-            media_selector_clear: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/clear.svg',
-            media_selector_delete: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/delete.svg',
-            media_selector_edit: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/edit.svg',
-            media_selector_info: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/info.svg',
+            media_selector_add: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/add.svg`,
+            media_selector_clear: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/clear.svg`,
+            media_selector_delete: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/delete.svg`,
+            media_selector_edit: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/edit.svg`,
+            media_selector_info: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/info.svg`,
             // type icons
-            media_selector_image: '/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-image.svg',
-            media_selector_video: '/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-video.svg',
-            media_selector_audio: '/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-audio.svg',
-            media_selector_document: '/assets/1/0/bundles/sitetheorymedia/images/mediaTypeIcons/media-icon-document.svg'
+            media_selector_image: `${Stratus.BaseUrl}sitetheorymedia/images/mediaTypeIcons/media-icon-image.svg`,
+            media_selector_video: `${Stratus.BaseUrl}sitetheorymedia/images/mediaTypeIcons/media-icon-video.svg`,
+            media_selector_audio: `${Stratus.BaseUrl}sitetheorymedia/images/mediaTypeIcons/media-icon-audio.svg`,
+            media_selector_document: `${Stratus.BaseUrl}sitetheorymedia/images/mediaTypeIcons/media-icon-document.svg`
         }, (value, key) => iconRegistry.addSvgIcon(key, sanitizer.bypassSecurityTrustResourceUrl(value)).getNamedSvgIcon(key))
 
         // TODO: Assess & Possibly Remove when the System.js ecosystem is complete

--- a/packages/angular/src/media-selector/media-selector.horizontal.component.html
+++ b/packages/angular/src/media-selector/media-selector.horizontal.component.html
@@ -34,7 +34,7 @@
                              }"
                              [ngStyle]="{'background': 'url(' + (_.get(selectedModel, '_thumbSrc') || _.get(selectedModel, 'bestImage.thumb') || _.get(selectedModel, 'meta.thumbnail_small')) + ') no-repeat center center', 'background-size': 'cover'}">
 
-                            <img class="shapeholder" src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">
+                            <img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">
 
                             <div class="thumb-gradient">&nbsp;</div>
 
@@ -164,7 +164,7 @@
                                 Close Library
                             </div>
                             <img class="shapeholder"
-                                 src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">
+                                 [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">
                         </div>
                     </a>
                 </li>

--- a/packages/angular/src/media-selector/media-selector.horizontal.component.html
+++ b/packages/angular/src/media-selector/media-selector.horizontal.component.html
@@ -7,9 +7,9 @@
         <p class="small-all-caps selected-media-label"
            [textContent]="'Selected ' + (type || 'Items')"></p>
         <div class="selected-area media-content">
-            <div class="selected-message-box" *ngIf="empty">
-                Nothing has been selected.
-            </div>
+            <!--<div class="selected-message-box" *ngIf="empty">-->
+            <!--    Nothing has been selected.-->
+            <!--</div>-->
             <ul cdkDropList class="list-inline media-selected-list"
                 cdkDropListOrientation="horizontal"
                 (cdkDropListDropped)="drop($event)">

--- a/packages/angular/src/selector/selector-autocomplete.component.html
+++ b/packages/angular/src/selector/selector-autocomplete.component.html
@@ -40,14 +40,14 @@
                     <div *ngIf="!isSelected(model) && model.contentType.iconResource">
                         <mat-icon class="content-type-icon position-center"
                                   aria-hidden="true"
-                                  [svgIcon]="getSvg('/assets/1/0/bundles/' + model.contentType.iconResourcePath) | async">
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + model.contentType.iconResourcePath) | async">
                             ContentType Icon
                         </mat-icon>
                     </div>
                 </div>
 
                 <!-- Shapeholder -->
-                <img class="shapeholder" src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">
+                <img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">
             </div>
         </div>
         <div class="column-title st-grid column80">

--- a/packages/angular/src/selector/selector.component.html
+++ b/packages/angular/src/selector/selector.component.html
@@ -45,7 +45,7 @@
                     <!--<div class="image" no-flex stratus-src-->
                          <!--[ngStyle]="{'background': 'url(' + findImage(selectedModel) + ') no-repeat center center', 'background-size': 'cover'}"-->
                     <!--&gt;-->
-                        <!--<img class="shapeholder" src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">-->
+                        <!--<img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">-->
                     <!--</div>-->
 
                     <!-- This only shows the bestImage if this isn't a Video, since images for Videos are not hosted by us, thus cannot lazy load a proper size -->
@@ -67,13 +67,13 @@
                          [ngClass]="_.get(selectedModel, 'contentType.class') + '-background-color'">
 
                         <mat-icon class="content-type-icon position-center"
-                                  [svgIcon]="getSvg('/assets/1/0/bundles/' + (_.get(selectedModel, 'contentType.iconResourcePath') || _.get(selectedModel, 'iconResourcePath'))) | async">
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + (_.get(selectedModel, 'contentType.iconResourcePath') || _.get(selectedModel, 'iconResourcePath'))) | async">
                             Icon
                         </mat-icon>
                     </div>
 
                     <!-- Shapeholder -->
-                    <img class="shapeholder" src="/assets/1/0/bundles/sitetheorycore/images/shapeholder-square.png">
+                    <img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">
 
                 </div>
                 <div class="column-title">
@@ -84,7 +84,7 @@
                         to break away from the div and float to the top of the selector container
                         -->
                         <mat-icon class="content-type-icon"
-                                  [svgIcon]="getSvg('/assets/1/0/bundles/' + _.get(selectedModel, 'contentType.iconResourcePath')) | async">
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + _.get(selectedModel, 'contentType.iconResourcePath')) | async">
                             ContentType Icon
                         </mat-icon>
                         <span class="comment content-type-name font-body"

--- a/packages/angular/src/selector/selector.component.ts
+++ b/packages/angular/src/selector/selector.component.ts
@@ -106,6 +106,9 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
     _ = _
     has = has
     log = console.log
+    Stratus = Stratus
+
+    // Forms
     selectCtrl = new FormControl()
 
     // Stratus Data Connectivity

--- a/packages/angular/src/selector/selector.component.ts
+++ b/packages/angular/src/selector/selector.component.ts
@@ -51,13 +51,12 @@ import {Model} from '@stratusjs/angularjs/services/model'
 import {Collection} from '@stratusjs/angularjs/services/collection'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'selector'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 // Utility Functions
 const has = (object: object, path: string) => _.has(object, path) && !_.isEmpty(_.get(object, path))
@@ -154,8 +153,8 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
 
         // SVG Icons
         _.forEach({
-            selector_delete: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/delete.svg',
-            selector_edit: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/edit.svg'
+            selector_delete: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/delete.svg`,
+            selector_edit: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/edit.svg`
         }, (value, key) => iconRegistry.addSvgIcon(key, sanitizer.bypassSecurityTrustResourceUrl(value)).getNamedSvgIcon(key))
 
         // TODO: Assess & Possibly Remove when the System.js ecosystem is complete

--- a/packages/angular/src/test/test.directive.ts
+++ b/packages/angular/src/test/test.directive.ts
@@ -13,7 +13,6 @@ import _ from 'lodash'
 
 
 // Local Setup
-// const installDir = '/assets/1/0/bundles'
 // const systemDir = '@stratusjs/angular'
 const moduleName = 'test'
 

--- a/packages/angular/src/tree/tree-dialog.component.html
+++ b/packages/angular/src/tree/tree-dialog.component.html
@@ -86,7 +86,7 @@
                         <span class="no-image-icon position-all"
                               *ngIf="model.contentType.iconResource">
                             <mat-icon aria-hidden="true"
-                                      [svgIcon]="getSvg('/assets/1/0/bundles/' + model.contentType.iconResourcePath) | async">
+                                      [svgIcon]="getSvg(Stratus.BaseUrl + model.contentType.iconResourcePath) | async">
                                 Icon
                             </mat-icon>
                         </span>
@@ -95,7 +95,7 @@
                         <!-- Content Type Icon -->
                         <mat-icon aria-hidden="true"
                                   *ngIf="model.contentType.iconResourcePath"
-                                  [svgIcon]="getSvg('/assets/1/0/bundles/' + model.contentType.iconResourcePath) | async">
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + model.contentType.iconResourcePath) | async">
                             Icon
                         </mat-icon>
 

--- a/packages/angular/src/tree/tree-dialog.component.ts
+++ b/packages/angular/src/tree/tree-dialog.component.ts
@@ -115,7 +115,8 @@ export class TreeDialogComponent extends ResponsiveComponent implements OnInit, 
     isStyled = false
 
     // Dependencies
-    _: any
+    _ = _
+    Stratus = Stratus
 
     // Root Component
     tree: TreeComponent
@@ -163,9 +164,6 @@ export class TreeDialogComponent extends ResponsiveComponent implements OnInit, 
         // Initialization
         this.uid = _.uniqueId(`sa_${_.snakeCase(moduleName)}_component_`)
         Stratus.Instances[this.uid] = this
-
-        // Dependencies
-        this._ = _
 
         // TODO: Assess & Possibly Remove when the System.js ecosystem is complete
         // Load Component CSS until System.js can import CSS properly.

--- a/packages/angular/src/tree/tree-dialog.component.ts
+++ b/packages/angular/src/tree/tree-dialog.component.ts
@@ -87,14 +87,13 @@ export interface DialogData {
 }
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'tree-dialog'
 const parentModuleName = 'tree'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 /**
  * @title Dialog for Nested Tree

--- a/packages/angular/src/tree/tree-node.component.html
+++ b/packages/angular/src/tree/tree-node.component.html
@@ -31,14 +31,14 @@
     <mat-icon class="type-icon hover-box"
               aria-hidden="true"
               *ngIf="node.model.get('content.contentType.iconResourcePath')"
-              [svgIcon]="getSvg('/assets/1/0/bundles/' + node.model.get('content.contentType.iconResourcePath')) | async">
+              [svgIcon]="getSvg(Stratus.BaseUrl + node.model.get('content.contentType.iconResourcePath')) | async">
     </mat-icon>
 
     <!-- Default Content Type Icon -->
     <mat-icon class="type-icon hover-box"
               aria-hidden="true"
               *ngIf="!node.model.get('content.contentType.iconResourcePath')"
-              [svgIcon]="getSvg('/assets/1/0/bundles/sitetheorycore/images/menuTypeIcon/default.svg') | async">
+              [svgIcon]="getSvg(Stratus.BaseUrl + 'sitetheorycore/images/menuTypeIcon/default.svg') | async">
     </mat-icon>
 
     <!-- clickable name is also the drag handle -->

--- a/packages/angular/src/tree/tree-node.component.ts
+++ b/packages/angular/src/tree/tree-node.component.ts
@@ -75,7 +75,8 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
     isStyled = false
 
     // Dependencies
-    _: any
+    _ = _
+    Stratus = Stratus
 
     // Inputs
     @Input() tree: TreeComponent
@@ -107,9 +108,6 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
         // Initialization
         this.uid = _.uniqueId(`sa_${_.snakeCase(moduleName)}_component_`)
         Stratus.Instances[this.uid] = this
-
-        // Dependencies
-        this._ = _
 
         // TODO: Assess & Possibly Remove when the System.js ecosystem is complete
         // Load Component CSS until System.js can import CSS properly.

--- a/packages/angular/src/tree/tree-node.component.ts
+++ b/packages/angular/src/tree/tree-node.component.ts
@@ -47,14 +47,13 @@ import {
 } from '@stratusjs/angular/core/responsive.component'
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'tree-node'
 const parentModuleName = 'tree'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 /**
  * @title Node for Nested Tree

--- a/packages/angular/src/tree/tree.component.ts
+++ b/packages/angular/src/tree/tree.component.ts
@@ -170,6 +170,7 @@ export class TreeComponent extends RootComponent implements OnInit, OnDestroy {
 
     // Dependencies
     _ = _
+    Stratus = Stratus
 
     // Stratus Data Connectivity
     registry = new Registry()

--- a/packages/angular/src/tree/tree.component.ts
+++ b/packages/angular/src/tree/tree.component.ts
@@ -121,13 +121,12 @@ export interface NodePatch {
 // }
 
 // Local Setup
-const installDir = '/assets/1/0/bundles'
 const systemDir = '@stratusjs/angular'
 const moduleName = 'tree'
 
 // Directory Template
 const min = !cookie('env') ? '.min' : ''
-const localDir = `${installDir}/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
 /**
  * @title Tree with Nested Drag & Drop
@@ -256,11 +255,11 @@ export class TreeComponent extends RootComponent implements OnInit, OnDestroy {
         // SVG Icons
         // TODO: Make this into a single service
         _.forEach({
-            tree_check: '/assets/1/0/bundles/sitetheorycore/images/icons/check.svg',
-            tree_add: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/add.svg',
-            tree_delete: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/delete.svg',
-            tree_edit: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/edit.svg',
-            tree_visibility: '/assets/1/0/bundles/sitetheorycore/images/icons/actionButtons/visibility.svg',
+            tree_check: `${Stratus.BaseUrl}sitetheorycore/images/icons/check.svg`,
+            tree_add: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/add.svg`,
+            tree_delete: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/delete.svg`,
+            tree_edit: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/edit.svg`,
+            tree_visibility: `${Stratus.BaseUrl}sitetheorycore/images/icons/actionButtons/visibility.svg`,
         }, (value, key) => this.iconRegistry.addSvgIcon(key, this.sanitizer.bypassSecurityTrustResourceUrl(value)).getNamedSvgIcon(key))
 
         // Data Connections

--- a/packages/angularjs/src/components/base.ts
+++ b/packages/angularjs/src/components/base.ts
@@ -88,7 +88,7 @@ Stratus.Components.Base = {
         Stratus.Instances[$ctrl.uid] = $scope
         $scope.elementId = $attrs.elementId || $ctrl.uid
         Stratus.Internals.CssLoader(
-            Stratus.BaseUrl + Stratus.BundlePath + localPath + '/' + name + min + '.css'
+            `${Stratus.BaseUrl + Stratus.BundlePath + localPath}/${name}${min}.css`
         )
         $scope.initialized = false
 
@@ -164,5 +164,5 @@ Stratus.Components.Base = {
     //             <stratus-pagination></stratus-pagination> \
     //         </ul> \
     //     </div>',
-    templateUrl: Stratus.BaseUrl + Stratus.DeploymentPath + localPath + '/' + name + min + '.html'
+    templateUrl: `${Stratus.BaseUrl}${Stratus.DeploymentPath}${localPath}/${name}${min}.html`
 }

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/map",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Angular Google Map component to be used as an add-on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/map/src/map.component.ts
+++ b/packages/map/src/map.component.ts
@@ -34,7 +34,7 @@ import {
 // Local Setup
 const packageName = 'map'
 const systemDir = `@stratusjs/${packageName}`
-const localDir = `/assets/1/0/bundles/${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
+const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 const moduleName = 'map'
 
 // Static Variables


### PR DESCRIPTION
Adds:

- Angular: Add Dynamic Install Path
- Angular & Map: Localized `Stratus` References for Templates

Changes:

- Angular: Bump to `0.2.84`
- Map: Bump to `0.4.1`
- Angular & Map: Use `Stratus.BaseUrl` instead of hard-coded locations
- AngularJS: Use Template Strings (Bump Unnecessary)

Removes:

- Media Selector: Empty Message