### PR TITLE
@stratusjs/swiper 1.1.0 Swiper upgraded to 7.3.1

### DIFF
--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "0.1.9",
+  "version": "1.0.0",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {
@@ -31,6 +31,6 @@
     "@stratusjs/angularjs": "^0.2.56",
     "@stratusjs/angularjs-extras": "^0.8.3",
     "@stratusjs/runtime": "^0.11.9",
-    "swiper": "^5.2.1"
+    "swiper": "^7.3.1"
   }
 }

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/swiper/src/carousel.component.html
+++ b/packages/swiper/src/carousel.component.html
@@ -6,7 +6,10 @@
                     <img class="swiper-image" data-ng-class="{'stretch-image': stretchWidth}"
                          data-ng-click="imageClick(image, $event)"
                          draggable="false"
-                         data-ng-src="{{::(image.src||image.url)}}"/>
+                         data-ng-src="{{::(image.src||image.url)}}"
+                         title="{{::(image.title||image.description||'Carousel Photo')}}"
+                         alt="{{::(image.description||image.title||'Carousel Photo')}}"
+                    />
                 </div>
             </div>
         </div>
@@ -17,7 +20,10 @@
                     <img class="swiper-image swiper-lazy" data-ng-class="{'stretch-image': stretchWidth}"
                          data-ng-click="imageClick(image, $event)"
                          draggable="false"
-                         data-ng-src="{{::(image.src||image.url)}}"/>
+                         data-ng-src="{{::(image.src||image.url)}}"
+                         title="{{::(image.title||image.description||'Carousel Photo')}}"
+                         alt="{{::(image.description||image.title||'Carousel Photo')}}"
+                    />
                     <div class="swiper-lazy-preloader"></div>
                 </div>
             </div>

--- a/packages/swiper/src/carousel.component.html
+++ b/packages/swiper/src/carousel.component.html
@@ -1,26 +1,24 @@
-<div id="{{ elementId }}" class="swiper-flex" data-injection="swiper" data-ng-class="{'swiper-main': !gallery, 'swiper-gallery': gallery}">
-    <div class="swiper-container" data-ng-class="{'gallery-top': gallery}" data-ng-init="initSwiper()">
-        <div class="swiper-wrapper">
+<div id="{{ ::elementId }}" class="swiper-flex" data-injection="swiper" data-ng-class="{'swiper-main': !gallery, 'swiper-gallery': gallery}">
+    <div class="swiper" data-ng-class="{'gallery-top': gallery}" data-ng-init="initSwiper()">
+        <div class="swiper-wrapper" data-ng-if="!lazyLoad">
             <div class="swiper-slide" data-ng-repeat="image in images track by $index" data-ng-transclude="slide">
                 <div data-ng-class="{'swiper-zoom-container': scaleHeight}">
-                    <!--<div data-ng-if="::lazyLoad" class="swiper-lazy-preloader"></div>-->
                     <img class="swiper-image" data-ng-class="{'stretch-image': stretchWidth}"
-                         data-ng-if="!lazyLoad"
                          data-ng-click="imageClick(image, $event)"
                          draggable="false"
                          data-ng-src="{{::(image.src||image.url)}}"/>
+                </div>
+            </div>
+        </div>
+        <div class="swiper-wrapper" data-ng-if="lazyLoad">
+            <div class="swiper-slide" data-ng-repeat="image in images track by $index" data-ng-transclude="slide">
+                <div data-ng-class="{'swiper-zoom-container': scaleHeight}">
                     <!-- swiper-lazy -->
                     <img class="swiper-image swiper-lazy" data-ng-class="{'stretch-image': stretchWidth}"
-                         data-ng-if="lazyLoad"
                          data-ng-click="imageClick(image, $event)"
                          draggable="false"
                          data-ng-src="{{::(image.src||image.url)}}"/>
