### PR TITLE
Add `bindHtml` Deep Compilation

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {


### PR DESCRIPTION
Adds:

- `bindHtml` Deep Compilation
- `bindHtml` Compile on `DOMSubtreeModified`
- `bindHtml` can now be a decorator with `ng-bind-html`

Changes:

- Bump `@stratusjs/angularjs-extras` to `0.9.2`