### PR TITLE
BUG - make best image show in selector.component in edge cases where there is video

### DIFF
--- a/packages/angular/src/selector/selector.component.html
+++ b/packages/angular/src/selector/selector.component.html
@@ -48,22 +48,16 @@
                         <!--<img class="shapeholder" [src]="Stratus.BaseUrl + 'sitetheorycore/images/shapeholder-square.png'">-->
                     <!--</div>-->
 
-                    <!-- This only shows the bestImage if this isn't a Video, since images for Videos are not hosted by us, thus cannot lazy load a proper size -->
+                    <!-- This adds stratus-src lazy loading if bestImage isn't a third party service without image sizes, e.g. Video -->
                     <div class="image position-all"
-                         *ngIf="has(selectedModel, 'version.bestImage._thumbnailUrl') && !has(selectedModel, 'version.videos')"
-                         data-stratus-src
+                         *ngIf="has(selectedModel, 'version.bestImage._thumbnailUrl')"
+                         [attr.data-stratus-src]="!_.get(selectedModel, 'version.bestImage.service') ? true : false"
                          [ngStyle]="{'background': 'url(' + _.get(selectedModel, 'version.bestImage._thumbnailUrl') + ') no-repeat center center', 'background-size': 'cover'}">
-                    </div>
-
-                    <!-- This is here because images for Videos are not hosted by us, so we cannot include stratus-src with it -->
-                    <div class="image position-all"
-                         *ngIf="!has(selectedModel, 'version.bestImage._thumbnailUrl') && has(selectedModel, 'version.videos')"
-                         [ngStyle]="{'background': 'url(' + _.get(selectedModel, 'version.videos[0].src') + ') no-repeat center center', 'background-size': 'cover'}">
                     </div>
 
                     <!-- Icon for items with no image -->
                     <div class="no-image-icon position-all"
-                         *ngIf="!has(selectedModel, 'version.bestImage._thumbnailUrl') && !has(selectedModel, 'version.videos')"
+                         *ngIf="!has(selectedModel, 'version.bestImage._thumbnailUrl')"
                          [ngClass]="_.get(selectedModel, 'contentType.class') + '-background-color'">
 
                         <mat-icon class="content-type-icon position-center"

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -1430,8 +1430,12 @@ Stratus.Internals.LoadImage = (obj: any) => {
             let unit: any = null
             let percentage: any = null
 
+            // Allow specifying an alternative element to reference the best size. Useful in cases like before/after images
+            const spyReference: any = hydrate(el.attr('data-stratus-src-spy')) || null
+            const $referenceElement = spyReference ? (jQuery(_.first(el.parents(spyReference))) || nativeEl) : nativeEl
+
             // if (el.width()) {
-            const nativeWidth = nativeEl.offsetWidth || nativeEl.clientWidth
+            const nativeWidth = $referenceElement.offsetWidth || $referenceElement.clientWidth
             if (nativeWidth) {
                 // Check if there is CSS width hard coded on the element
                 // width = el.width()
@@ -1465,7 +1469,9 @@ Stratus.Internals.LoadImage = (obj: any) => {
                 // so in some cases we need to flag to find the parent regardless of invisibility.
                 const visibilitySelector: any = hydrate(el.attr('data-ignore-visibility')) ? null : ':visible'
                 // TODO need a replacement for jQuery().parents() and jQuery().find() with class
-                const $visibleParent = jQuery(_.first(jQuery(obj.el).parents(visibilitySelector)))
+                // NOTE: this was previously finding parents of el but we changed to be $referenceElement
+                // in case they want to reference something else
+                const $visibleParent = jQuery(_.first(jQuery($referenceElement).parents(visibilitySelector)))
                 // let $visibleParent = obj.spy || el.parent()
                 width = $visibleParent ? $visibleParent.width() : 0
 


### PR DESCRIPTION
- [Bug] - In Stratus repo fix a bug in the selector component where the best image wouldn't show if the model has a video (bad logic). The best image should always show, but we just want to only show the stratus-src lazy loading if it's not a third party service, e.g. [attr.data-stratus-src]="!_.get(selectedModel, 'version.bestImage.service') ? true : false"