### PR TITLE
Minor Fixes for `@stratusjs/angularjs` and `@stratusjs/runtime`

### DIFF
--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -361,9 +361,9 @@ export class Collection<T = LooseObject> extends EventManager {
 
                 // Data
                 this.header.set(responseHeaders || this.xhr.getAllResponseHeaders())
-                this.meta.set(response.meta || {})
+                this.meta.set((response as LooseObject).meta || {})
                 this.models = []
-                const payload = response.payload || response
+                const payload = (response as LooseObject).payload || response
 
                 // XHR Flags
                 this.error = false

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -558,9 +558,9 @@ export class Model<T = LooseObject> extends ModelBase<T> {
                 // TODO: Make this into an over-writable function
                 // Gather Data
                 this.header.set(this.xhr.getAllResponseHeaders() || {})
-                this.meta.set(response.meta || {})
-                this.route.set(response.route || {})
-                const payload = response.payload || response
+                this.meta.set((response as LooseObject).meta || {})
+                this.route.set((response as LooseObject).route || {})
+                const payload = (response as LooseObject).payload || response
                 const status: { code: string }[] = this.meta.get('status') || []
 
                 // Evaluate Payload
@@ -635,6 +635,8 @@ export class Model<T = LooseObject> extends ModelBase<T> {
                 this.data = _.cloneDeep(intermediateData) as T
                 this.changed = false
                 this.saving = false
+
+                // FIXME: This should be finding the changed identifier...
                 this.handleChanges()
                 this.patch = {}
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/runtime",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "This is the runtime package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -1901,7 +1901,7 @@ Stratus.Internals.TrackLocation = () => {
             })
         } else {
             Stratus.Internals.XHR({
-                url: 'https://ipapi.co/' + Stratus.Environment.get('ip') + '/json/',
+                url: 'https://ipapi.co/json/',
                 success(data: any) {
                     if (!data) {
                         data = {}


### PR DESCRIPTION
Changes:

- Bump `@stratusjs/angularjs` to `0.3.3`
- Bump `@stratusjs/runtime` to `0.11.11`

Removes:

- Unnecessary Environment IP Reference

Fixes:

- TypeCasting for AngularJS Model/Collection