-                    <div data-ng-if="lazyLoad" class="swiper-lazy-preloader"></div>
-                    <!--
-                    <div class="small-label font-primary bold"
-                         data-ng-if="image.name" data-ng-bind="image.name">
-                    </div>
-                    -->
+                    <div class="swiper-lazy-preloader"></div>
                 </div>
             </div>
         </div>

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -1,15 +1,19 @@
-// IdxPropertyList Component
-// @stratusjs/idx/property/list.component
-// <stratus-idx-property-list>
+// Carousel Component
+// @stratusjs/swiper/carousel.component
+// <stratus-swiper-carousel>
 // --------------
 
 // Runtime
 import _ from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import * as angular from 'angular'
-import Swiper from 'swiper'
+import Swiper, {SwiperOptions} from 'swiper'
+import {PaginationOptions} from 'swiper/types/modules/pagination'
+import {AutoplayOptions} from 'swiper/types/modules/autoplay'
+import {LazyOptions} from 'swiper/types/modules/lazy'
 // Stratus Dependencies
 import {Model} from '@stratusjs/angularjs/services/model'
+import {Collection} from '@stratusjs/angularjs/services/collection'
 import {isJSON} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 // Stratus Directives
@@ -31,6 +35,67 @@ const packageName = 'swiper'
 // const moduleName = 'components'
 const componentName = 'carousel'
 const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/`
+
+export type SwiperCarouselScope = angular.IScope & {
+    elementId: string
+    localDir: string
+    initialized: boolean
+    swiperContainer: HTMLElement
+    swiperParameters: SwiperOptions
+    swiper: Swiper
+    gallerySwiper?: Swiper
+    model?: Model
+    collection?: Collection
+    property?: string
+    images: SlideImage[]
+
+    /** @deprecated */
+    imageLinkTarget: '_self' | '_blank'
+    slideLinkTarget: '_self' | '_blank'
+
+    /** During pagination, allows a the last slide to return to the very first slide */
+    loop: true | boolean
+    /** Allow moving the slides using a finger of mouse */
+    allowTouchMove: true | boolean
+    direction: 'vertical' | 'horizontal'
+    transitionEffect: 'slide' | 'fade' | 'cube' | 'coverflow' | 'flip'
+    /** Set to true to round values of slides width and height to prevent blurry texts on usual resolution screens (if you have such) */
+    roundLengths: true | boolean
+    /** EXPERIMENTAL
+     * Enables a thumbnail gallery directly below the main carousel. Does not currently with with loop and will disable it.
+     */
+    gallery: false | boolean
+    /** Scales an image 'out' if it is too big for a the containing element to match to fit. Also centers all images
+     *  that don't fit perfectly
+     */
+    scaleHeight: true | boolean
+    /** Resizes the entire element to match the height of the current slide. May cause resizes every time slide changes */
+    autoHeight: false | boolean
+    /** Allow image to stretch wider than the image provided. May cause expected blurriness. */
+    stretchWidth: false | boolean
+    /** Allow Zooming into an image my double clicking or pinching on Mobile. Requires and force enabled scaleHeight */
+    allowZoom: false | boolean
+    transitionDelay: 3000 | number
+    navigation: true | boolean
+    /** FIXME 'bullet' is deprecated. Use 'bullets' instead */
+    pagination: false | boolean | PaginationOptions & {
+        render?: 'fraction' | 'customFraction' | 'progressbarOpposite' | 'progressbar' | 'numberBullet' | 'bullet' | 'bullets'
+    }
+    /** Enable Lazy Loading to prevent everything from being fetched at once
+     * By default Lazy Loading is enabled only for the next and previous images to give a buffer
+     * FIXME lazyLoad currently has been changed to use stratus-src. Need to have an option is disable Sitetheory
+     * lazyLoading, as it doesn't work for external image urls
+     */
+    lazyLoad: boolean | LazyOptions
+    /** Automatically changes the slide at set intervals. Provide object and extra options */
+    autoplay: boolean | AutoplayOptions
+    scrollbar: false | boolean
+    slidesPerGroup: 1 | number
+
+    initSwiper(): void
+    imageClick(slideImage: SlideImage): void
+    remove(): void
+}
 
 Stratus.Components.SwiperCarousel = {
     transclude: {
@@ -82,7 +147,7 @@ Stratus.Components.SwiperCarousel = {
     controller(
         $attrs: angular.IAttributes,
         $element: angular.IRootElementService,
-        $scope: object | any, // angular.IScope breaks references so far
+        $scope: SwiperCarouselScope, // object | any, // angular.IScope breaks references so far
         $timeout: angular.ITimeoutService,
         $window: angular.IWindowService,
         // tslint:disable-next-line:no-shadowed-variable
@@ -99,29 +164,17 @@ Stratus.Components.SwiperCarousel = {
         Stratus.Internals.CssLoader(`${localDir}${componentName}.component${min}.css`)
         $scope.initialized = false
 
-        Stratus.Internals.CssLoader(`${Stratus.BaseUrl}${Stratus.DeploymentPath}swiper/css/swiper${min}.css`)
+        Stratus.Internals.CssLoader(`${Stratus.BaseUrl}${Stratus.DeploymentPath}swiper/swiper-bundle${min}.css`)
 
         // Hoist Attributes
         $scope.property = $attrs.property || null
 
-        // Data References
-        $scope.data = null
-        $scope.model = null
-        $scope.collection = null
-
-        // Registry Connectivity
-        /*
-        if ($attrs.target) {
-          Registry.fetch($attrs, $scope)
-        }(
-        */
-
         // Symbiotic Data Connectivity
-        $scope.$watch('$ctrl.ngModel', (data: Model) => {
+        $scope.$watch('$ctrl.ngModel', (data: Model | Collection) => {
             if (data instanceof Model && data !== $scope.model) {
-                $scope.model = data
+                $scope.model = data as Model
             } else if (data instanceof Collection && data !== $scope.collection) {
-                $scope.collection = data
+                $scope.collection = data as Collection
             }
         })
 
@@ -200,7 +253,7 @@ Stratus.Components.SwiperCarousel = {
             }
             if (_.isArray(images)) {
                 // The main element doesn't have a size ever, so use the inner container
-                const thisEl = $element[0].querySelector('.swiper-container')
+                const thisEl = $element[0].querySelector('.swiper')
                 const sizeName = getImageSizeName(thisEl)
                 const processedImages: SlideImage[] = []
                 images.forEach(
@@ -248,103 +301,30 @@ Stratus.Components.SwiperCarousel = {
             /** @deprecated */
             $scope.imageLinkTarget = $attrs.imageLinkTarget ? $attrs.imageLinkTarget : null
             $scope.slideLinkTarget = $attrs.slideLinkTarget ? $attrs.slideLinkTarget : $scope.imageLinkTarget
-
-            /**
-             * type {String}
-             */
             $scope.direction = $attrs.direction && $attrs.direction === 'vertical' ? 'vertical' : 'horizontal'
-
-            /**
-             * FIXME Some transitions seem to have trouble with lazyLoad that we'll need to work on
-             * type {String} ['slide','fade','cube','coverflow','flip']
-             */
+            /** FIXME Some transitions seem to have trouble with lazyLoad that we'll need to work on */
             $scope.transitionEffect = $attrs.transitionEffect ? $attrs.transitionEffect : 'slide'
-
-            /**
-             * Set to true to round values of slides width and height to prevent blurry texts on usual resolution screens (if you have such)
-             * Enabled by default
-             * type {boolean}
-             */
             $scope.roundLengths = $attrs.roundLengths && isJSON($attrs.roundLengths) ? JSON.parse($attrs.roundLengths) : true
-
-            /**
-             * During pagination, allows a the last slide to return to the very first slide
-             * Enabled by default
-             * type {boolean}
-             */
             $scope.loop = $attrs.loop && isJSON($attrs.loop) ? JSON.parse($attrs.loop) : true
-
-            /**
-             * EXPERIMENTAL
-             * Enables a thumbnail gallery directly below the main carousel. Does not currently with with loop and will disable it.
-             * Disabled by default
-             * type {boolean}
-             */
             $scope.gallery = $attrs.gallery && isJSON($attrs.gallery) ? JSON.parse($attrs.gallery) : false
             if ($scope.gallery) {
                 $scope.loop = false
             }
-
-            /**
-             * Scales an image 'out' if it is too big for a the containing element to match to fit. Also centers all
-             * images that don't fit perfectly
-             * Enabled by default
-             * type {boolean}
-             */
             $scope.scaleHeight = $attrs.scaleHeight && isJSON($attrs.scaleHeight) ? JSON.parse($attrs.scaleHeight) : true
-
-            /**
-             * Allow Zooming into an image my double clicking or pinching on Mobile. Requires and force enabled scaleHeight
-             * Disabled by default
-             * type {boolean}
-             */
             $scope.allowZoom = $attrs.allowZoom && isJSON($attrs.allowZoom) ? JSON.parse($attrs.allowZoom) : false
             $scope.scaleHeight = $scope.scaleHeight || $scope.allowZoom
-
-            /**
-             * Allow image to stretch wider than the image provided. May cause expected blurriness.
-             * type {boolean}
-             */
             $scope.stretchWidth = $attrs.stretchWidth && isJSON($attrs.stretchWidth) ? JSON.parse($attrs.stretchWidth) : false
-            /**
-             * Resizes the entire element to match the height of the current slide. May cause resizes every time slide changes
-             * type {boolean}
-             */
             $scope.autoHeight = $attrs.autoHeight && isJSON($attrs.autoHeight) ? JSON.parse($attrs.autoHeight) : false
-            /**
-             * Automatically changes the slide at set intervals. Provide object and extra options
-             * type {Object || boolean}
-             */
             $scope.autoplay = $attrs.autoplay && isJSON($attrs.autoplay) ? JSON.parse($attrs.autoplay) : false
-            /**
-             * Allow moving the slides using a finger of mouse
-             * Enabled by default
-             * type {boolean}
-             */
             $scope.allowTouchMove = $attrs.allowTouchMove && isJSON($attrs.allowTouchMove) ? JSON.parse($attrs.allowTouchMove) : true
-            /** type {Number} */
             $scope.transitionDelay = $attrs.transitionDelay && isJSON($attrs.transitionDelay) ? JSON.parse($attrs.transitionDelay) : 3000
-
-            // FIXME lazyLoad currently has been changed to use stratus-src. Need to have an option is disable Sitetheory
-            // lazyLoading, as it doesn't work for external image urls
-            /**
-             * Enable Lazy Loading to prevent everything from being fetched at once
-             * By default Lazy Loading is enabled only for the next and previous images to give a buffer
-             * type {Object || boolean}
-             */
             $scope.lazyLoad = $attrs.lazyLoad && isJSON($attrs.lazyLoad) ? JSON.parse($attrs.lazyLoad) : {}
-
-            /** type {boolean} */
             $scope.navigation = $attrs.navigation && isJSON($attrs.navigation) ? JSON.parse($attrs.navigation) : true
 
             /** type {Object || boolean} */
             $scope.pagination = $attrs.pagination && isJSON($attrs.pagination) ? JSON.parse($attrs.pagination) : false
-
-            /** type {boolean} */
             $scope.scrollbar = $attrs.scrollbar && isJSON($attrs.scrollbar) ? JSON.parse($attrs.scrollbar) : false
-
-            /** type {boolean} */
-            $scope.slidesPerGroup = $attrs.slidesPerGroup && isJSON($attrs.slidesPerGroup) ? JSON.parse($attrs.slidesPerGroup) : false
+            $scope.slidesPerGroup = $attrs.slidesPerGroup && isJSON($attrs.slidesPerGroup) ? JSON.parse($attrs.slidesPerGroup) : 1
 
             initImages(slides)
             $scope.initSwiper()
@@ -393,9 +373,9 @@ Stratus.Components.SwiperCarousel = {
          */
         $scope.initSwiper = (): void => {
             // TODO need to select like this: probably need to get away from className however
-            $ctrl.swiperContainer = $element[0].querySelector('.swiper-container')
+            $scope.swiperContainer = $element[0].querySelector('.swiper')
 
-            $ctrl.swiperParameters = {
+            $scope.swiperParameters = {
                 init: false,
                 // Optional parameters
                 direction: $scope.direction,
@@ -412,10 +392,10 @@ Stratus.Components.SwiperCarousel = {
              * @see {@link http://idangero.us/swiper/api/#navigation|Swiper Doc}
              */
             if ($scope.navigation) {
-                $ctrl.swiperNextEl = $ctrl.swiperContainer.getElementsByClassName('swiper-button-next')[0]
-                $ctrl.swiperPrevEl = $ctrl.swiperContainer.getElementsByClassName('swiper-button-prev')[0]
+                $ctrl.swiperNextEl = $scope.swiperContainer.getElementsByClassName('swiper-button-next')[0]
+                $ctrl.swiperPrevEl = $scope.swiperContainer.getElementsByClassName('swiper-button-prev')[0]
 
-                $ctrl.swiperParameters.navigation = {
+                $scope.swiperParameters.navigation = {
                     nextEl: $ctrl.swiperNextEl,
                     prevEl: $ctrl.swiperPrevEl
                 }
@@ -426,7 +406,7 @@ Stratus.Components.SwiperCarousel = {
              * @see {@link http://idangero.us/swiper/api/#pagination|Swiper Doc}
              */
             if ($scope.pagination) {
-                $ctrl.swiperParameters.pagination = {}
+                $scope.swiperParameters.pagination = {}
 
                 if (typeof $scope.pagination === 'string') {
                     $scope.pagination = {
@@ -435,54 +415,55 @@ Stratus.Components.SwiperCarousel = {
                 }
 
                 if (typeof $scope.pagination === 'object') {
-                    if (Object.prototype.hasOwnProperty.call($scope.pagination, 'el')) {
-                        $ctrl.swiperPaginationEl = $ctrl.swiperContainer.getElementsByClassName($scope.pagination.el)[0]
-                    }
+                    /*if (Object.prototype.hasOwnProperty.call($scope.pagination, 'el')) {
+                        $ctrl.swiperPaginationEl = $scope.swiperContainer.getElementsByClassName($scope.pagination.el)[0]
+                    }*/
                     if (Object.prototype.hasOwnProperty.call($scope.pagination, 'clickable')) {
-                        $ctrl.swiperParameters.pagination.clickable = $scope.pagination.clickable
+                        $scope.swiperParameters.pagination.clickable = $scope.pagination.clickable
                     }
                     if (Object.prototype.hasOwnProperty.call($scope.pagination, 'dynamicBullets')) {
-                        $ctrl.swiperParameters.pagination.dynamicBullets = $scope.pagination.dynamicBullets
+                        $scope.swiperParameters.pagination.dynamicBullets = $scope.pagination.dynamicBullets
                     }
                     if (Object.prototype.hasOwnProperty.call($scope.pagination, 'dynamicMainBullets')) {
-                        $ctrl.swiperParameters.pagination.dynamicMainBullets = $scope.pagination.dynamicMainBullets
+                        $scope.swiperParameters.pagination.dynamicMainBullets = $scope.pagination.dynamicMainBullets
                     }
                     if (Object.prototype.hasOwnProperty.call($scope.pagination, 'render')) {
                         // TODO this is just a custom selectable for now, need more customization
                         switch ($scope.pagination.render) {
                             case 'fraction':
-                                $ctrl.swiperParameters.pagination.type = 'fraction'
+                                $scope.swiperParameters.pagination.type = 'fraction'
                                 break
                             case 'customFraction':
-                                $ctrl.swiperParameters.pagination.type = 'fraction'
-                                $ctrl.swiperParameters.pagination.renderFraction = (currentClass: string, totalClass: string) => {
+                                $scope.swiperParameters.pagination.type = 'fraction'
+                                $scope.swiperParameters.pagination.renderFraction = (currentClass: string, totalClass: string) => {
                                     return '<span class="' + currentClass + '"></span>' + ' of ' + '<span class="' + totalClass + '"></span>'
                                 }
                                 break
                             case 'progressbarOpposite':
-                                $ctrl.swiperParameters.pagination.progressbarOpposite = true
-                                $ctrl.swiperParameters.pagination.type = 'progressbar'
+                                $scope.swiperParameters.pagination.progressbarOpposite = true
+                                $scope.swiperParameters.pagination.type = 'progressbar'
                                 break
                             case 'progressbar':
-                                $ctrl.swiperParameters.pagination.type = 'progressbar'
+                                $scope.swiperParameters.pagination.type = 'progressbar'
                                 break
                             // TODO requires custom css at this time (see testing page)
                             case 'numberBullet':
-                                $ctrl.swiperParameters.pagination.renderBullet = (index: number, className: string) => {
+                                $scope.swiperParameters.pagination.renderBullet = (index: number, className: string) => {
                                     return '<span class="' + className + ' swiper-pagination-number-bullet">' + (index + 1) + '</span>'
                                 }
                                 break
                             case 'bullet':
+                            case 'bullets':
                             default:
-                                $ctrl.swiperParameters.pagination.type = 'bullet'
+                                $scope.swiperParameters.pagination.type = 'bullets'
                         }
                     }
                 }
 
                 if (!$ctrl.swiperPaginationEl) {
-                    $ctrl.swiperPaginationEl = $ctrl.swiperContainer.getElementsByClassName('swiper-pagination')[0]
+                    $ctrl.swiperPaginationEl = $scope.swiperContainer.getElementsByClassName('swiper-pagination')[0]
                 }
-                $ctrl.swiperParameters.pagination.el = $ctrl.swiperPaginationEl
+                $scope.swiperParameters.pagination.el = $ctrl.swiperPaginationEl
             }
 
             /**
@@ -490,16 +471,17 @@ Stratus.Components.SwiperCarousel = {
              * @see {@link http://idangero.us/swiper/api/#scrollbar|Swiper Doc}
              */
             if ($scope.scrollbar) {
-                $ctrl.swiperScrollbarEl = $ctrl.swiperContainer.getElementsByClassName('swiper-scrollbar')[0]
+                $ctrl.swiperScrollbarEl = $scope.swiperContainer.getElementsByClassName('swiper-scrollbar')[0]
 
-                $ctrl.swiperParameters.scrollbar = {
+                $scope.swiperParameters.scrollbar = {
                     el: $ctrl.swiperScrollbarEl
                 }
             }
 
             // TODO: Add Documentation
-            if ($scope.slidesPerGroup) {
-                $ctrl.swiperParameters.slidesPerView = $scope.slidesPerGroup
+            // TODO: This needs work but unused atm
+            if ($scope.slidesPerGroup > 1) {
+                $scope.swiperParameters.slidesPerView = $scope.slidesPerGroup
             }
 
             /**
@@ -515,7 +497,7 @@ Stratus.Components.SwiperCarousel = {
                     }
                 }
                 if (!$scope.loop && $scope.autoplay) {
-                    if (typeof $scope.autoplay === 'boolean') {
+                    if (_.isBoolean($scope.autoplay)) {
                         $scope.autoplay = {}
                     }
                     if (!Object.prototype.hasOwnProperty.call($scope.autoplay, 'stopOnLastSlide')) {
@@ -523,7 +505,7 @@ Stratus.Components.SwiperCarousel = {
                     }
                 }
 
-                $ctrl.swiperParameters.autoplay = $scope.autoplay
+                $scope.swiperParameters.autoplay = $scope.autoplay
             }
 
             /**
@@ -547,37 +529,37 @@ Stratus.Components.SwiperCarousel = {
                     $scope.lazyLoad.loadOnTransitionStart = true
                 }
 
-                $ctrl.swiperParameters.lazy = $scope.lazyLoad
-                $ctrl.swiperParameters.preloadImages = false
+                $scope.swiperParameters.lazy = $scope.lazyLoad
+                $scope.swiperParameters.preloadImages = false
             }
 
-            // console.log('swiperParameters', $ctrl.swiperParameters)
+            // console.log('swiperParameters', $scope.swiperParameters)
 
             $scope.$applyAsync(() => {
                 // $applyAsync is causing this function to run twice. Adding check to make sure it doesn't
-                if ($ctrl.swiper) {
+                if ($scope.swiper) {
                     // console.log('swiper already exists, canceling')
                     return
                 }
-                // console.log('parameters:', $ctrl.swiperParameters, $ctrl)
-                $ctrl.swiper = new Swiper($ctrl.swiperContainer, $ctrl.swiperParameters)
+                // console.log('parameters:', $scope.swiperParameters, $ctrl)
+                $scope.swiper = new Swiper($scope.swiperContainer, $scope.swiperParameters)
                 /*
                 Issue: When loading a page, the first time a set of Swiper slideshows are called, it will load fine.
                 However, if a set is loaded a second time, the slides seem to fail to initialize and the next/prev buttons do not register.
                 This issue seems to resolve itself when the Window is resized or swiper is forcibly updated (swiper.update())
                 Below are attempts at a workaround to ensure swiper continues to work after second load by causing a delayed update
                 */
-                $ctrl.swiper.on('init', () => {
+                $scope.swiper.on('init', () => {
                     $timeout(() => {
-                        $ctrl.swiper.update()
+                        $scope.swiper.update()
                     }, 100)
                 })
 
                 if ($scope.gallery) {
-                    $ctrl.galleryContainer = $element[0].getElementsByClassName('swiper-gallery')[0].getElementsByClassName('swiper-container')[0]
+                    $ctrl.galleryContainer = $element[0].getElementsByClassName('swiper-gallery')[0].getElementsByClassName('swiper')[0]
                     // Looping does not work correctly with gallery, so it will need to be disabled
                     // FIXME this is controlling the gallery, but its offset by 1 if looping...so it never matches... need to debug
-                    $ctrl.gallerySwiper = new Swiper($ctrl.galleryContainer, {
+                    $scope.gallerySwiper = new Swiper($ctrl.galleryContainer, {
                         direction: 'horizontal',
                         effect: 'slide',
                         // lazy: $scope.lazyLoad,
@@ -603,11 +585,11 @@ Stratus.Components.SwiperCarousel = {
                         touchRatio: 0.2,
                         slideToClickedSlide: true
                     })
-                    $ctrl.swiper.controller.control = $ctrl.gallerySwiper
-                    $ctrl.gallerySwiper.controller.control = $ctrl.swiper
+                    $scope.swiper.controller.control = $scope.gallerySwiper
+                    $scope.gallerySwiper.controller.control = $scope.swiper
                 }
                 // initializing manually to allow on init events
-                $ctrl.swiper.init()
+                $scope.swiper.init()
             })
         }
 
@@ -616,7 +598,8 @@ Stratus.Components.SwiperCarousel = {
          */
         $scope.remove = (): void => {
             // console.log('destroying swiper widget... after destroying, still doenst work')
-            delete $ctrl.swiper
+            delete $scope.swiper
+            delete $scope.gallerySwiper
         }
     },
     templateUrl: (): string => `${localDir}${componentName}.component${min}.html`

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -268,6 +268,9 @@ Stratus.Components.SwiperCarousel = {
                                     image.src = replaceImageSizeSrc(image.src, sizeName)
                                     // console.log('image upgraded to ', image.src)
                                 }
+                                image.title = _.get(image, 'title')
+                                image.description = _.get(image, 'ShortDescription') ||
+                                    _.get(image, 'description') || _.get(image, 'LongDescription') || image.title
                                 preppedImage = image
                             }
                         }


### PR DESCRIPTION
#### @stratusjs/swiper 1.1.0 published
Adds:
- Add Component Typings

Changes:
- Swiper upgraded to version 7.3.1 to include a number of accessibility improvements
- Adjust options to account for new version
- Improved angular template to only process ng-ifs once before foreachs
