### PR TITLE
@stratusjs/idx 0.14.0 Listing Credit/ADA

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/src/disclaimer/disclaimer.component.ts
+++ b/packages/idx/src/disclaimer/disclaimer.component.ts
@@ -251,5 +251,5 @@ Stratus.Components.IdxDisclaimer = {
             $scope.onWatchers.forEach(killOnWatcher => killOnWatcher())
         }
     },
-    template: '<div id="{{::elementId}}" class="disclaimer-outer-container" data-ng-cloak data-ng-show="idxService.length > 0 && !hideMe" aria-label="Disclaimers"><div class="disclaimer-container" data-ng-repeat="service in idxService" data-ng-bind-html="service.disclaimerHTML"></div><div class="mls-logos-container" aria-label="Logos"><img class="mls-service-logo" data-ng-show="service.logo.default" data-ng-repeat="service in idxService" aria-label="{{service.name}}" data-ng-src="{{service.logo.medium || service.logo.default}}"></div></div>'
+    template: '<div id="{{::elementId}}" class="disclaimer-outer-container" data-ng-cloak data-ng-show="idxService.length > 0 && !hideMe" role="contentinfo" aria-label="IDX Disclaimers"><div class="disclaimer-container" data-ng-repeat="service in idxService" data-ng-bind-html="service.disclaimerHTML"></div><div class="mls-logos-container" aria-label="Logos"><img class="mls-service-logo" data-ng-show="service.logo.default" data-ng-repeat="service in idxService" aria-label="{{service.name}}" data-ng-src="{{service.logo.medium || service.logo.default}}"></div></div>'
 }

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -545,6 +545,8 @@ export interface Property extends LooseObject {
     ListAgentFullName?: string
     ListAgentFirstName?: string
     ListAgentLastName?: string
+    ListAgentDirectPhone?: string
+    ListAgentOfficePhone?: string
     CoListAgentFullName?: string
     CoListAgentFirstName?: string
     CoListAgentLastName?: string
@@ -1237,34 +1239,39 @@ const angularJsService = (
                 sharedValues.contact.name = response.data.contactName
             }
             if (
-                Object.prototype.hasOwnProperty.call(response.data.contact, 'emails')
-                && _.isPlainObject(response.data.contact.emails)
+                Object.prototype.hasOwnProperty.call(response.data, 'contact')
+                && _.isPlainObject(response.data.contact)
             ) {
-                sharedValues.contact.emails = response.data.contact.emails
-            }
-            if (
-                Object.prototype.hasOwnProperty.call(response.data.contact, 'locations')
-                && _.isPlainObject(response.data.contact.locations)
-            ) {
-                sharedValues.contact.locations = response.data.contact.locations
-            }
-            if (
-                Object.prototype.hasOwnProperty.call(response.data.contact, 'phones')
-                && _.isPlainObject(response.data.contact.phones)
-            ) {
-                sharedValues.contact.phones = response.data.contact.phones
-            }
-            if (
-                Object.prototype.hasOwnProperty.call(response.data.contact, 'socialUrls')
-                && _.isPlainObject(response.data.contact.socialUrls)
-            ) {
-                sharedValues.contact.socialUrls = response.data.contact.socialUrls
-            }
-            if (
-                Object.prototype.hasOwnProperty.call(response.data.contact, 'urls')
-                && _.isPlainObject(response.data.contact.urls)
-            ) {
-                sharedValues.contact.urls = response.data.contact.urls
+                if (
+                    Object.prototype.hasOwnProperty.call(response.data.contact, 'emails')
+                    && _.isPlainObject(response.data.contact.emails)
+                ) {
+                    sharedValues.contact.emails = response.data.contact.emails
+                }
+                if (
+                    Object.prototype.hasOwnProperty.call(response.data.contact, 'locations')
+                    && _.isPlainObject(response.data.contact.locations)
+                ) {
+                    sharedValues.contact.locations = response.data.contact.locations
+                }
+                if (
+                    Object.prototype.hasOwnProperty.call(response.data.contact, 'phones')
+                    && _.isPlainObject(response.data.contact.phones)
+                ) {
+                    sharedValues.contact.phones = response.data.contact.phones
+                }
+                if (
+                    Object.prototype.hasOwnProperty.call(response.data.contact, 'socialUrls')
+                    && _.isPlainObject(response.data.contact.socialUrls)
+                ) {
+                    sharedValues.contact.socialUrls = response.data.contact.socialUrls
+                }
+                if (
+                    Object.prototype.hasOwnProperty.call(response.data.contact, 'urls')
+                    && _.isPlainObject(response.data.contact.urls)
+                ) {
+                    sharedValues.contact.urls = response.data.contact.urls
+                }
             }
         }
 
@@ -3178,6 +3185,38 @@ const angularJsService = (
         return googleMapsKey
     }
 
+    function getWebsiteMainContact(): {
+        name: string
+        email: string | null
+        phone: string | null
+    } | null {
+        const contact: {
+            name: string | null
+            email: string | null
+            phone: string | null
+        } = {
+            name: null,
+            email: null,
+            phone: null,
+        }
+
+        if (_.isPlainObject(sharedValues.contact)) {
+            contact.name = _.clone(sharedValues.contact.name)
+            if (sharedValues.contact.emails.hasOwnProperty('Main')) {
+                contact.email = _.clone(sharedValues.contact.emails.Main)
+            }
+            if (sharedValues.contact.phones.hasOwnProperty('Main')) {
+                contact.phone = _.clone(sharedValues.contact.phones.Main)
+            }
+        }
+
+        if (!_.isString(contact.name) || contact.name === '') {
+            // Don't return an empty object. (or one withg a name, as a a basic item)
+            return null
+        }
+        return contact
+    }
+
     /**
      * Get the Input element of a specified ID
      */
@@ -3304,6 +3343,7 @@ const angularJsService = (
         getStreetAddress,
         getUrlOptions,
         getUrlOptionsPath,
+        getWebsiteMainContact,
         on,
         registerDetailsInstance,
         registerDisclaimerInstance,

--- a/packages/idx/src/property/details-sub-section.component.html
+++ b/packages/idx/src/property/details-sub-section.component.html
@@ -1,7 +1,7 @@
-<div data-ng-class="::className" data-ng-if="visibleFields">
-	<div data-ng-bind="::sectionName" class="section-name" aria-label="{{::sectionName}} Details"></div>
+<section id="{{::elementId}}" data-ng-class="::className" role="region" aria-labelledby="{{::sectionNameId}}" data-ng-if="visibleFields">
+	<strong data-ng-bind="::sectionName" class="section-name" id="{{::sectionNameId}}"></strong>
 	<div data-ng-repeat="(itemVariable, item) in ::items" class="sub-detail">
-		<div data-ng-if="::!item.hide && model.data.hasOwnProperty(itemVariable)" data-ng-switch="::typeOf(model.data[itemVariable])">
+		<div data-ng-if="::!item.hide && model.data.hasOwnProperty(itemVariable)" data-ng-switch="::typeOf(model.data[itemVariable])" role="text">
 			<div data-ng-switch-when="array">
 				<span data-ng-if="::item.name" data-ng-bind="::item.name + ':'" class="item-label"></span>
 				<span data-ng-repeat="item in ::model.data[itemVariable]" class="repeatedArray"><span data-ng-bind="::item"></span><span class="hideLastChild">,&nbsp;</span></span>
@@ -23,4 +23,4 @@
 			</div>
 		</div>
 	</div>
-</div>
+</section>

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -13,11 +13,11 @@
 		<div class="details-container" data-md-whiteframe="1">
 			<div class="details-header dotted-spaced-underline" data-layout="row" data-layout-align="space-between start" data-layout-wrap>
 				<div class="address-container" data-flex="100" data-flex-gt-xs="80" aria-label="Address">
-					<h3 class="address" aria-label="Street Address">
+					<h3 class="address">
 						<!--span data-ng-bind="::model.data.UnparsedAddress"></span-->
 						<span data-ng-bind="::model.data.InternetAddressDisplayYN === false ? 'Address Not Disclosed' : getStreetAddress()"></span><!--Address not yet available-->
 					</h3>
-					<div class="address2">
+					<div class="address2" role="text">
 						<span data-ng-bind="::model.data.City | lowercase" aria-label="City"></span><span data-ng-if="::model.data.StateOrProvince">, <span data-ng-bind="::model.data.StateOrProvince" aria-label="State"></span></span>
 						<span data-ng-bind="::model.data.PostalCode" aria-label="Postal Code"></span>
 						<span data-ng-bind="::model.data.Country" aria-label="Country"></span>
@@ -26,7 +26,7 @@
 				<div class="contact-container" data-flex="100" data-flex-gt-xs="20">
 					<!-- TODO data-ng-click="return cms.obj.listtrac.track('lead');"-->
 					<!--a data-ng-href="/site/contact?comments={{::getFullAddress(true)}}" target="_blank">Contact</a-->
-					<md-button class="button" target="_blank" data-ng-href="/site/contact?subject={{::getFullAddress(true)}}" aria-label="Website Owner">
+					<md-button class="button" target="_blank" data-ng-href="/site/contact?subject={{::getFullAddress(true)}}" aria-label="Website Contact">
 						Contact
 					</md-button>
 				</div>
@@ -56,7 +56,7 @@
 				<div class="image-container" data-flex="100" data-flex-gt-xs="75">
 					<div class="price-banner" data-ng-if="::model.data.ClosePrice || model.data.ListPrice">
 						<div class="price-banner-corner" aria-hidden="true"></div>
-						<div class="list-price-container">
+						<div class="list-price-container" role="text">
 							<span class="list-price-label" data-ng-bind="model.data.ClosePrice ? 'Sold for' : 'Listed at'"></span>
 							<span class="list-price" data-ng-bind="'$' + (model.data.ClosePrice || model.data.ListPrice | number)" aria-label="Listing Price"></span>
 						</div>
@@ -71,54 +71,54 @@
 					</div>
 				</div>
 
-				<div class="details-specs-container" data-flex="100" data-flex-gt-xs="20">
+				<section class="details-specs-container" data-flex="100" data-flex-gt-xs="20" role="region" aria-label="Detail Highlights">
 					<div class="details-specs">
-						Status: <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)" aria-label="Property Status"></span>
-						<span data-ng-if="::model.data.BedroomsTotal > 0" aria-label="Number of Bedrooms"><br><span data-ng-bind="::model.data.BedroomsTotal"></span> Beds</span>
-                        <span data-ng-if="::model.data.BathroomsFull > 0 || model.data.BathroomsTotalInteger > 0" aria-label="Number of Bathrooms">
+                        <span role="text" aria-label="Property Status">Status: <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)"></span></span>
+						<span data-ng-if="::model.data.BedroomsTotal > 0" role="text" aria-label="Number of Bedrooms"><br><span data-ng-bind="::model.data.BedroomsTotal"></span> Beds</span>
+                        <span data-ng-if="::model.data.BathroomsFull > 0 || model.data.BathroomsTotalInteger > 0" role="text" aria-label="Number of Bathrooms">
                             <br><span data-ng-bind="::model.data.BathroomsFull || model.data.BathroomsTotalInteger"></span> Baths
                         </span>
-                        <span data-ng-if="::model.data.BathroomsHalf > 0" aria-label="Number of Half Bathrooms">
+                        <span data-ng-if="::model.data.BathroomsHalf > 0" role="text" aria-label="Number of Half Bathrooms">
                             <br><span data-ng-bind="::model.data.BathroomsHalf"></span> Half Baths
                         </span>
-                        <span data-ng-if="::model.data.BathroomsOneQuarter > 0" aria-label="Number of Quarter Bathrooms">
+                        <span data-ng-if="::model.data.BathroomsOneQuarter > 0" role="text" aria-label="Number of Quarter Bathrooms">
                             <br><span data-ng-bind="::model.data.BathroomsOneQuarter"></span> Quarter Baths
                         </span>
-                        <span data-ng-if="::model.data.BathroomsPartial > 0" aria-label="Number of Partial Bathrooms">
+                        <span data-ng-if="::model.data.BathroomsPartial > 0" role="text" aria-label="Number of Partial Bathrooms">
                             <br><span data-ng-bind="::model.data.BathroomsPartial"></span> Partial Baths
                         </span>
