### PR TITLE
@stratusjs/angularjs 0.3.6 add collection on/trigger events

### DIFF
--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -26,8 +26,8 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/core": "^0.2.26",
-    "@stratusjs/runtime": "^0.11.10",
+    "@stratusjs/core": "^0.3.1",
+    "@stratusjs/runtime": "^0.11.14",
     "angular": "1.7.9",
     "angular-animate": "1.7.9",
     "angular-aria": "1.7.9",
@@ -36,6 +36,6 @@
     "angular-paging": "2.2.2",
     "angular-resource": "1.7.9",
     "angular-sanitize": "1.7.9",
-    "tslib": "^1.11.1"
+    "tslib": "^2.4.0"
   }
 }

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -335,6 +335,7 @@ export class Collection<T = LooseObject> extends EventManager {
 
                     // Trigger Change Event
                     this.throttleTrigger('change')
+                    this.trigger('error', error)
 
                     // Promise
                     reject(error)
@@ -392,6 +393,7 @@ export class Collection<T = LooseObject> extends EventManager {
 
                 // Trigger Change Event
                 this.throttleTrigger('change')
+                this.trigger('complete')
 
                 // Promise
                 resolve(this.models)
@@ -408,6 +410,7 @@ export class Collection<T = LooseObject> extends EventManager {
                     // (/(.*)\sReceived/i).exec(error.message)[1]
                     console.error(`XHR: ${request.method} ${request.url}`)
                     this.throttleTrigger('change')
+                    this.trigger('error', error)
                     reject(error)
                     throw error
                 })


### PR DESCRIPTION
@stratusjs/angularjs 0.3.6 published

Adds:
- `complete`/`error` on/trigger events for collections (avoid filtering through change events)