### PR TITLE
Fix  swiper and idx dependency issues

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {
@@ -30,11 +30,11 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angular": "^0.2.88",
-    "@stratusjs/angularjs": "^0.2.54",
+    "@stratusjs/angular": "^0.2.89",
+    "@stratusjs/angularjs": "^0.2.56",
     "@stratusjs/angularjs-extras": "^0.8.3",
     "@stratusjs/map": "^0.4.1",
     "@stratusjs/runtime": "^0.11.9",
-    "@stratusjs/swiper": "^0.1.8"
+    "@stratusjs/swiper": "^0.1.9"
   }
 }

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/map",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Angular Google Map component to be used as an add-on to StratusJS",
   "main": "",
   "scripts": {
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "@angular/google-maps": "^11.0.3",
-    "@stratusjs/angular": "^0.2.59"
+    "@stratusjs/angular": "^0.2.89"
   }
 }

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {
@@ -28,9 +28,9 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.2.11",
-    "@stratusjs/angularjs-extras": "^0.3.0",
-    "@stratusjs/runtime": "^0.10.3",
+    "@stratusjs/angularjs": "^0.2.56",
+    "@stratusjs/angularjs-extras": "^0.8.3",
+    "@stratusjs/runtime": "^0.11.9",
     "swiper": "^5.2.1"
   }
 }


### PR DESCRIPTION
### @stratusjs/swiper 0.1.9 published
### @stratusjs/idx 0.14.1 published
### @stratusjs/map 0.4.2 published

Changes:

- Updates dependencies of swiper and idx to prevent old @stratusjs modules from installing (e.g. this was force installing @stratusjs/angularjs-extras 0.3.0 installing its now incompatible modules)
- Updates map to latest stratus dependencies