-                        <span data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'" aria-label="Date Closed">
+                        <span data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'" role="text" aria-label="Date Closed">
                             <br><span data-ng-bind="::Idx.getFriendlyStatus(model.data, preferredStatus)"></span> on
                             <time data-ng-bind="::model.data.CloseDate | moment:{unix:false,format:'MMM Do YYYY'}" datetime="{{::model.data.CloseDate}}"></time>
                         </span>
-                        <span data-ng-if="::model.data.OnMarketDate" aria-label="Date Listed">
+                        <span data-ng-if="::model.data.OnMarketDate" role="text" aria-label="Date Listed">
                             <br>Listed on
                             <time data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,format:'MMM Do YYYY'}" datetime="{{::model.data.OnMarketDate}}"></time>
                         </span>
-                        <span data-ng-if="::model.data.CloseDate && model.data.ClosePrice && model.data.ListPrice" aria-label="List Price">
+                        <span data-ng-if="::model.data.CloseDate && model.data.ClosePrice && model.data.ListPrice" role="text" aria-label="List Price">
                             <br>Listed at <span data-ng-bind="'$' + (model.data.ListPrice | number)"></span>
                         </span>
-                        <span data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) === 'Closed' && model.data.CloseDate">
+                        <span data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) === 'Closed' && model.data.CloseDate" role="text">
                             <!-- Closed with start and end Dates. Give number of days between -->
                             <br>Days on Market:
                             <span data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,diff:model.data.CloseDate,duration:'days'}"></span>
                         </span>
-                        <span data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) !== 'Closed'">
+                        <span data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) !== 'Closed'" role="text">
                             <!-- Not Closed Yet, Days since open -->
                             <br>Days on Market:
                             <span data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,diff:true,duration:'days'}"></span>
                         </span>
-                        <span data-ng-if="::model.data.DaysOnMarket && !model.data.OnMarketDate">
+                        <span data-ng-if="::model.data.DaysOnMarket && !model.data.OnMarketDate" role="text">
                             <!-- MLS provides DaysOnMarket, but we weren't given a Start time, use MLS provided times (may be inaccurate) -->
                             <br>Days on Market: <span data-ng-bind="::model.data.DaysOnMarket | number"></span>
                         </span>
-                        <span data-ng-if="::model.data.ArchitecturalStyle" aria-label="Architectural Style">
+                        <span data-ng-if="::model.data.ArchitecturalStyle" role="text" aria-label="Architectural Style">
                             <br>Style: <span data-ng-repeat="item in ::model.data.ArchitecturalStyle" class="repeatedArray"><span data-ng-bind="::item"></span><span class="hideLastChild">,&nbsp;</span></span>
                         </span>
-                        <span data-ng-if="::model.data.YearBuilt" aria-label="Year Built">
+                        <span data-ng-if="::model.data.YearBuilt" role="text" aria-label="Year Built">
                             <br>Built in <span data-ng-bind="::model.data.YearBuilt"></span>
                         </span>
-                        <span data-ng-if="::model.data.LivingArea" aria-label="Living Area Size">
+                        <span data-ng-if="::model.data.LivingArea" role="text" aria-label="Living Area Size">
                             <br>Living Area:
                             <span data-ng-bind="::model.data.LivingArea | number"></span>
                             <span data-ng-if="::model.data.LivingAreaUnits">
@@ -128,7 +128,7 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="::model.data.LeasableArea" aria-label="Leasable Area Size">
+                        <span data-ng-if="::model.data.LeasableArea" role="text" aria-label="Leasable Area Size">
                             <br>Leasable:
                             <span data-ng-bind="::model.data.LeasableArea | number"></span>
                             <span data-ng-if="::model.data.LeasableAreaUnits">
@@ -138,7 +138,7 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="::model.data.BuildingAreaTotal" aria-label="Building Area Size">
+                        <span data-ng-if="::model.data.BuildingAreaTotal" role="text" aria-label="Building Area Size">
                             <br>Building:
                             <span data-ng-bind="::model.data.BuildingAreaTotal | number"></span>
                             <span data-ng-if="::model.data.BuildingAreaUnits">
@@ -148,7 +148,7 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="::model.data.LotSizeArea" aria-label="Lot Size">
+                        <span data-ng-if="::model.data.LotSizeArea" role="text" aria-label="Lot Size">
                             <br>Lot: <span data-ng-bind="::model.data.LotSizeArea | number"></span>
                             <span data-ng-if="::model.data.LotSizeUnits">
 								<span data-ng-bind="::model.data.LotSizeUnits"></span>
@@ -157,14 +157,14 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeAcres" aria-label="Lot Size Acres">
+                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeAcres" role="text" aria-label="Lot Size Acres">
                             <br>Lot: <span data-ng-bind="::model.data.LotSizeAcres"></span> Acres
                         </span>
-                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeSquareFeet" aria-label="Lot Size Square Feet">
+                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeSquareFeet" role="text" aria-label="Lot Size Square Feet">
                             <br>Lot: <span data-ng-bind="::model.data.LotSizeSquareFeet  | number"></span> SqFt
                         </span>
-                        <span data-ng-if="::model.data.PoolPrivateYN" aria-label="Listing Contains Pool"><br>With Pool</span>
-                        <span data-ng-if="::model.data.Stories" aria-label="Number of Stories"><br>Stories: <span data-ng-bind="::model.data.Stories"></span></span>
+                        <span data-ng-if="::model.data.PoolPrivateYN" role="text" aria-label="Listing Contains Pool"><br>With Pool</span>
+                        <span data-ng-if="::model.data.Stories" role="text" aria-label="Number of Stories"><br>Stories: <span data-ng-bind="::model.data.Stories"></span></span>
 
 						<!--{if !empty($data.standard.subdivision)}<br/>Subdivision: {$data.standard.subdivision}{/if}-->
 
@@ -188,15 +188,15 @@
 
 
 					<div class="mls-service-container">
-						<div class="mls-service" data-ng-if="::model.data.ListingId || model.data.ListingKey">
+						<div class="mls-service" data-ng-if="::model.data.ListingId || model.data.ListingKey" role="text">
 							<span data-ng-bind="getMLSName()" aria-label="Providing MLS"></span>#
 							<span data-ng-bind="::model.data.ListingId || model.data.ListingKey" aria-label="Property MLS Id or Number"></span>
 						</div>
 					</div>
-				</div>
+				</section>
 			</div>
 
-            <div class="listing-credit-container" data-layout="row" data-layout-xs="column" data-layout-align="space-around stretch">
+            <section class="listing-credit-container" data-layout="row" data-layout-xs="column" data-layout-align="space-around stretch" role="region" aria-label="Listing Credits">
                 <div class="presenting-agent-container" data-ng-if="::Idx.sharedValues.contact.name" data-flex data-layout="column" aria-label="Advertising Broker">
                     <h4 class="listing-credit-title">Presented By</h4>
                     <!--p class="listing-credit-contact">Realtor Name | Brokerage Name</p-->
@@ -205,8 +205,8 @@
                         <!--a href="mailto:email@address.com">email@address.com</a-->
                         <a data-ng-href="mailto:{{::Idx.sharedValues.contact.emails.Main}}" target="_blank" data-ng-bind="::Idx.sharedValues.contact.emails.Main"></a>
                     </p>
-                    <p class="listing-credit-contact" data-ng-if="::(Idx.sharedValues.contact.phones && Idx.sharedValues.contact.phones.Main) && !(Idx.sharedValues.contact.emails && Idx.sharedValues.contact.emails.Main)" aria-label="Advertising Broker Contact">
-                        <a data-ng-href="tel:{{::Idx.sharedValues.contact.phones.Main}}" data-ng-bind="::Idx.sharedValues.contact.phones.Main"></a>
+                    <p class="listing-credit-contact" data-ng-if="::(Idx.sharedValues.contact.phones && Idx.sharedValues.contact.phones.Main) && !(Idx.sharedValues.contact.emails && Idx.sharedValues.contact.emails.Main)">
+                        <a data-ng-href="tel:{{::Idx.sharedValues.contact.phones.Main}}" data-ng-bind="::Idx.sharedValues.contact.phones.Main" aria-label="Advertising Broker Contact"></a>
                     </p>
                 </div>
                 <div class="listing-credit-divider" data-ng-if="getListAgentName() && Idx.sharedValues.contact.name" data-flex="10" data-hide-xs></div>
@@ -219,26 +219,25 @@
                         <!--a href="mailto:email@address.com">email@address.com</a-->
                         <a data-ng-href="mailto:{{::model.data.ListAgentEmail}}" target="_blank" data-ng-bind="::model.data.ListAgentEmail"></a>
                     </p>
-                    <p class="listing-credit-contact" data-ng-if="getListAgentPhone() && !model.data.ListAgentEmail" aria-label="Listing Broker Contact">
-                        <a data-ng-href="tel:{{::getListAgentPhone()}}" data-ng-bind="::getListAgentPhone()"></a>
+                    <p class="listing-credit-contact" data-ng-if="getListAgentPhone() && !model.data.ListAgentEmail">
+                        <a data-ng-href="tel:{{::getListAgentPhone()}}" data-ng-bind="::getListAgentPhone()" aria-label="Listing Broker Contact"></a>
                     </p>
                 </div>
 
-            </div>
+            </section>
 		</div>
 
-		<div class="additional-photos details-container" data-ng-if="model.data.Images && model.data.Images.length > 0" data-md-whiteframe="1">
+		<section class="additional-photos details-container" role="region" aria-label="Image Slideshow" data-ng-if="model.data.Images && model.data.Images.length > 0" data-md-whiteframe="1">
 			<stratus-swiper-carousel
 					init-now="model.completed"
 					slides="images"
-                    aria-label="Image Slideshow"
 			></stratus-swiper-carousel>
 
 			<!-- autoplay="true" -->
 			<!-- pagination='{"clickable":true,"render":"numberBullet"}' -->
-		</div>
+		</section>
 
-		<div class="additional-details details-container" data-md-whiteframe="1">
+		<section class="additional-details details-container" role="region" aria-label="Additional Details" data-md-whiteframe="1">
 			<div class="description" data-ng-if="::model.data.PublicRemarks" data-ng-bind-html="::getPublicRemarksHTML()" aria-label="Description"></div>
 
 			<!-- TODO Missing quite a number of minor details -->
@@ -256,25 +255,25 @@
 
 			</div>
 
