### PR TITLE
@stratusjs/calendar 1.0.2 use CORS proxy

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/calendar",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AngularJS Calendar component and iCAL service to be used as an add on to StratusJS. Makes use of fullcalendar and iCAL",
   "scripts": {},
   "repository": {

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -292,6 +292,13 @@ Stratus.Components.Calendar = {
             /*if (fullUrl.startsWith('http')) {
                 fullUrl = `https://cors-anywhere.herokuapp.com/${url}`
             }*/
+            if (
+                url.startsWith('http') &&
+                !url.startsWith('/') &&
+                !url.startsWith('https://app004.sitetheory.io/')
+            ) {
+                url = `https://app004.sitetheory.io/${url}`
+            }
 
             const response: any = await $http.get(url)
             if (cookie('env')) {


### PR DESCRIPTION
**@stratusjs/calendar 1.0.2 published**
Adds:
- @stratusjs/calendar attempts to use CORS proxy for added ics files