### PR TITLE
@stratusjs/calendar 1.0.3

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/calendar",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "AngularJS Calendar component and iCAL service to be used as an add on to StratusJS. Makes use of fullcalendar and iCAL",
   "scripts": {},
   "repository": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -27,17 +27,17 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@fullcalendar/common": "^5.10.1",
-    "@fullcalendar/core": "^5.10.1",
-    "@fullcalendar/daygrid": "^5.10.1",
-    "@fullcalendar/list": "^5.10.1",
-    "@fullcalendar/moment": "^5.10.1",
-    "@fullcalendar/moment-timezone": "^5.10.1",
-    "@fullcalendar/timegrid": "^5.10.1",
+    "@fullcalendar/common": "^5.11.2",
+    "@fullcalendar/core": "^5.11.2",
+    "@fullcalendar/daygrid": "^5.11.2",
+    "@fullcalendar/list": "^5.11.2",
+    "@fullcalendar/moment": "^5.11.2",
+    "@fullcalendar/moment-timezone": "^5.11.2",
+    "@fullcalendar/timegrid": "^5.11.2",
     "@stratusjs/angularjs": "^0.3.2",
     "@stratusjs/angularjs-extras": "^0.9.4",
     "@stratusjs/runtime": "^0.11.9",
-    "ical.js": "^1.4.0",
+    "ical.js": "^1.5.0",
     "tslib": "^2.4.0"
   }
 }

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -34,10 +34,10 @@
     "@fullcalendar/moment": "^5.10.1",
     "@fullcalendar/moment-timezone": "^5.10.1",
     "@fullcalendar/timegrid": "^5.10.1",
-    "@stratusjs/angularjs": "^0.2.56",
-    "@stratusjs/angularjs-extras": "^0.8.5",
+    "@stratusjs/angularjs": "^0.3.2",
+    "@stratusjs/angularjs-extras": "^0.9.4",
     "@stratusjs/runtime": "^0.11.9",
-    "ical.js": "^1.3.0",
-    "tslib": "^2.1.0"
+    "ical.js": "^1.4.0",
+    "tslib": "^2.4.0"
   }
 }

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -269,9 +269,12 @@ Stratus.Components.Calendar = {
                         await $ctrl.render()
                     })
                     setTimeout(async () => {
-                        // render a second time for safety... as it doesn't seem to always grab the window size (fullcalendar issue)
+                        // render a second and third time for safety... as it doesn't seem to always grab the window size
                         $scope.calendar.render()
-                    }, 200)
+                        setTimeout(async () => {
+                            $scope.calendar.render()
+                        }, 300)
+                    }, 300)
 
                     // process a list of URLS, just using single example below
                     // Process each feed before continuing noting that Calendar is done loading

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -265,7 +265,14 @@ Stratus.Components.Calendar = {
                         console.log('loading external urls:', $scope.options.eventSources)
                     }
                     // Render happens once prior to any url fetching
-                    await $ctrl.render()
+                    $scope.$applyAsync(async () => {
+                        await $ctrl.render()
+                    })
+                    setTimeout(async () => {
+                        // render a second time for safety... as it doesn't seem to always grab the window size (fullcalendar issue)
+                        $scope.calendar.render()
+                    }, 200)
+
                     // process a list of URLS, just using single example below
                     // Process each feed before continuing noting that Calendar is done loading
                     await Promise.all(
@@ -411,8 +418,8 @@ Stratus.Components.Calendar = {
          * @TODO Methods to look into:
          * 'viewRender' for callbacks on new date range (pagination maybe)  - http:// fullcalendar.io/docs/display/viewRender/
          * 'dayRender' for modifying day cells - http://fullcalendar.io/docs/display/dayRender/
-         * 'windowResize' for callbacks on window resizing - http://fullcalendar.io/docs/display/windowResize/
-         * 'render' force calendar to redraw - http://fullcalendar.io/docs/display/render/
+         * 'windowResize' for callbacks on window resizing - https://fullcalendar.io/docs/handleWindowResize
+         * 'render' force calendar to redraw - https://fullcalendar.io/docs/render
          */
         $ctrl.render = () => {
             // return new Promise((resolve: any) => {


### PR DESCRIPTION
@stratusjs/calendar 1.0.3 published
Changes:
 - Adds additional rendering increments for initial calendar display
 - Updates dependencies to sync with stratus + fix header issue