-			<div class="agent-section">
-				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getListAgentName()">
+			<section class="agent-section" role="region" aria-label="Source Agents">
+				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getListAgentName()" role="text">
 					<strong>Listing Agent: </strong>
 					<span data-ng-bind="::getListAgentName()" aria-label="List Agent Name"></span><span data-ng-if="::model.data.ListAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.ListAgentStateLicense" aria-label="List Agent State License"></span>)</span><span data-ng-if="::model.data.ListAgentKey && !model.data.ListAgentStateLicense"> (Agent #<span data-ng-bind="::model.data.ListAgentKey" aria-label="List Agent MLS Key"></span>)</span><span data-ng-if="::model.data.ListOfficeName">, <span data-ng-bind="::model.data.ListOfficeName" aria-label="List Office Name"></span></span>
 				</div>
-				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getCoListAgentName()">
+				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getCoListAgentName()" role="text">
 					<strong>Co-Listing Agent: </strong>
 					<span data-ng-bind="::getCoListAgentName()" aria-label="CoList Agent Name"></span><span data-ng-if="::model.data.CoListAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.CoListAgentStateLicense" aria-label="CoList Agent State License"></span>)</span><span data-ng-if="::model.data.CoListAgentKey && !model.data.CoListAgentStateLicense"> (Agent #<span data-ng-bind="::model.data.CoListAgentKey" aria-label="CoList Agent MLS Key"></span>)</span><span data-ng-if="::model.data.CoListOfficeName">, <span data-ng-bind="::model.data.CoListOfficeName" aria-label="CoList Office Name"></span></span>
 				</div>
-				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getBuyerAgentName()">
+				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getBuyerAgentName()" role="text">
 					<strong>Buyer Agent: </strong>
 					<span data-ng-bind="::getBuyerAgentName()" aria-label="Buyer Agent Name"></span><span data-ng-if="::model.data.BuyerAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.BuyerAgentStateLicense" aria-label="Buyer Agent State License"></span>)</span><span data-ng-if="::model.data.BuyerAgentKey && !model.data.BuyerAgentStateLicense"> (Agent #<span data-ng-bind="::model.data.BuyerAgentKey" aria-label="Buyer Agent MLS Key"></span>)</span><span data-ng-if="::model.data.BuyerOfficeName">, <span data-ng-bind="::model.data.BuyerOfficeName" aria-label="Buyer Office Name"></span></span>
 				</div>
-				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getCoBuyerAgentName()">
+				<div class="agent dotted-spaced-underline underline-top" data-ng-if="getCoBuyerAgentName()" role="text">
 					<strong>Co-Buyer Agent: </strong>
 					<span data-ng-bind="::getCoBuyerAgentName()" aria-label="CoBuyer Agent Name"></span><span data-ng-if="::model.data.CoBuyerAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.CoBuyerAgentStateLicense" aria-label="CoBuyer Agent State License"></span>)</span><span data-ng-if="::model.data.CoBuyerAgentKey && !model.data.CoBuyerAgentStateLicense"> (Agent #<span data-ng-bind="::model.data.CoBuyerAgentKey" aria-label="CoBuyer Agent MLS Key"></span>)</span><span data-ng-if="::model.data.CoBuyerOfficeName">, <span data-ng-bind="::model.data.CoBuyerOfficeName" aria-label="CoBuyer Office Name"></span></span>
 				</div>
-			</div>
-		</div>
+			</section>
+		</section>
 
 		<div class="map-location details-container" data-md-whiteframe="1" data-ng-if="::getGoogleMapEmbed()" aria-label="Google Maps Display">
             <iframe data-ng-src="{{::getGoogleMapEmbed()}}" class="google-map-embed"></iframe>

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -195,6 +195,36 @@
 					</div>
 				</div>
 			</div>
+
+            <div class="listing-credit-container" data-layout="row" data-layout-xs="column" data-layout-align="space-around stretch">
+                <div class="presenting-agent-container" data-ng-if="::Idx.sharedValues.contact.name" data-flex data-layout="column" aria-label="Advertising Broker">
+                    <h4 class="listing-credit-title">Presented By</h4>
+                    <!--p class="listing-credit-contact">Realtor Name | Brokerage Name</p-->
+                    <p class="listing-credit-contact" data-ng-bind="::Idx.sharedValues.contact.name"></p>
+                    <p class="listing-credit-contact" data-ng-if="::Idx.sharedValues.contact.emails && Idx.sharedValues.contact.emails.Main" aria-label="Advertising Broker Contact">
+                        <!--a href="mailto:email@address.com">email@address.com</a-->
+                        <a data-ng-href="mailto:{{::Idx.sharedValues.contact.emails.Main}}" target="_blank" data-ng-bind="::Idx.sharedValues.contact.emails.Main"></a>
+                    </p>
+                    <p class="listing-credit-contact" data-ng-if="::(Idx.sharedValues.contact.phones && Idx.sharedValues.contact.phones.Main) && !(Idx.sharedValues.contact.email && Idx.sharedValues.contact.emails.Main)" aria-label="Advertising Broker Contact">
+                        <a data-ng-href="tel:{{::Idx.sharedValues.contact.phones.Main}}" data-ng-bind="::Idx.sharedValues.contact.phones.Main"></a>
+                    </p>
+                </div>
+                <div class="listing-credit-divider" data-ng-if="getListAgentName() && Idx.sharedValues.contact.name" data-flex="10" data-hide-xs></div>
+                <div class="listing-agent-container" data-ng-if="getListAgentName()" data-flex data-layout="column" aria-label="Listing Broker">
+                    <h4 class="listing-credit-title">Listing Agent</h4>
+                    <p class="listing-credit-contact">
+                        <span data-ng-bind="::getListAgentName()"></span> | <span data-ng-bind="::model.data.ListOfficeName"></span>
+                    </p>
+                    <p class="listing-credit-contact" data-ng-if="model.data.ListAgentEmail" aria-label="Listing Broker Contact">
+                        <!--a href="mailto:email@address.com">email@address.com</a-->
+                        <a data-ng-href="mailto:{{::model.data.ListAgentEmail}}" target="_blank" data-ng-bind="::model.data.ListAgentEmail"></a>
+                    </p>
+                    <p class="listing-credit-contact" data-ng-if="getListAgentPhone() && !model.data.ListAgentEmail" aria-label="Listing Broker Contact">
+                        <a data-ng-href="tel:{{::getListAgentPhone()}}" data-ng-bind="::getListAgentPhone()"></a>
+                    </p>
+                </div>
+
+            </div>
 		</div>
 
 		<div class="additional-photos details-container" data-ng-if="model.data.Images && model.data.Images.length > 0" data-md-whiteframe="1">

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -23,10 +23,12 @@
 						<span data-ng-bind="::model.data.Country" aria-label="Country"></span>
 					</div>
 				</div>
-				<div class="contact-container" data-flex="100" data-flex-gt-xs="20">
+				<div class="contact-container" data-flex="100" data-flex-gt-xs="20" data-ng-show="::contactUrl || Idx.sharedValues.contactUrl">
 					<!-- TODO data-ng-click="return cms.obj.listtrac.track('lead');"-->
 					<!--a data-ng-href="/site/contact?comments={{::getFullAddress(true)}}" target="_blank">Contact</a-->
-					<md-button class="button" target="_blank" data-ng-href="/site/contact?subject={{::getFullAddress(true)}}" aria-label="Website Contact">
+					<md-button class="button" target="_blank" aria-label="Website Contact"
+                               data-ng-href="{{::contactUrl || Idx.sharedValues.contactUrl}}{{(Idx.sharedValues.contactCommentVariable ? '?' + Idx.sharedValues.contactCommentVariable + '=' + getFullAddress(true) : '')}}"
+                    >
 						Contact
 					</md-button>
 				</div>

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -277,7 +277,7 @@
 			</section>
 		</section>
 
-		<div class="map-location details-container" data-md-whiteframe="1" data-ng-if="::getGoogleMapEmbed()" aria-label="Google Maps Display">
+		<div class="map-location details-container" data-md-whiteframe="1" data-ng-if="::getGoogleMapEmbed()" role="presentation" aria-label="Google Maps Display">
             <iframe data-ng-src="{{::getGoogleMapEmbed()}}" class="google-map-embed"></iframe>
 		</div>
 

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -12,7 +12,7 @@
 	<div data-ng-if="model.completed && (model.data.ListingId || model.data.ListingKey)">
 		<div class="details-container" data-md-whiteframe="1">
 			<div class="details-header dotted-spaced-underline" data-layout="row" data-layout-align="space-between start" data-layout-wrap>
-				<div class="address-container" data-flex="100" data-flex-gt-xs="80" aria-label="Address">
+				<div class="address-container" data-flex="100" data-flex-gt-xs="80">
 					<h3 class="address">
 						<!--span data-ng-bind="::model.data.UnparsedAddress"></span-->
 						<span data-ng-bind="::model.data.InternetAddressDisplayYN === false ? 'Address Not Disclosed' : getStreetAddress()"></span><!--Address not yet available-->
@@ -60,7 +60,7 @@
 						<div class="price-banner-corner" aria-hidden="true"></div>
 						<div class="list-price-container" role="text">
 							<span class="list-price-label" data-ng-bind="model.data.ClosePrice ? 'Sold for' : 'Listed at'"></span>
-							<span class="list-price" data-ng-bind="'$' + (model.data.ClosePrice || model.data.ListPrice | number)" aria-label="Listing Price"></span>
+							<span class="list-price" data-ng-bind="'$' + (model.data.ClosePrice || model.data.ListPrice | number)"></span>
 						</div>
 					</div>
 					<div class="details-image">
@@ -75,32 +75,32 @@
 
 				<section class="details-specs-container" data-flex="100" data-flex-gt-xs="20" role="region" aria-label="Detail Highlights">
 					<div class="details-specs">
-                        <span role="text" aria-label="Property Status">Status: <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)"></span></span>
-						<span data-ng-if="::model.data.BedroomsTotal > 0" role="text" aria-label="Number of Bedrooms"><br><span data-ng-bind="::model.data.BedroomsTotal"></span> Beds</span>
-                        <span data-ng-if="::model.data.BathroomsFull > 0 || model.data.BathroomsTotalInteger > 0" role="text" aria-label="Number of Bathrooms">
+                        <span role="text">Status: <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)"></span></span>
+						<span data-ng-if="::model.data.BedroomsTotal > 0" role="text"><br><span data-ng-bind="::model.data.BedroomsTotal"></span> Beds</span>
+                        <span data-ng-if="::model.data.BathroomsFull > 0 || model.data.BathroomsTotalInteger > 0" role="text">
                             <br><span data-ng-bind="::model.data.BathroomsFull || model.data.BathroomsTotalInteger"></span> Baths
                         </span>
-                        <span data-ng-if="::model.data.BathroomsHalf > 0" role="text" aria-label="Number of Half Bathrooms">
+                        <span data-ng-if="::model.data.BathroomsHalf > 0" role="text">
                             <br><span data-ng-bind="::model.data.BathroomsHalf"></span> Half Baths
                         </span>
-                        <span data-ng-if="::model.data.BathroomsOneQuarter > 0" role="text" aria-label="Number of Quarter Bathrooms">
+                        <span data-ng-if="::model.data.BathroomsOneQuarter > 0" role="text">
                             <br><span data-ng-bind="::model.data.BathroomsOneQuarter"></span> Quarter Baths
                         </span>
-                        <span data-ng-if="::model.data.BathroomsPartial > 0" role="text" aria-label="Number of Partial Bathrooms">
+                        <span data-ng-if="::model.data.BathroomsPartial > 0" role="text">
                             <br><span data-ng-bind="::model.data.BathroomsPartial"></span> Partial Baths
                         </span>
-                        <span data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'" role="text" aria-label="Date Closed">
+                        <span data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'" role="text">
                             <br><span data-ng-bind="::Idx.getFriendlyStatus(model.data, preferredStatus)"></span> on
                             <time data-ng-bind="::model.data.CloseDate | moment:{unix:false,format:'MMM Do YYYY'}" datetime="{{::model.data.CloseDate}}"></time>
                         </span>
-                        <span data-ng-if="::model.data.OnMarketDate" role="text" aria-label="Date Listed">
+                        <span data-ng-if="::model.data.OnMarketDate" role="text">
                             <br>Listed on
                             <time data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,format:'MMM Do YYYY'}" datetime="{{::model.data.OnMarketDate}}"></time>
                         </span>
-                        <span data-ng-if="::model.data.CloseDate && model.data.ClosePrice && model.data.ListPrice" role="text" aria-label="List Price">
+                        <span data-ng-if="::model.data.CloseDate && model.data.ClosePrice && model.data.ListPrice" role="text">
                             <br>Listed at <span data-ng-bind="'$' + (model.data.ListPrice | number)"></span>
                         </span>
-                        <span data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) === 'Closed' && model.data.CloseDate" role="text">
+                        <span data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) === 'Closed' && model.data.CloseDate">
                             <!-- Closed with start and end Dates. Give number of days between -->
                             <br>Days on Market:
                             <span data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,diff:model.data.CloseDate,duration:'days'}"></span>
@@ -114,13 +114,13 @@
                             <!-- MLS provides DaysOnMarket, but we weren't given a Start time, use MLS provided times (may be inaccurate) -->
                             <br>Days on Market: <span data-ng-bind="::model.data.DaysOnMarket | number"></span>
                         </span>
-                        <span data-ng-if="::model.data.ArchitecturalStyle" role="text" aria-label="Architectural Style">
+                        <span data-ng-if="::model.data.ArchitecturalStyle" role="text">
                             <br>Style: <span data-ng-repeat="item in ::model.data.ArchitecturalStyle" class="repeatedArray"><span data-ng-bind="::item"></span><span class="hideLastChild">,&nbsp;</span></span>
                         </span>
-                        <span data-ng-if="::model.data.YearBuilt" role="text" aria-label="Year Built">
+                        <span data-ng-if="::model.data.YearBuilt" role="text">
                             <br>Built in <span data-ng-bind="::model.data.YearBuilt"></span>
                         </span>
-                        <span data-ng-if="::model.data.LivingArea" role="text" aria-label="Living Area Size">
+                        <span data-ng-if="::model.data.LivingArea" role="text">
                             <br>Living Area:
                             <span data-ng-bind="::model.data.LivingArea | number"></span>
                             <span data-ng-if="::model.data.LivingAreaUnits">
@@ -130,7 +130,7 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="::model.data.LeasableArea" role="text" aria-label="Leasable Area Size">
+                        <span data-ng-if="::model.data.LeasableArea" role="text">
                             <br>Leasable:
                             <span data-ng-bind="::model.data.LeasableArea | number"></span>
                             <span data-ng-if="::model.data.LeasableAreaUnits">
@@ -140,7 +140,7 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="::model.data.BuildingAreaTotal" role="text" aria-label="Building Area Size">
+                        <span data-ng-if="::model.data.BuildingAreaTotal" role="text">
                             <br>Building:
                             <span data-ng-bind="::model.data.BuildingAreaTotal | number"></span>
                             <span data-ng-if="::model.data.BuildingAreaUnits">
@@ -150,7 +150,7 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="::model.data.LotSizeArea" role="text" aria-label="Lot Size">
+                        <span data-ng-if="::model.data.LotSizeArea" role="text">
                             <br>Lot: <span data-ng-bind="::model.data.LotSizeArea | number"></span>
                             <span data-ng-if="::model.data.LotSizeUnits">
 								<span data-ng-bind="::model.data.LotSizeUnits"></span>
@@ -159,14 +159,14 @@
 								Square Feet
 							</span>
                         </span>
-                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeAcres" role="text" aria-label="Lot Size Acres">
+                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeAcres" role="text">
                             <br>Lot: <span data-ng-bind="::model.data.LotSizeAcres"></span> Acres
                         </span>
-                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeSquareFeet" role="text" aria-label="Lot Size Square Feet">
+                        <span data-ng-if="!model.data.LotSizeArea && model.data.LotSizeSquareFeet" role="text">
                             <br>Lot: <span data-ng-bind="::model.data.LotSizeSquareFeet  | number"></span> SqFt
                         </span>
-                        <span data-ng-if="::model.data.PoolPrivateYN" role="text" aria-label="Listing Contains Pool"><br>With Pool</span>
-                        <span data-ng-if="::model.data.Stories" role="text" aria-label="Number of Stories"><br>Stories: <span data-ng-bind="::model.data.Stories"></span></span>
+                        <span data-ng-if="::model.data.PoolPrivateYN" role="text"><br>With Pool</span>
+                        <span data-ng-if="::model.data.Stories" role="text"><br>Stories: <span data-ng-bind="::model.data.Stories"></span></span>
 
 						<!--{if !empty($data.standard.subdivision)}<br/>Subdivision: {$data.standard.subdivision}{/if}-->
 
@@ -177,8 +177,8 @@
 							</ul>
 						</span-->
 						<!--{if !empty($data.standard.sale_type) && !empty($data.standard.sale_type && $data.standard.sale_type != "NONE")}<br/>Sale Condition: {$data.standard.sale_type}{/if}-->
-						<span data-ng-if="::model.data.PropertyType"><br><span data-ng-bind="::model.data.PropertyType" aria-label="Property Type"></span></span>
-						<span data-ng-if="::model.data.PropertySubType"><br><span data-ng-bind="::model.data.PropertySubType" aria-label="Property Sub Type"></span></span>
+						<span data-ng-if="::model.data.PropertyType"><br><span data-ng-bind="::model.data.PropertyType"></span></span>
+						<span data-ng-if="::model.data.PropertySubType"><br><span data-ng-bind="::model.data.PropertySubType"></span></span>
 					</div>
 
 

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -205,7 +205,7 @@
                         <!--a href="mailto:email@address.com">email@address.com</a-->
                         <a data-ng-href="mailto:{{::Idx.sharedValues.contact.emails.Main}}" target="_blank" data-ng-bind="::Idx.sharedValues.contact.emails.Main"></a>
                     </p>
-                    <p class="listing-credit-contact" data-ng-if="::(Idx.sharedValues.contact.phones && Idx.sharedValues.contact.phones.Main) && !(Idx.sharedValues.contact.email && Idx.sharedValues.contact.emails.Main)" aria-label="Advertising Broker Contact">
+                    <p class="listing-credit-contact" data-ng-if="::(Idx.sharedValues.contact.phones && Idx.sharedValues.contact.phones.Main) && !(Idx.sharedValues.contact.emails && Idx.sharedValues.contact.emails.Main)" aria-label="Advertising Broker Contact">
                         <a data-ng-href="tel:{{::Idx.sharedValues.contact.phones.Main}}" data-ng-bind="::Idx.sharedValues.contact.phones.Main"></a>
                     </p>
                 </div>

--- a/packages/idx/src/property/details.classic.component.html
+++ b/packages/idx/src/property/details.classic.component.html
@@ -32,11 +32,11 @@
 				</div>
 			</div>
 
-			<div class="open-house-section dotted-spaced-underline" data-ng-if="model.data.OpenHouses && model.data.OpenHouses.length">
+			<section class="open-house-section dotted-spaced-underline" data-ng-if="model.data.OpenHouses && model.data.OpenHouses.length" role="region" aria-label="Open Houses">
 				<h4 class="section-title">Open House</h4>
-				<div class="open-house-container dotted-spaced-sideline">
+				<div class="open-house-container dotted-spaced-sideline" role="list" aria-label="Open Houses">
 					<span class="description" data-ng-if="::model.data.OpenHouses[0].OpenHouseRemarks" data-ng-bind="::model.data.OpenHouses[0].OpenHouseRemarks" aria-label="Open House Description"></span>
-					<div class="open-house" id="{{'open_house_' + openHouse.OpenHouseId}}" data-ng-repeat="openHouse in model.data.OpenHouses">
+					<div class="open-house" id="{{'open_house_' + openHouse.OpenHouseId}}" data-ng-repeat="openHouse in model.data.OpenHouses" role="listitem" aria-label="{{::openHouse.OpenHouseStartTime | moment:{unix:false,format:'dddd MMM Do, h:mm a'}}">
 						<time data-ng-bind="::openHouse.OpenHouseStartTime | moment:{unix:false,format:'dddd MMM Do, h:mm a'}" aria-label="Open House Start Time" datetime="{{::openHouse.OpenHouseStartTime}}"></time>
 						<span data-ng-if="::openHouse.OpenHouseEndTime"> —
 							<time data-ng-bind="::openHouse.OpenHouseEndTime | moment:{unix:false,format:'h:mm a'}" aria-label="Open House End Time" datetime="{{::openHouse.OpenHouseEndTime}}"></time>
@@ -50,7 +50,7 @@
 						</span>
 					</div>
 				</div>
-			</div>
+			</section>
 
 			<div class="image-specs-container" data-layout="row" data-layout-align="space-between start" data-layout-wrap>
 				<div class="image-container" data-flex="100" data-flex-gt-xs="75">

--- a/packages/idx/src/property/details.classic.component.less
+++ b/packages/idx/src/property/details.classic.component.less
@@ -302,6 +302,7 @@ stratus-idx-property-details {
           margin: 0 0 1em;
           width: 100%;
           .section-name {
+            display: block;
             color: #222;
             text-transform: uppercase;
             font-size: 13px;

--- a/packages/idx/src/property/details.classic.component.less
+++ b/packages/idx/src/property/details.classic.component.less
@@ -3,8 +3,8 @@ Nothing should be outside 'stratus-idx-property-details' or it will leak into ot
 */
 
 /* FIXME @desktop-only and @phone have been reversed, need to adjust all css */
-@phone: ~"(min-width: 600px)";
-@desktop-only: ~"(max-width: 599px)";
+@phone: ~"(max-width: 599px)";
+@desktop-only: ~"(min-width: 600px)";
 stratus-idx-property-details {
   /* Generic Button */
   .button {
@@ -68,7 +68,7 @@ stratus-idx-property-details {
           font-size: 12px;
           padding-bottom: 22px;
 
-          @media @phone {
+          @media @desktop-only {
             padding-bottom: 30px;
           }
         }
@@ -76,7 +76,7 @@ stratus-idx-property-details {
       .contact-container {
         padding-bottom: 35px;
 
-        @media @phone {
+        @media @desktop-only {
           padding-bottom: 0;
           .button {
             float: right;
@@ -84,7 +84,7 @@ stratus-idx-property-details {
         }
       }
 
-      @media @phone {
+      @media @desktop-only {
         text-align: left;
         margin-bottom: 35px;
       }
@@ -103,7 +103,7 @@ stratus-idx-property-details {
         letter-spacing: 1px;
         margin: 25px auto;
 
-        @media @phone {
+        @media @desktop-only {
           padding: 0;
           margin-top: 0;
           text-align: left;
@@ -125,12 +125,12 @@ stratus-idx-property-details {
           }
         }
 
-        @media @phone {
+        @media @desktop-only {
           padding-left: 25px;
           text-align: left;
         }
 
-        @media @desktop-only {
+        @media @phone {
           background: none;
         }
       }
@@ -191,7 +191,7 @@ stratus-idx-property-details {
         line-height: 2;
         text-align: center;
 
-        @media @phone {
+        @media @desktop-only {
           text-align: left;
         }
       }
@@ -203,13 +203,13 @@ stratus-idx-property-details {
           font-size: 11px;
           text-transform: uppercase;
 
-          @media @phone {
+          @media @desktop-only {
             padding-top: 6px;
             margin-bottom: 9px;
           }
         }
 
-        @media @phone {
+        @media @desktop-only {
           margin: 25px 0;
           padding-bottom: 15px;
           text-align: left;
@@ -222,15 +222,36 @@ stratus-idx-property-details {
           text-align: center;
           margin: 15px 0;
 
-          @media @phone {
+          @media @desktop-only {
             text-align: left;
             margin-bottom: 0;
           }
         }
       }
 
+      @media @desktop-only {
+        margin-top: 0;
+      }
+    }
+
+    /* Listing Credit for Presented By / List Agent */
+    .listing-credit-container {
+      margin-top: 20px;
+      .listing-credit-divider {
+        border-left: 1px solid rgba(0, 0, 0, 0.2);
+      }
+      .listing-credit-title {
+        font-size: 12px;
+        letter-spacing: 2px;
+      }
+      .listing-credit-contact {
+        margin: 0 0 10px 0;
+        font-size: 13px;
+      }
+
       @media @phone {
         margin-top: 0;
+        text-align: center;
       }
     }
 
@@ -304,7 +325,7 @@ stratus-idx-property-details {
         }
       }
 
-      @media @phone {
+      @media @desktop-only {
         text-align: left;
       }
     }

--- a/packages/idx/src/property/details.classic.component.less
+++ b/packages/idx/src/property/details.classic.component.less
@@ -2,7 +2,7 @@
 Nothing should be outside 'stratus-idx-property-details' or it will leak into other modules
 */
 
-/* FIXME @desktop-only and @phone have been reversed, need to adjust all css */
+/* these numbers are based on what angularjs does */
 @phone: ~"(max-width: 599px)";
 @desktop-only: ~"(min-width: 600px)";
 stratus-idx-property-details {

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -292,9 +292,9 @@
                  data-ng-if="model.data.Images && model.data.Images[0]"
                  data-stratus-src-version="{{::(model.data.Images[0].Lazy == 'stratus-src' ? 'best' : 'false')}}"
                  data-stratus-src="{{::model.data.Images[0].MediaURL}}"
-                 aria-label="Background Image of the Listing"
+                 aria-label="Background Image of Listing"
             >
-                <img data-ng-if="model.data.Images && model.data.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="{{::model.data.InternetAddressDisplayYN === false ? 'Address Not Disclosed' : getStreetAddress()}}"/>
+                <img data-ng-if="model.data.Images && model.data.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="Image Shapeholder" aria-hidden="true"/>
                 <img data-ng-if="!model.data.Images" data-ng-src="{{::localDir}}images/no-image-simple.jpg" alt="No Image Available"/>
             </div>
         </div>

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -323,7 +323,7 @@
             <div>
                 <div class="detail-sections">
                     <stratus-idx-property-details-sub-section
-                            ng-model="model"
+                            data-ng-model="model"
                             data-ng-repeat="detail in ::minorDetails"
                             section-name="{{::detail.section}}"
                             items="{{::detail.items | json}}"

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -335,7 +335,7 @@
                          data-ng-if="::getListAgentName() || getCoListAgentName() || getBuyerAgentName() || getCoBuyerAgentName()"
                     >
                         <div class="sub-detail-section" role="region" aria-label="Source Agents">
-                            <div class="section-name">Agent</div>
+                            <strong class="section-name">Agent</strong>
                             <div class="sub-detail" data-ng-if="getListAgentName()" role="text">
                                 <span class="item-label">Listing Agent: </span>
                                 <span data-ng-bind="::getListAgentName()" aria-label="List Agent NAme"></span><span data-ng-if="::model.data.ListAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.ListAgentStateLicense" aria-label="List Agent State License"></span>)</span><span data-ng-if="::model.data.ListAgentKey && !model.data.ListAgentStateLicense"> (Agent # <span data-ng-bind="::model.data.ListAgentKey" aria-label="List Agent MLS Key"></span>)</span><span data-ng-if="::model.data.ListOfficeName">, <span data-ng-bind="::model.data.ListOfficeName" aria-label="List Office Name"></span></span>

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -37,64 +37,64 @@
 
         <div class="about-container details-container static-element">
             <div class="clearfix">
-                <div class="details-left">
+                <section class="details-left" role="region" aria-label="Detail Highlights">
                     <h2>About</h2>
-                    <ul class="details-specs primary_font">
+                    <ul class="details-specs primary_font" aria-label="Detail Highlights">
                         <li>
                             <!-- TODO need a prettier word for the status and a detail of real status -->
-                            <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)" aria-label="Property Status"></span>
+                            <span data-ng-bind="::Idx.getFullStatus(model.data, preferredStatus)" role="text"></span>
                         </li>
-                        <li data-ng-if="::model.data.BedroomsTotal && model.data.BedroomsTotal > 0" aria-label="Number of Bedrooms">
+                        <li data-ng-if="::model.data.BedroomsTotal && model.data.BedroomsTotal > 0" role="text">
                             <span data-ng-bind="::model.data.BedroomsTotal"></span> Beds
                         </li>
                         <li
                                 data-ng-if="::(model.data.BathroomsFull && model.data.BathroomsFull > 0) || (model.data.BathroomsTotalInteger && model.data.BathroomsTotalInteger > 0)"
-                                aria-label="Number of Bathrooms"
+                                role="text"
                         >
                             <span data-ng-bind="::model.data.BathroomsFull || model.data.BathroomsTotalInteger"></span>
                             Baths
                         </li>
-                        <li data-ng-if="::model.data.BathroomsHalf && model.data.BathroomsHalf > 0" aria-label="Number of Half Bathrooms">
+                        <li data-ng-if="::model.data.BathroomsHalf && model.data.BathroomsHalf > 0" role="text">
                             <span data-ng-bind="::model.data.BathroomsHalf"></span> Half Baths
                         </li>
-                        <li data-ng-if="::model.data.BathroomsOneQuarter && model.data.BathroomsOneQuarter > 0" aria-label="Number of Quarter Bathrooms">
+                        <li data-ng-if="::model.data.BathroomsOneQuarter && model.data.BathroomsOneQuarter > 0" role="text">
                             <span data-ng-bind="::model.data.BathroomsOneQuarter"></span> Quarter Baths
                         </li>
-                        <li data-ng-if="::model.data.BathroomsPartial && model.data.BathroomsPartial > 0" aria-label="Number of Partial Bathrooms">
+                        <li data-ng-if="::model.data.BathroomsPartial && model.data.BathroomsPartial > 0" role="text">
                             <span data-ng-bind="::model.data.BathroomsPartial"></span> Partial Baths
                         </li>
-                        <li data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'" aria-label="Date Closed">
+                        <li data-ng-if="::model.data.CloseDate && Idx.getFriendlyStatus(model.data) == 'Closed'" role="text">
                             <span data-ng-bind="::Idx.getFriendlyStatus(model.data, preferredStatus)"></span> on
                             <time data-ng-bind="::model.data.CloseDate | moment:{unix:false,format:'MMM Do YYYY'}" datetime="{{::model.data.CloseDate}}"></time>
                         </li>
-                        <li data-ng-if="::model.data.OnMarketDate" aria-label="Date Listed">
+                        <li data-ng-if="::model.data.OnMarketDate" role="text">
                             Listed on
                             <time data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,format:'MMM Do YYYY'}" datetime="{{::model.data.OnMarketDate}}"></time>
                         </li>
-                        <li data-ng-if="::model.data.CloseDate && model.data.ClosePrice && model.data.ListPrice">
+                        <li data-ng-if="::model.data.CloseDate && model.data.ClosePrice && model.data.ListPrice" role="text">
                             Listed at <span data-ng-bind="'$' + (model.data.ListPrice | number)"></span>
                         </li>
-                        <li data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) === 'Closed' && model.data.CloseDate">
+                        <li data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) === 'Closed' && model.data.CloseDate" role="text">
                             <!-- Closed with start and end Dates. Give number of days between -->
                             Days on Market:
                             <span data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,diff:model.data.CloseDate,duration:'days'}"></span>
                         </li>
-                        <li data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) !== 'Closed'">
+                        <li data-ng-if="::model.data.OnMarketDate && Idx.getFriendlyStatus(model.data) !== 'Closed'" role="text">
                             <!-- Not Closed Yet, Days since open -->
                             Days on Market:
                             <span data-ng-bind="::model.data.OnMarketDate | moment:{unix:false,diff:true,duration:'days'}"></span>
                         </li>
-                        <li data-ng-if="::model.data.DaysOnMarket && !model.data.OnMarketDate">
+                        <li data-ng-if="::model.data.DaysOnMarket && !model.data.OnMarketDate" role="text">
                             <!-- MLS provides DaysOnMarket, but we weren't given a Start time, use MLS provided times (may be inaccurate) -->
                             Days on Market: <span data-ng-bind="::model.data.DaysOnMarket | number"></span>
                         </li>
-                        <li data-ng-if="::model.data.ArchitecturalStyle" aria-label="Architectural Style(s)">
+                        <li data-ng-if="::model.data.ArchitecturalStyle" role="text">
                             Style: <span data-ng-repeat="item in ::model.data.ArchitecturalStyle" class="repeatedArray"><span data-ng-bind="::item"></span><span class="hideLastChild">,&nbsp;</span></span>
                         </li>
-                        <li data-ng-if="::model.data.YearBuilt" aria-label="Year Built">
+                        <li data-ng-if="::model.data.YearBuilt" aria-label="Year Built" role="text">
                             Built in <span data-ng-bind="::model.data.YearBuilt"></span>
                         </li>
-                        <li data-ng-if="::model.data.LivingArea && model.data.LivingArea > 0" aria-label="Living Area Size">
+                        <li data-ng-if="::model.data.LivingArea && model.data.LivingArea > 0" role="text">
                             Living Area:
                             <span data-ng-bind="::model.data.LivingArea | number"></span>
                             <span data-ng-if="::model.data.LivingAreaUnits">
@@ -104,7 +104,7 @@
 								Square Feet
 							</span>
                         </li>
-                        <li data-ng-if="::model.data.LeasableArea && model.data.LeasableArea > 0" aria-label="Leasable Area Size">
+                        <li data-ng-if="::model.data.LeasableArea && model.data.LeasableArea > 0" role="text">
                             Leasable:
                             <span data-ng-bind="::model.data.LeasableArea | number"></span>
                             <span data-ng-if="::model.data.LeasableAreaUnits">
@@ -114,7 +114,7 @@
 								Square Feet
 							</span>
                         </li>
-                        <li data-ng-if="::model.data.BuildingAreaTotal && model.data.BuildingAreaTotal > 0" aria-label="Building Area Size">
+                        <li data-ng-if="::model.data.BuildingAreaTotal && model.data.BuildingAreaTotal > 0" role="text">
                             Building:
                             <span data-ng-bind="::model.data.BuildingAreaTotal | number"></span>
                             <span data-ng-if="::model.data.BuildingAreaUnits">
@@ -124,7 +124,7 @@
 								Square Feet
 							</span>
                         </li>
-                        <li data-ng-if="::model.data.LotSizeArea && model.data.LotSizeArea > 0" aria-label="Lot Size">
+                        <li data-ng-if="::model.data.LotSizeArea && model.data.LotSizeArea > 0" role="text">
                             Lot: <span data-ng-bind="::model.data.LotSizeArea | number"></span>
                             <span data-ng-if="::model.data.LotSizeUnits">
 								<span data-ng-bind="::model.data.LotSizeUnits"></span>
@@ -133,37 +133,37 @@
 								Square Feet
 							</span>
                         </li>
-                        <li data-ng-if="!model.data.LotSizeArea && model.data.LotSizeAcres && model.data.LotSizeAcres > 0" aria-label="Lot Size Acres">
+                        <li data-ng-if="!model.data.LotSizeArea && model.data.LotSizeAcres && model.data.LotSizeAcres > 0" role="text">
                             Lot: <span data-ng-bind="::model.data.LotSizeAcres"></span> Acres
                         </li>
-                        <li data-ng-if="!model.data.LotSizeArea && model.data.LotSizeSquareFeet && model.data.LotSizeSquareFeet > 0" aria-label="Lot Size Square Feet">
+                        <li data-ng-if="!model.data.LotSizeArea && model.data.LotSizeSquareFeet && model.data.LotSizeSquareFeet > 0" role="text">
                             Lot: <span data-ng-bind="::model.data.LotSizeSquareFeet | number"></span> SqFt
                         </li>
                         <li data-ng-if="::model.data.PoolPrivateYN">
                             With Pool
                         </li>
-                        <li data-ng-if="::model.data.Stories && model.data.Stories > 0" aria-label="Number of Stories">
+                        <li data-ng-if="::model.data.Stories && model.data.Stories > 0" role="text">
                             Stories: <span data-ng-bind="::model.data.Stories"></span>
                         </li>
                         <li data-ng-if="::model.data.PropertyType">
-                            <span data-ng-bind="::model.data.PropertyType" aria-label="Property Type"></span>
+                            <span data-ng-bind="::model.data.PropertyType"></span>
                         </li>
-                        <li data-ng-if="::model.data.PropertySubType && model.data.PropertySubType != model.data.PropertyType">
-                            <span data-ng-bind="::model.data.PropertySubType" aria-label="Property Sub Type"></span>
+                        <li data-ng-if="::model.data.PropertySubType && model.data.PropertySubType != model.data.PropertyType" role="text">
+                            <span data-ng-bind="::model.data.PropertySubType"></span>
                         </li>
-                        <li data-ng-if="::!model.data.PropertyType && !model.data.PropertySubType">
-                            <span data-ng-bind="::model.data._Class" aria-label="Property Class (Type)"></span>
+                        <li data-ng-if="::!model.data.PropertyType && !model.data.PropertySubType" role="text">
+                            <span data-ng-bind="::model.data._Class"></span>
                         </li>
-                        <li class="mls-service" data-ng-if="::model.data.ListingId || model.data.ListingKey">
-                            <span data-ng-bind="getMLSName()" aria-label="Providing MLS"></span>#
-                            <span data-ng-bind="::model.data.ListingId || model.data.ListingKey" aria-label="Property MLS Id or Number"></span>
+                        <li class="mls-service" data-ng-if="::model.data.ListingId || model.data.ListingKey" role="text">
+                            <span data-ng-bind="getMLSName()"></span>#
+                            <span data-ng-bind="::model.data.ListingId || model.data.ListingKey"></span>
                         </li>
                     </ul>
 
-                </div>
+                </section>
                 <div class="details-right">
 
-                    <div class="listing-credit-container dotted-spaced-underline" data-ng-if="::Idx.sharedValues.contact.name || getListAgentName()" data-layout="row" data-layout-xs="column" data-layout-align="space-around stretch">
+                    <section class="listing-credit-container dotted-spaced-underline" data-ng-if="::Idx.sharedValues.contact.name || getListAgentName()" role="region" aria-label="Listing Credits" data-layout="row" data-layout-xs="column" data-layout-align="space-around stretch">
                         <div class="presenting-agent-container" data-ng-if="::Idx.sharedValues.contact.name" data-flex data-layout="column" aria-label="Advertising Broker">
                             <h4 class="listing-credit-title">Presented By</h4>
                             <!--p class="listing-credit-contact">Realtor Name | Brokerage Name</p-->
@@ -190,9 +190,9 @@
                                 <a data-ng-href="tel:{{::getListAgentPhone()}}" data-ng-bind="::getListAgentPhone()"></a>
                             </p>
                         </div>
-                    </div>
+                    </section>
 
-                    <div class="list-price font-secondary" data-ng-if="::model.data.ClosePrice || model.data.ListPrice">
+                    <div class="list-price font-secondary" data-ng-if="::model.data.ClosePrice || model.data.ListPrice" role="text">
                         <span class="list-price-label" data-ng-bind="model.data.ClosePrice ? Idx.getFriendlyStatus(model.data, preferredStatus) + ' for' : 'Listed at'"></span>
                         <span class="list-price" data-ng-bind="'$' + (model.data.ClosePrice || model.data.ListPrice | number)" aria-label="Property Price"></span>
                     </div>
@@ -220,9 +220,9 @@
         </div>
 
         <!-- Open Houses -->
-        <div class="open-house-container details-container accent-bg-color static-element"
+        <section class="open-house-container details-container accent-bg-color static-element"
              data-ng-if="model.data.OpenHouses && model.data.OpenHouses.length"
-             aria-label="Open Houses"
+             role="region" aria-label="Open Houses"
         >
             <div class="open-house">
                 <div class="clearfix">
@@ -232,16 +232,16 @@
                             Please join us for an open showing of this property on the following dates:
                         </p>
                     </div>
-                    <div class="details-right">
+                    <div class="details-right" role="list" aria-label="Open Houses">
 
                         <div class="open-house-item"
                              data-ng-repeat="openHouse in model.data.OpenHouses"
                              id="{{'open_house_' + openHouse.OpenHouseKey}}"
+                             role="listitem" aria-label="{{::openHouse.OpenHouseStartTime | moment:{unix:false,format:'dddd MMM Do, h:mm a'}}"
                         >
                             <!-- FIXME Daniela, do we wish to show the Open House descriptions that are possible on each open house? -->
                             <div class="month primary_font"
                                   data-ng-bind="::openHouse.OpenHouseStartTime | moment:{unix:false,format:'MMMM'}"
-                                  aria-label="Open House Month"
                             ></div>
                             <div data-layout-gt-xs="row" data-layout-align-gt-xs="space-between center">
                                 <div class="primary_font" data-layout="row" data-layout-align="space-between center">
@@ -251,13 +251,13 @@
                                         <span data-ng-if="::openHouse.OpenHouseEndTime"> —
                                             <time data-ng-bind="::openHouse.OpenHouseEndTime | moment:{unix:false,format:'h:mm a'}" datetime="{{::openHouse.OpenHouseEndTime}}"></time>
                                         </span>
-                                        <span data-ng-if="::openHouse.OpenHouseStatus && openHouse.OpenHouseStatus !== 'Active'"> (<span data-ng-bind="::openHouse.OpenHouseStatus" aria-label="Open House Status"></span>)</span>
+                                        <span data-ng-if="::openHouse.OpenHouseStatus && openHouse.OpenHouseStatus !== 'Active'" role="text"> (<span data-ng-bind="::openHouse.OpenHouseStatus"></span>)</span>
                                         <br/>
                                         <!-- openHouse._unmapped.OpenHouseType && openHouse._unmapped.OpenHouseType === 'Virtual' -->
-                                        <span data-ng-if="::openHouse._unmapped.VirtualOpenHouseURL" aria-label="Virtual Open House">
+                                        <span data-ng-if="::openHouse._unmapped.VirtualOpenHouseURL">
                                             <a data-ng-href="{{::openHouse._unmapped.VirtualOpenHouseURL}}" target="_blank" data-ng-bind="::(openHouse._unmapped.VirtualOpenHouseURLLinkText || 'Virtual Open House')" aria-label="Open House Virtual Tour Link"></a>
                                         </span>
-                                        <span data-ng-if="::openHouse.ShowingAgentFirstName" aria-label="Open House Shown by Agent">
+                                        <span data-ng-if="::openHouse.ShowingAgentFirstName" role="text">
                                             with <span data-ng-bind="::openHouse.ShowingAgentFirstName"></span> <span data-ng-bind="::openHouse.ShowingAgentLastName"></span>
                                         </span>
                                     </div>
@@ -273,7 +273,7 @@
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
 
         <!-- This needs to display the second image in the slideshow or maybe the last image? -->
         <!-- parallax-element disabled, cannot use height altering on the entire widget -->
@@ -281,7 +281,7 @@
             <!-- TODO MLSL requires listrac: data-ng-click="return cms.obj.listtrac.track('lead');"-->
             <a class="btn btn-alt btn-contact" data-ng-show="::contactUrl || Idx.sharedValues.contactUrl"
                target="_blank" data-ng-href="{{::contactUrl || Idx.sharedValues.contactUrl}}{{(Idx.sharedValues.contactCommentVariable ? '?' + Idx.sharedValues.contactCommentVariable + '=' + getFullAddress(true) : '')}}"
-               aria-label="Contact Website Agent Link"
+               aria-label="Website Contact"
             >
                 Contact
             </a>
@@ -315,7 +315,7 @@
         </div>
 
 
-        <div class="additional-details details-container static-element">
+        <section class="additional-details details-container static-element" role="region" aria-label="Additional Details">
             <h2 class="dotted-spaced-underline">More</h2>
             <!-- TODO Missing quite a number of minor details -->
             <!-- TODO Wishlist, would love to replace sections with Masonry ability https://passy.github.io/angular-masonry/ -->
@@ -334,21 +334,21 @@
                     <div class="property-details-sub-section"
                          data-ng-if="::getListAgentName() || getCoListAgentName() || getBuyerAgentName() || getCoBuyerAgentName()"
                     >
-                        <div class="sub-detail-section">
+                        <div class="sub-detail-section" role="region" aria-label="Source Agents">
                             <div class="section-name">Agent</div>
-                            <div class="sub-detail" data-ng-if="getListAgentName()">
+                            <div class="sub-detail" data-ng-if="getListAgentName()" role="text">
                                 <span class="item-label">Listing Agent: </span>
                                 <span data-ng-bind="::getListAgentName()" aria-label="List Agent NAme"></span><span data-ng-if="::model.data.ListAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.ListAgentStateLicense" aria-label="List Agent State License"></span>)</span><span data-ng-if="::model.data.ListAgentKey && !model.data.ListAgentStateLicense"> (Agent # <span data-ng-bind="::model.data.ListAgentKey" aria-label="List Agent MLS Key"></span>)</span><span data-ng-if="::model.data.ListOfficeName">, <span data-ng-bind="::model.data.ListOfficeName" aria-label="List Office Name"></span></span>
                             </div>
-                            <div class="sub-detail" data-ng-if="getCoListAgentName()">
+                            <div class="sub-detail" data-ng-if="getCoListAgentName()" role="text">
                                 <span class="item-label">Co-Listing Agent: </span>
                                 <span data-ng-bind="::getCoListAgentName()" aria-label="CoList Agent Name"></span><span data-ng-if="::model.data.CoListAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.CoListAgentStateLicense" aria-label="CoList Agent State License"></span>)</span><span data-ng-if="::model.data.CoListAgentKey && !model.data.CoListAgentStateLicense"> (Agent # <span data-ng-bind="::model.data.CoListAgentKey" aria-label="CoList Agent MLS Key"></span>)</span><span data-ng-if="::model.data.CoListOfficeName">, <span data-ng-bind="::model.data.CoListOfficeName" aria-label="CoList Office Name"></span></span>
                             </div>
-                            <div class="sub-detail" data-ng-if="getBuyerAgentName()">
+                            <div class="sub-detail" data-ng-if="getBuyerAgentName()" role="text">
                                 <span class="item-label">Buyer Agent: </span>
                                 <span data-ng-bind="::getBuyerAgentName()" aria-label="Buyer Agent Name"></span><span data-ng-if="::model.data.BuyerAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.BuyerAgentStateLicense" aria-label="Buyer Agent State License"></span>)</span><span data-ng-if="::model.data.BuyerAgentKey && !model.data.BuyerAgentStateLicense"> (Agent # <span data-ng-bind="::model.data.BuyerAgentKey" aria-label="Buyer Agent MLS Key"></span>)</span><span data-ng-if="::model.data.BuyerOfficeName">, <span data-ng-bind="::model.data.BuyerOfficeName" aria-label="Buyer Office Name"></span></span>
                             </div>
-                            <div class="sub-detail" data-ng-if="getCoBuyerAgentName()">
+                            <div class="sub-detail" data-ng-if="getCoBuyerAgentName()" role="text">
                                 <span class="item-label">Co-Buyer Agent: </span>
                                 <span data-ng-bind="::getCoBuyerAgentName()" aria-label="CoBuyer Agent Name"></span><span data-ng-if="::model.data.CoBuyerAgentStateLicense"> (DRE# <span data-ng-bind="::model.data.CoBuyerAgentStateLicense" aria-label="CoBuyer Agent State License"></span>)</span><span data-ng-if="::model.data.CoBuyerAgentKey && !model.data.CoBuyerAgentStateLicense"> (Agent # <span data-ng-bind="::model.data.CoBuyerAgentKey" aria-label="CoBuyer Agent MLS Key"></span>)</span><span data-ng-if="::model.data.CoBuyerOfficeName">, <span data-ng-bind="::model.data.CoBuyerOfficeName" aria-label="CoBuyer Office Name"></span></span>
                             </div>
@@ -357,46 +357,24 @@
 
                 </div>
             </div>
-
-            <!-- Real Additional Details
-            <div class="agent-section">
-                <div class="agent underline-top" data-ng-if="getListAgentName()">
-                    <strong>Listing Agent: </strong>
-                    <span data-ng-bind="::getListAgentName()"></span><span data-ng-if="::model.data.ListOfficeName">, <span data-ng-bind="::model.data.ListOfficeName"></span></span>
-                </div>
-                <div class="agent dotted-spaced-underline underline-top" data-ng-if="getCoListAgentName()">
-                    <strong>Co-Listing Agent: </strong>
-                    <span data-ng-bind="::getCoListAgentName()"></span><span data-ng-if="::model.data.CoListOfficeName">, <span data-ng-bind="::model.data.CoListOfficeName"></span></span>
-                </div>
-                <div class="agent dotted-spaced-underline underline-top" data-ng-if="getBuyerAgentName()">
-                    <strong>Buyer Agent: </strong>
-                    <span data-ng-bind="::getBuyerAgentName()"></span><span data-ng-if="::model.data.BuyerOfficeName">, <span data-ng-bind="::model.data.BuyerOfficeName"></span></span>
-                </div>
-                <div class="agent dotted-spaced-underline underline-top" data-ng-if="getCoBuyerAgentName()">
-                    <strong>Co-Buyer Agent: </strong>
-                    <span data-ng-bind="::getCoBuyerAgentName()"></span><span data-ng-if="::model.data.CoBuyerOfficeName">, <span data-ng-bind="::model.data.CoBuyerOfficeName"></span></span>
-                </div>
-            </div>-->
-
-
-        </div>
+        </section>
 
         <!-- Contact Area -->
-        <div class="contact-container details-container static-element"
-             data-ng-show="::contact || Idx.sharedValues.contact"
+        <section class="contact-container details-container static-element"
+                 data-ng-show="::contact || Idx.sharedValues.contact"
+                 role="region" aria-label="Website Contact"
         >
             <h2>Contact</h2>
-
-            <h4 class="site-name" data-ng-show="::contact.name || (Idx.sharedValues.contact && Idx.sharedValues.contact.name)" data-ng-bind="::contact.name || Idx.sharedValues.contact.name" aria-label="Site Name"></h4>
+            <h4 class="site-name" data-ng-show="::contact.name || (Idx.sharedValues.contact && Idx.sharedValues.contact.name)" data-ng-bind="::contact.name || Idx.sharedValues.contact.name"></h4>
 
             <p class="phone" data-ng-show="(contact.phones && contact.phones.Main) || (Idx.sharedValues.contact.phones && Idx.sharedValues.contact.phones.Main)">
-                <a data-ng-href="tel:{{::contact.phones.Main || Idx.sharedValues.contact.phones.Main}}" data-ng-bind="::contact.phones.Main || Idx.sharedValues.contact.phones.Main" aria-label="Site Phone Contact"></a>
+                <a data-ng-href="tel:{{::contact.phones.Main || Idx.sharedValues.contact.phones.Main}}" data-ng-bind="::contact.phones.Main || Idx.sharedValues.contact.phones.Main"></a>
             </p>
             <p class="email" data-ng-show="(contact.emails && contact.emails.Main) || (Idx.sharedValues.contact.emails && Idx.sharedValues.contact.emails.Main)">
-                <a data-ng-href="mailto:{{::contact.emails.Main || Idx.sharedValues.contact.emails.Main}}" data-ng-bind="::contact.emails.Main || Idx.sharedValues.contact.emails.Main" target="_blank" aria-label="Site Emal Contact"></a>
+                <a data-ng-href="mailto:{{::contact.emails.Main || Idx.sharedValues.contact.emails.Main}}" data-ng-bind="::contact.emails.Main || Idx.sharedValues.contact.emails.Main" target="_blank" aria-label="Website Email Contact"></a>
             </p>
 
-        </div>
+        </section>
 
         <div class="disclaimer-container details-container static-element">
             <stratus-idx-disclaimer

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -162,6 +162,36 @@
 
                 </div>
                 <div class="details-right">
+
+                    <div class="listing-credit-container dotted-spaced-underline" data-ng-if="::Idx.sharedValues.contact.name || getListAgentName()" data-layout="row" data-layout-xs="column" data-layout-align="space-around stretch">
+                        <div class="presenting-agent-container" data-ng-if="::Idx.sharedValues.contact.name" data-flex data-layout="column" aria-label="Advertising Broker">
+                            <h4 class="listing-credit-title">Presented By</h4>
+                            <!--p class="listing-credit-contact">Realtor Name | Brokerage Name</p-->
+                            <p class="listing-credit-contact" data-ng-bind="::Idx.sharedValues.contact.name"></p>
+                            <p class="listing-credit-contact" data-ng-if="::Idx.sharedValues.contact.emails && Idx.sharedValues.contact.emails.Main" aria-label="Advertising Broker Contact">
+                                <!--a href="mailto:email@address.com">email@address.com</a-->
+                                <a data-ng-href="mailto:{{::Idx.sharedValues.contact.emails.Main}}" target="_blank" data-ng-bind="::Idx.sharedValues.contact.emails.Main"></a>
+                            </p>
+                            <p class="listing-credit-contact" data-ng-if="::(Idx.sharedValues.contact.phones && Idx.sharedValues.contact.phones.Main) && !(Idx.sharedValues.contact.emails && Idx.sharedValues.contact.emails.Main)" aria-label="Advertising Broker Contact">
+                                <a data-ng-href="tel:{{::Idx.sharedValues.contact.phones.Main}}" data-ng-bind="::Idx.sharedValues.contact.phones.Main"></a>
+                            </p>
+                        </div>
+                        <div class="listing-credit-divider" data-ng-if="getListAgentName() && Idx.sharedValues.contact.name" data-flex="10" data-hide-xs></div>
+                        <div class="listing-agent-container" data-ng-if="getListAgentName()" data-flex data-layout="column" aria-label="Listing Broker">
+                            <h4 class="listing-credit-title">Listing Agent</h4>
+                            <p class="listing-credit-contact">
+                                <span data-ng-bind="::getListAgentName()"></span> | <span data-ng-bind="::model.data.ListOfficeName"></span>
+                            </p>
+                            <p class="listing-credit-contact" data-ng-if="model.data.ListAgentEmail" aria-label="Listing Broker Contact">
+                                <!--a href="mailto:email@address.com">email@address.com</a-->
+                                <a data-ng-href="mailto:{{::model.data.ListAgentEmail}}" target="_blank" data-ng-bind="::model.data.ListAgentEmail"></a>
+                            </p>
+                            <p class="listing-credit-contact" data-ng-if="getListAgentPhone() && !model.data.ListAgentEmail" aria-label="Listing Broker Contact">
+                                <a data-ng-href="tel:{{::getListAgentPhone()}}" data-ng-bind="::getListAgentPhone()"></a>
+                            </p>
+                        </div>
+                    </div>
+
                     <div class="list-price font-secondary" data-ng-if="::model.data.ClosePrice || model.data.ListPrice">
                         <span class="list-price-label" data-ng-bind="model.data.ClosePrice ? Idx.getFriendlyStatus(model.data, preferredStatus) + ' for' : 'Listed at'"></span>
                         <span class="list-price" data-ng-bind="'$' + (model.data.ClosePrice || model.data.ListPrice | number)" aria-label="Property Price"></span>

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -309,7 +309,7 @@
                     data-map-type="roadmap"
             ></sa-map>
         </div-->
-        <div class="map-location details-container static-element" data-ng-if="::getGoogleMapEmbed()" aria-label="Google Maps Display">
+        <div class="map-location details-container static-element" data-ng-if="::getGoogleMapEmbed()" role="presentation" aria-label="Google Maps Display">
             <h2 class="dotted-spaced-underline">Location</h2>
             <iframe data-ng-src="{{::getGoogleMapEmbed()}}" class="google-map-embed"></iframe>
         </div>

--- a/packages/idx/src/property/details.component.less
+++ b/packages/idx/src/property/details.component.less
@@ -446,6 +446,7 @@ stratus-idx-property-details {
             margin: 0 0 40px;
             width: 100%;
             .section-name {
+              display: block;
               margin: 0 0 12px;
               font-size: 12px;
               font-weight: bold;

--- a/packages/idx/src/property/details.component.less
+++ b/packages/idx/src/property/details.component.less
@@ -7,6 +7,8 @@ z-index can cause a bleeding effect on popups (z-index 100 equates to the top mo
 @desktop-only: ~"(min-width: 600px)";
 stratus-idx-property-details {
   position: relative;
+  line-height: 1.5;
+  font-size: 15px;
   md-progress-circular {
     margin: 30px auto;
     path,

--- a/packages/idx/src/property/details.component.less
+++ b/packages/idx/src/property/details.component.less
@@ -3,7 +3,7 @@ Nothing should be outside 'stratus-idx-property-details' or it will leak into ot
 z-index can cause a bleeding effect on popups (z-index 100 equates to the top most item for angular, use the lowest number possible and work up)
 */
 @tablet: ~"(max-width: 959px)";
-@phone: ~"(max-width: 600px)";
+@phone: ~"(max-width: 599px)";
 @desktop-only: ~"(min-width: 600px)";
 stratus-idx-property-details {
   position: relative;
@@ -166,9 +166,33 @@ stratus-idx-property-details {
         width: 67%;
       }
     }
+
+    /* Listing Credit for Presented By / List Agent */
+    .listing-credit-container {
+      padding-bottom: 40px;
+      margin-bottom: 40px;
+      .listing-credit-divider {
+        border-left: 1px solid rgba(0, 0, 0, 0.2);
+      }
+      .listing-credit-title {
+        font-size: 13px;
+        letter-spacing: 2px;
+        margin: 0 0 5px 0;
+
+        @media @phone {
+          margin-top: 30px;
+        }
+      }
+      .listing-credit-contact {
+        margin: 10px 0 0 0;
+        font-size: 16px;
+      }
+    }
+
+    /* Standard Sections */
     .list-price {
       margin: 0 0 50px;
-      font-size: 16px;
+      font-size: 20px;
       font-weight: bold;
       color: #1d1d1d;
       text-transform: uppercase;

--- a/packages/idx/src/property/details.component.ts
+++ b/packages/idx/src/property/details.component.ts
@@ -1386,6 +1386,8 @@ Stratus.Components.IdxPropertyDetails = {
         $scope.getListAgentName = (): string => $scope.model.data.ListAgentFullName || ($scope.model.data.ListAgentFirstName ?
             $scope.model.data.ListAgentFirstName + ' ' + $scope.model.data.ListAgentLastName : null)
 
+        $scope.getListAgentPhone = (): string => $scope.model.data.ListAgentDirectPhone || $scope.model.data.ListAgentOfficePhone || null
+
         $scope.getCoListAgentName = (): string => $scope.model.data.CoListAgentFullName || ($scope.model.data.CoListAgentFirstName ?
             $scope.model.data.CoListAgentFirstName + ' ' + $scope.model.data.CoListAgentLastName : null)
 

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -4,7 +4,7 @@
         <div class="header-section clearfix" data-ng-if="displayOrderOptions">
             <div class="sort-options-container" data-ng-if="collection.meta.data.totalRecords">
                 <md-menu data-md-position-mode="target-right target" data-md-offset="0 30">
-                    <div class=" options-button" data-ng-click="$mdMenu.open()" aria-label="Sort Options">
+                    <div class=" options-button" data-ng-click="$mdMenu.open()" aria-label="Sort Options - {{getOrderName()}}">
                         <i class="arrow small down grey"></i> <span class="options-name"><a href="" data-ng-bind="getOrderName() || 'Sort Options'"></a></span>
                     </div>
                     <md-menu-content data-ng-click="$mdMenu.close()">
@@ -20,94 +20,100 @@
         <div data-ng-show="collection.completed && !collection.pending && collection.models.length === 0" class="no-results">
             We didn't find any properties that fit your criteria.<span> You might want to try a broader search.</span>
         </div>
-        <div data-ng-show="collection.completed && !collection.pending && collection.models.length > 0"
-             class="list-container clearfix"
-             data-ng-class="displayPerRowText + '-per-row'"
-        >
-            <div data-ng-repeat="property in collection.models | limitTo:query.perPage:(query.page-1)*query.perPage" id="{{::elementId}}_{{::property._id}}"
-                 class="property-container" aria-labelledby="{{::elementId}}_{{::property._id}}_address" data-ng-cloak
+        <section role="region" aria-label="Property Results List">
+            <div data-ng-show="collection.completed && !collection.pending && collection.models.length > 0"
+                 class="list-container clearfix"
+                 data-ng-class="displayPerRowText + '-per-row'"
+                 role="list"
+                 aria-label="Property Results"
+                 aria-live="polite"
             >
-                <md-card class="property-item" data-ng-class="{highlight: property._unmapped._highlight}">
-                    <div class="property-image">
-                        <div class="property-status font-body" data-ng-bind="::Idx.getFriendlyStatus(property, preferredStatus)" aria-label="Property Status"></div>
-                        <div class="button btn" data-ng-href="{{::getDetailsURL(property)}}">
-                            Details
-                        </div>
-                        <a data-ng-click="displayModelDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}" target="popup">
-                            <div class="image-wrapper"
-                                 data-stratus-src-version="{{::(property.Images[0].Lazy == 'stratus-src' ? 'best' : 'false')}}"
-                                 data-stratus-src="{{::property.Images[0].MediaURL}}"
-                                 aria-label="Main Image of Listing"
-                            >
-                                <img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="Image Shapeholder" aria-hidden="true" />
-                                <img data-ng-if="::property.Images.length === 0 || !property.Images" data-ng-src="{{::localDir}}images/no-image.jpg" alt="No Main Image Available"/>
+                <div data-ng-repeat="property in collection.models | limitTo:query.perPage:(query.page-1)*query.perPage" id="{{::elementId}}_{{::property._id}}"
+                     class="property-container" aria-labelledby="{{::elementId}}_{{::property._id}}_address"
+                     role="listitem" data-ng-cloak
+                >
+                    <md-card class="property-item" data-ng-class="{highlight: property._unmapped._highlight}">
+                        <div class="property-image">
+                            <div class="property-status font-body" data-ng-bind="::Idx.getFriendlyStatus(property, preferredStatus)"></div>
+                            <!-- This button is hidden in the CSS -->
+                            <div class="button btn" data-ng-href="{{::getDetailsURL(property)}}" aria-hidden="true">
+                                Details
                             </div>
-                        </a>
-                    </div>
-                    <div class="property-content">
-                        <div class="property-address dotted-spaced-underline">
-                            <div aria-label="Address" id="{{::elementId}}_{{::property._id}}_address">
-                                <h4>
-                                    <a data-ng-click="displayModelDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}" data-ng-bind="::getStreetAddress(property)" aria-label="Street Address" target="popup"></a>
-                                    <br/>
-                                    <span class="city" data-ng-bind="::property.City" aria-label="City"></span>
-                                </h4>
-                            </div>
+                            <a data-ng-click="displayModelDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}" target="popup">
+                                <div class="image-wrapper"
+                                     data-stratus-src-version="{{::(property.Images[0].Lazy == 'stratus-src' ? 'best' : 'false')}}"
+                                     data-stratus-src="{{::property.Images[0].MediaURL}}"
+                                     aria-label="Main Image of Listing"
+                                >
+                                    <img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="Image Shapeholder" aria-hidden="true" />
+                                    <img data-ng-if="::property.Images.length === 0 || !property.Images" data-ng-src="{{::localDir}}images/no-image.jpg" alt="No Main Image Available"/>
+                                </div>
+                            </a>
                         </div>
-                        <div class="property-data">
-                            <div class="property-type font-body">
-                                <span data-ng-if="::property.BedroomsTotal > 0" aria-label="Number of Beds">
-                                    <span data-ng-bind="::property.BedroomsTotal"></span> Beds
-                                </span>
-                                <span data-ng-if="::property.BathroomsFull > 0 || property.BathroomsTotalInteger > 0" aria-label="Number of Bathrooms">
-                                    <span data-ng-bind="::property.BathroomsFull || property.BathroomsTotalInteger"></span><span data-ng-if="::property.BathroomsHalf || property.BathroomsOneQuarter || property.BathroomsPartial">+</span>
-                                    Baths
+                        <div class="property-content">
+                            <div class="property-address dotted-spaced-underline">
+                                <div id="{{::elementId}}_{{::property._id}}_address" role="text">
+                                    <h4>
+                                        <a data-ng-click="displayModelDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}" data-ng-bind="::getStreetAddress(property)" target="popup"></a>
+                                        <br/>
+                                        <span class="city" data-ng-bind="::property.City"></span>
+                                    </h4>
+                                </div>
+                            </div>
+                            <div class="property-data">
+                                <div class="property-type font-body">
+                                    <span data-ng-if="::property.BedroomsTotal > 0" role="text">
+                                        <span data-ng-bind="::property.BedroomsTotal"></span> Beds
                                     </span>
-                                <span data-ng-bind="::property.PropertySubType || property.PropertyType || property._Class" aria-label="Property Type"></span>
-                                <span class="property-price" data-ng-if="::property.ClosePrice || property.ListPrice" aria-label="Price">
-                                    $<span data-ng-bind="::property.ClosePrice || property.ListPrice | number"></span>
-                                </span>
+                                    <span data-ng-if="::property.BathroomsFull > 0 || property.BathroomsTotalInteger > 0" role="text">
+                                        <span data-ng-bind="::property.BathroomsFull || property.BathroomsTotalInteger"></span><span data-ng-if="::property.BathroomsHalf || property.BathroomsOneQuarter || property.BathroomsPartial">+</span>
+                                        Baths
+                                        </span>
+                                    <span data-ng-bind="::property.PropertySubType || property.PropertyType || property._Class"></span>
+                                    <span class="property-price" data-ng-if="::property.ClosePrice || property.ListPrice" role="text">
+                                        $<span data-ng-bind="::property.ClosePrice || property.ListPrice | number"></span>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="mls-service-name" role="text">
+                                <span data-ng-bind="::getMLSName(property._ServiceId)"></span>#
+                                <span data-ng-bind="::property.ListingId || property.ListingKey"></span>
                             </div>
                         </div>
-                        <!--<md-card-icon-actions>-->
-                        <!--<div class="property-button-container">-->
-                        <!--<md-button class="button btn" data-ng-click="displayModelDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}">-->
-                        <!--Details-->
-                        <!--</md-button>-->
-                        <!--</div>-->
-                        <!--</md-card-icon-actions>-->
-                        <div class="mls-service-name" aria-label="MLS Number">
-                            <span data-ng-bind="::getMLSName(property._ServiceId)"></span>#
-                            <span data-ng-bind="::property.ListingId || property.ListingKey"></span>
-                        </div>
-                    </div>
-                </md-card>
+                    </md-card>
+                </div>
             </div>
-        </div>
+        </section>
         <div class="pager-container clearfix" data-ng-if="displayPager && collection.meta.data.totalPages >= 2">
-            <div class="pager-section">
+            <nav class="pager-section" role="navigation" aria-label="Property List Nav">
                 <div class="pager-count" data-ng-if="collection.meta.data.totalRecords">
-                    <span data-ng-bind="query.page"></span>/<span data-ng-bind="collection.meta.data.totalPages"></span>
+                    <span data-ng-bind="query.page" aria-current="page" aria-live=polite></span>/<span data-ng-bind="collection.meta.data.totalPages"></span>
                     Pages
                     <span class="pager-totals">
                     (
                         <!--<span data-ng-bind="(query.page-1)*query.perPage+1"></span>-<span data-ng-bind="(query.page*query.perPage)|min:collection.meta.data.totalRecords"></span> of --><span data-ng-bind="collection.meta.data.totalRecords"></span> properties )
                     </span>
                 </div>
-                <a class="pager-button {{query.page > 1 && collection.completed ? '' : 'disabled'}}" data-ng-click="pagePrevious($event)" aria-label="Previous Page">
+                <a class="pager-button {{query.page > 1 && collection.completed ? '' : 'disabled'}}"
+                   data-ng-disabled="!(query.page > 1 && collection.completed)"
+                   data-ng-click="pagePrevious($event)" aria-label="Previous Page"
+                >
                     <i class="arrow small left"></i>
                 </a>
-                <a class="pager-button {{query.page < collection.meta.data.totalPages && collection.completed ? '' : 'disabled'}}" data-ng-click="pageNext($event)" aria-label="Next Page">
+                <md-button class="pager-button {{query.page < collection.meta.data.totalPages && collection.completed ? '' : 'disabled'}}"
+                   data-ng-disabled="!(query.page < collection.meta.data.totalPages && collection.completed)"
+                   data-ng-click="pageNext($event)" aria-label="Next Page"
+                >
                     <i class="arrow small right"></i>
-                </a>
-                <div class="search-more-filters advanced-search-link" data-ng-if="advancedSearchUrl">
+                </md-button>
+                <md-button class="search-more-filters advanced-search-link" data-ng-if="advancedSearchUrl">
                     <a class="open-filters-link"
                        data-ng-href="{{ advancedSearchUrl }}">
                         <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/filters.svg' }}"></md-icon>
                         <span class="btn-text"><span data-ng-bind="advancedSearchLinkName"></span></span>
                     </a>
-                </div>
-            </div>
+                </md-button>
+            </nav>
 
         </div>
         <stratus-idx-disclaimer data-init-now="collection.completed" data-hide-on-duplicate="{{hideDisclaimer}}"></stratus-idx-disclaimer>

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -37,9 +37,10 @@
                             <div class="image-wrapper"
                                  data-stratus-src-version="{{::(property.Images[0].Lazy == 'stratus-src' ? 'best' : 'false')}}"
                                  data-stratus-src="{{::property.Images[0].MediaURL}}"
+                                 aria-label="Main Image of Listing"
                             >
-                                <img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="shapeholder"/>
-                                <img data-ng-if="::property.Images.length === 0 || !property.Images" data-ng-src="{{::localDir}}images/no-image.jpg"/>
+                                <img data-ng-if="::property.Images.length > 0" data-ng-src="{{::localDir}}images/stratus-property-shapeholder.png" alt="Image Shapeholder" aria-hidden="true" />
+                                <img data-ng-if="::property.Images.length === 0 || !property.Images" data-ng-src="{{::localDir}}images/no-image.jpg" alt="No Main Image Available"/>
                             </div>
                         </a>
                     </div>

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -414,7 +414,8 @@ stratus-idx-property-list {
         }
       }
       .pager-button {
-        margin-right: 5px;
+        margin: 0 5px 0 0;
+        min-width: 0;
         float: left;
         border: 1px solid rgba(0, 0, 0, 0.2);
         padding: 14px;

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -482,8 +482,8 @@ stratus-idx-property-list {
     -webkit-transition: all 0.2s ease-out;
     position: fixed;
     z-index: 2;
-    top: 5%;
-    right: 5%;
+    top: 2%;
+    right: 2%;
     padding: 6px;
     background: transparent;
     border-radius: 50%;

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -915,7 +915,7 @@ Stratus.Components.IdxPropertyList = {
                 }
 
                 let template =
-                    `<md-dialog aria-label="${model.ListingKey}" class="stratus-idx-property-list-dialog">` +
+                    `<md-dialog class="stratus-idx-property-list-dialog" aria-label="${$scope.getStreetAddress(model)} Details">` +
                     `<div class="popup-close-button-container">` +
                     `<div aria-label="Close Popup" class="close-button" data-ng-click="closePopup()" aria-label="Close Details Popup"></div>` +
                     `</div>` +

--- a/packages/idx/src/property/search.classic.component.html
+++ b/packages/idx/src/property/search.classic.component.html
@@ -1,4 +1,4 @@
-<div id="{{elementId}}" class="search-mini font-primary" data-ng-cloak>
+<div id="{{elementId}}" class="search-mini font-primary" role="search" aria-label="Property" data-ng-cloak>
     <div class="search-row">
         <h2 data-ng-show="widgetName" data-ng-bind="widgetName"></h2>
         <div class="search-input">
@@ -170,7 +170,7 @@
                     </div>
 
                     <!-- Only Include if these were preset in a Property Filter pages and we need the ability to remove them -->
-                    <div ng-if="options.query.where.City.length || options.query.where.MLSAreaMajor.length || options.PostalCode.length">
+                    <div data-ng-if="options.query.where.City.length || options.query.where.MLSAreaMajor.length || options.PostalCode.length">
                         <div class="sale-status-border dotted-spaced-underline"></div>
                         <h3 data-layout-align="space-around center">Preset Filters</h3>
                         <div class="specific-filters" data-layout="row" data-layout-align="space-around center" aria-label="Specific Areas">
@@ -234,20 +234,23 @@
                     <div class="sale-status-border dotted-spaced-underline"></div>
 
                     <div data-layout="row" data-layout-align="space-around center">
-                        <a class="btn" data-ng-click="search();filterMenu.close();">Search</a>
+                        <a class="btn" data-ng-click="search();filterMenu.close();" aria-label="Search Submission">Search</a>
                     </div>
 
                 </div>
             </div>
         </div>
 
-        <a class="open-filters" ng-click="showInlinePopup($event, '.stratus-idx-property-search-menu')">
+        <a
+                class="open-filters" data-ng-click="showInlinePopup($event, '.stratus-idx-property-search-menu')"
+                aria-label="Open Additional Search Options"
+        >
         Advanced Filters
         </a>
 
     </div>
 
     <div class="search-row" data-layout="row" data-layout-align="space-around center">
-        <a class="btn btn-submit" data-ng-click="search()">Search Now</a>
+        <a class="btn btn-submit" data-ng-click="search()" aria-label="Search Submission">Search Now</a>
     </div>
 </div>

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -1,7 +1,7 @@
 
 <div id="{{elementId}}"
      class="idx-search-component search-full"
-     data-ng-cloak
+     role="search" aria-label="Property" data-ng-cloak
 >
     <h2 data-ng-show="widgetName" data-ng-bind="widgetName"></h2>
     <!-- div class="search-header">


### PR DESCRIPTION
## @stratusjs/idx [0.14.0]
published for pre-release
### Added
- Added required Listing Credit to the top of `details`
- Added required Listing Credit to the top of `details.classic`
- Added now unused `getWebsiteMainContact()` to `IDX` service for quick reference
- Added basic Accessibility to common idx widgets
- - Updated image shapeholders
- - ADA added to property/`details-sub-section`
- - ADA added to property `search` / `search.classic` (just simple items, needs more testing)
- - ADA added to property/`list`
- - - Pagination fixes
- - - Dialog popups labels
- - - Listed property items
- - ADA compatibility and navigation added to property `details` / `details.classic`
- - - `details.classic` given missing contact variables and functionality from modern versions
- - ADA added to property/`disclaimer`

### Changed
- Fix `contact` variable checks on the initial token fetch
- Moved the details popup close button to be close to edge to not overlap the content
- property/`details` given standardized font styles to keep compatible on all systems deployed
- added `data-` additions to non-standard attributes such as `ng` directives

### TODO
- property/`details.classic` may need some alignment work with Listing Credits
- property/details-sub-section `aria-labelby` needs to be replaced with `aria-label` as is not compatible with all screen readers

As we were informed of a new regulation on Oct 28th with CRMLS regulations and likely soon be every where, a "Presented by"  / "Listing Agent" section has been added towards top of Details pages.
`details`
![details](https://user-images.githubusercontent.com/626727/141032450-fa8c3a34-18c9-493d-a230-349ffd5d42a8.png)
`details.classic`
![details classic](https://user-images.githubusercontent.com/626727/141032457-093dfbd0-4566-42a5-b640-c78a71f8a719.png)


