### PR TITLE
@stratusjs/angular 0.4.3 @stratusjs/angularjs-extras 0.11.2

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angular/src/editor/citation-dialog.component.html
+++ b/packages/angular/src/editor/citation-dialog.component.html
@@ -6,24 +6,22 @@
         <mat-card-content mat-dialog-content class="citation-dialog-content">
             <mat-progress-bar mode="indeterminate" *ngIf="isPopupLoading"></mat-progress-bar>
             <p *ngIf="!isPopupLoading && warningMessage" [innerHTML]='warningMessage'></p>
+            <mat-form-field class="form-field" style="width: 100%;">
+                <input matInput placeholder="Optional Citation Number/Title"
+                       aria-label="Optional Citation Number/Title"
+                       [readonly]="formDisabled || isPopupLoading"
+                       formControlName='citationTitleInput'
+                >
+            </mat-form-field>
             <!-- HTML Content -->
             <mat-form-field class="form-field" style="width: 100%;">
                 <textarea matInput placeholder="Add a Citation Content"
                           aria-label="Add a Citation Content"
-                          formControlName='citationElementInput'
+                          formControlName='citationContentInput'
                           [readonly]="formDisabled || isPopupLoading"
                           style="min-height: 100px;"
                 ></textarea>
             </mat-form-field>
-            <!-- citationTitleInput. Disabled as the editor cannot handle angular -->
-            <!--<mat-form-field class="form-field" style="width: 100%;">
-                <input matInput placeholder="Add a Optional Citation Number/Title"
-                       aria-label="Add a Optional Citation Number/Title"
-                       [readonly]="formDisabled || isPopupLoading"
-                       [disabled]="formDisabled || isPopupLoading"
-                       formControlName='citationTitleInput'
-                >
-            </mat-form-field>-->
         </mat-card-content>
         <mat-card-actions>
             <!-- [disabled]="isSelected(mediaEntity)" -->

--- a/packages/angular/src/editor/citation-dialog.component.html
+++ b/packages/angular/src/editor/citation-dialog.component.html
@@ -12,7 +12,6 @@
                           aria-label="Add a Citation Content"
                           formControlName='citationElementInput'
                           [readonly]="formDisabled || isPopupLoading"
-                          [disabled]="formDisabled || isPopupLoading"
                           style="min-height: 100px;"
                 ></textarea>
             </mat-form-field>

--- a/packages/angular/src/editor/citation-dialog.component.ts
+++ b/packages/angular/src/editor/citation-dialog.component.ts
@@ -48,6 +48,7 @@ import {
 import {IconOptions, MatIconRegistry} from '@angular/material/icon'
 import {DomSanitizer} from '@angular/platform-browser'
 import {InputButtonPlugin} from '@stratusjs/angular/froala/plugins/inputButton'
+import {CitationManager} from '@stratusjs/angular/froala/plugins/citationManager'
 
 // Local Setup
 const systemDir = '@stratusjs/angular'
@@ -89,7 +90,7 @@ export class CitationDialogComponent extends ResponsiveComponent implements OnIn
     editor: TriggerInterface
     eventManager: InputButtonPlugin<string>
     baseEditor: LooseObject & {
-        citationManager: LooseObject<LooseFunction>
+        citationManager: CitationManager // LooseObject<LooseFunction>
         selection: LooseObject<LooseFunction> & {
             element(): Element // entire element surrounding the highlighted text (maybe be inaccurate due to froala selection tags)
             endElement(): Element // entire element surrounding the highlighted text
@@ -144,9 +145,12 @@ export class CitationDialogComponent extends ResponsiveComponent implements OnIn
 
         this.highlightedText = this.baseEditor.selection.text()
         // Let's figure out if this is going to make a new citation or update an existing
-        const containedElement = this.baseEditor.selection.endElement()
-        const containedElementName = containedElement.tagName
-        if (containedElementName === 'STRATUS-CITATION') {
+        const containedElement = this.baseEditor.citationManager.getSelectedCitation() ||
+            this.baseEditor.citationManager.getLastKnownCitation() // Last known detect better and set from Toolbar
+        this.baseEditor.citationManager.hideToolbar() // Let's ensure this closes and all vars reset
+        // const containedElement = this.baseEditor.selection.endElement()
+        // const containedElementName = containedElement.tagName
+        if (containedElement) {
             this.newCitation = false
             this.existingCitationElement = containedElement
             // console.log('We selected an existing citation, so we\'ll be only updating it (ignore highlighted text)')

--- a/packages/angular/src/editor/editor.component.scss
+++ b/packages/angular/src/editor/editor.component.scss
@@ -25,6 +25,12 @@
       // Nothing yet
     }
   }
+  /* Reduce the spacing of the toolbar button groups to fit more */
+  .fr-toolbar {
+    .fr-btn-grp {
+      margin: 0 0 0 5px;
+    }
+  }
 }
 
 // This fixes the sticky toolbar if nested in md-tabs

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -430,7 +430,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             'insertTable',
             'insertVideo',
             'insertFile',
-            'citationManager',
+            'citationInsert',
             'insertHR',
             'specialCharacters',
             // 'insertLink',

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -634,6 +634,8 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             'md-virtual-repeat', 'md-virtual-repeat-container', 'md-whiteframe',
             // AngularJS Material Secondary Tags
             'md-svg-src',
+            // Stratus AngularJS Tags
+            'stratus-citation-notitle',
             // Stratus Angular+ Tags
             'sa-boot',
             'sa-editor',

--- a/packages/angular/src/froala/plugins/citationManager.scss
+++ b/packages/angular/src/froala/plugins/citationManager.scss
@@ -3,21 +3,31 @@
   stratus-citation {
     position: relative;
     display: inline-block;
-    counter-increment: stratus-citation-counter;
-    color: transparent;
     border-style: dotted;
     border-color: cornflowerblue;
     border-width: 2px;
+    color: #f85b3b; /* handle generic color better */
     cursor: pointer;
-    height: 20px;
-    width: 20px;
-    overflow: hidden;
-    &::before {
+    min-height: 17px;
+    min-width: 20px;
+    stratus-citation-content {
+      display: none;
+    }
+    stratus-citation-title {
+      display: block;
+      position: relative;
+      top: -4px;
+      margin-bottom: -6px;
+      padding-top: 4px;
+      padding-right: 1px;
+      font-size: 0.75em;
+    }
+    stratus-citation-notitle::before {
+      counter-increment: stratus-citation-counter;
       content: counter(stratus-citation-counter);
       position: absolute;
       left: 2px;
       font-size: 0.75em;
-      color: #f85b3b; /* handle generic color better */
     }
   }
 }

--- a/packages/angular/src/froala/plugins/citationManager.scss
+++ b/packages/angular/src/froala/plugins/citationManager.scss
@@ -7,6 +7,7 @@
     color: transparent;
     border-style: dotted;
     border-color: cornflowerblue;
+    border-width: 2px;
     cursor: pointer;
     height: 20px;
     width: 20px;

--- a/packages/angular/src/froala/plugins/citationManager.ts
+++ b/packages/angular/src/froala/plugins/citationManager.ts
@@ -63,7 +63,10 @@ FroalaEditor.PLUGINS.citationManager = function citationManager(editor: any) {
             if (
                 clickEvent.hasOwnProperty('target') &&
                 // clickEvent.target.hasOwnProperty('nodeName') &&
-                (clickEvent.target as Element).nodeName === 'STRATUS-CITATION'
+                (
+                    (clickEvent.target as Element).nodeName === 'STRATUS-CITATION' ||
+                    (clickEvent.target as Element).nodeName === 'STRATUS-CITATION-TITLE'
+                )
             ) {
                 const citation = getSelectedCitation() // If citation isn't fully grabbed, will not attempt
                 if (citation) {
@@ -157,6 +160,7 @@ FroalaEditor.PLUGINS.citationManager = function citationManager(editor: any) {
         // Show the custom toolbar.
         // The button's outerHeight is required in case the popup needs to be displayed above it.
         editor.popups.show('citationManager.toolbar', left, top, btn.outerHeight())
+        // Hold onto this lastKnown for the dialog to use -this- element
         editor.citationManager.setLastKnownCitation(citation)
     }
 

--- a/packages/angular/src/froala/plugins/citationManager.ts
+++ b/packages/angular/src/froala/plugins/citationManager.ts
@@ -1,5 +1,6 @@
 import {cookie} from '@stratusjs/core/environment'
 import {Stratus} from '@stratusjs/runtime/stratus'
+import {extend} from 'lodash'
 // Universal Button
 import {
     InputButtonPlugin
@@ -18,18 +19,23 @@ const parentModuleName = 'froala/plugins'
 const min = !cookie('env') ? '.min' : ''
 const localDir = `${Stratus.BaseUrl}${boot.configuration.paths[`${systemDir}/*`].replace(/[^/]*$/, '')}`
 
-// Plugin Options
-FroalaEditor.DEFAULTS = Object.assign(FroalaEditor.DEFAULTS, {
-    endpoint: '/Api/Content'
+// Define toolbar template.
+extend(FroalaEditor.POPUP_TEMPLATES,{
+    'citationManager.toolbar': '[_BUTTONS_]'
 })
 
-/**
+// Define toolbar buttons.
+extend(FroalaEditor.DEFAULTS,{
+    citationToolbarButtons: ['citationEdit', 'citationDelete']
+})
+
+/*
  * @param editor The Froala instance
  */
-FroalaEditor.PLUGINS.citationManager = function citationManager (editor: any) {
+FroalaEditor.PLUGINS.citationManager = function citationManager(editor: any) {
     let inputButton: InputButtonPlugin
 
-    const debug = true // needs false
+    const debug = false
 
     // When the plugin is initialized,this will be called.
     function _init() {
@@ -45,7 +51,6 @@ FroalaEditor.PLUGINS.citationManager = function citationManager (editor: any) {
 
         if (debug) {
             console.log('initialized:', {
-                options: editor.opts.endpoint,
                 instance: this
             })
         }
@@ -54,7 +59,18 @@ FroalaEditor.PLUGINS.citationManager = function citationManager (editor: any) {
         // editor.methodName(params);
 
         // Event listeners
-        // editor.events.add('contentChanged', function (params) {});
+        editor.events.on('click', (clickEvent: MouseEvent) => {
+            if (
+                clickEvent.hasOwnProperty('target') &&
+                // clickEvent.target.hasOwnProperty('nodeName') &&
+                (clickEvent.target as Element).nodeName === 'STRATUS-CITATION'
+            ) {
+                const citation = getSelectedCitation() // If citation isn't fully grabbed, will not attempt
+                if (citation) {
+                    editor.citationManager.showToolbar(clickEvent, citation)
+                }
+            }
+        })
     }
 
     function onClick() {
@@ -65,17 +81,135 @@ FroalaEditor.PLUGINS.citationManager = function citationManager (editor: any) {
         inputButton.onClick(editor.el)
     }
 
+    function getSelectedCitation(): Element | null {
+        let containedElement = editor.selection.endElement()
+        if (containedElement.tagName === 'STRATUS-CITATION') {
+            // console.log('returning endElement', containedElement.tagName)
+            return containedElement
+        }
+
+        // console.log('endElement was a ', containedElement.tagName, containedElement)
+        containedElement = editor.selection.element()
+        if (containedElement.tagName === 'STRATUS-CITATION') {
+            // console.log('returning element', containedElement.tagName)
+            return containedElement
+        }
+
+        // console.log('element was a ', containedElement.tagName, containedElement)
+        // Check the parent just to be sure
+        containedElement = containedElement.parentElement
+        if (containedElement.tagName === 'STRATUS-CITATION') {
+            // console.log('returning parent element', containedElement.tagName)
+            return containedElement
+        }
+        // console.log('parent element was a ', containedElement.tagName, containedElement, 'returning nothing')
+
+        return null
+    }
+
+    function getLastKnownCitation() {
+        // console.log('returning last citation', editor.citationManager.lastCitation)
+        return editor.citationManager.lastCitation || null
+    }
+
+    function setLastKnownCitation(el: Element | null) {
+        // console.log('setting last citation to', el)
+        editor.citationManager.lastCitation = el
+    }
+
+    // Create custom inline toolbar.
+    function initToolbar() {
+        // Toolbar buttons.
+        let citationToolbarButtons = ''
+        // Create the list of buttons.
+        if (editor.opts.citationToolbarButtons.length > 1) {
+            citationToolbarButtons += '<div class="fr-buttons">'
+            citationToolbarButtons += editor.button.buildList(editor.opts.citationToolbarButtons)
+            citationToolbarButtons += '</div>'
+        }
+        // Load popup template.
+        const template = {
+            buttons: citationToolbarButtons
+        }
+        // Create popup.
+        return editor.popups.create('citationManager.toolbar', template)
+    }
+
+    // Show the toolbar
+    function showToolbar(clickEvent: MouseEvent, citation: Element) {
+        // Get the popup object defined above.
+        const popup = editor.popups.get('citationManager.toolbar')
+        // If popup doesn't exist then create it.
+        // To improve performance it is best to create the popup when it is first needed
+        // and not when the editor is initialized.
+        if (!popup) initToolbar()
+
+        // Set the editor toolbar as the popup's container.
+        editor.popups.setContainer('citationManager.toolbar', editor.$tb)
+        // This will trigger the refresh event assigned to the popup.
+        // editor.popups.refresh('citationManager.toolbar');
+        // This custom popup is opened by pressing a button from the editor's toolbar.
+        // Get the button's object in order to place the popup relative to it.
+        const btn = editor.$tb.find('.fr-command[data-cmd="myButton"]')
+        // Set the popup's position.
+        const left = clickEvent.pageX
+        const top = clickEvent.pageY
+        // Show the custom toolbar.
+        // The button's outerHeight is required in case the popup needs to be displayed above it.
+        editor.popups.show('citationManager.toolbar', left, top, btn.outerHeight())
+        editor.citationManager.setLastKnownCitation(citation)
+    }
+
+    // Hide the custom popup.
+    function hideToolbar() {
+        editor.citationManager.setLastKnownCitation(null)
+        editor.popups.hide('citationManager.toolbar')
+    }
+
     // Expose public methods.
     // Public methods can be accessed through the editor API:
     // editor.myPlugin.publicMethod();
     return {
         // If _init is not public then the plugin won't be initialized.
         _init,
-        onClick
+        onClick,
+        showToolbar,
+        hideToolbar,
+        getSelectedCitation,
+        getLastKnownCitation,
+        setLastKnownCitation
     }
 }
+export type CitationManager = {
+    hideToolbar(): void
+    showToolbar(): void
+    getSelectedCitation(): Element | null
+    getLastKnownCitation(): Element | null
+    setLastKnownCitation(el: Element | null): void
+}
 
-FroalaEditor.RegisterCommand('citationManager', {
+FroalaEditor.DefineIcon('citationDelete',{NAME: 'citationDelete', SVG_KEY: 'remove'})
+FroalaEditor.RegisterCommand('citationDelete', {
+    title: 'Delete Citation',
+    undo: false,
+    focus: false,
+    callback() {
+        /// only grab the selectedCitation
+        const containedElement = this.citationManager.getSelectedCitation()
+        if (containedElement) {
+            (containedElement as Element).remove()
+        }
+        this.citationManager.hideToolbar()
+    }
+})
+
+// Define button icons
+FroalaEditor.DefineIcon('citationManager', {NAME: 'citationManager', SVG_KEY: 'imageCaption'})
+// See https://froala.com/wysiwyg-editor/docs/concepts/custom/icon/ for making new icons
+
+// Define a insert button
+FroalaEditor.RegisterCommand('citationInsert', {
+    icon: 'citationManager',
     title: 'Insert Citation',
     undo: false,
     focus: false,
@@ -93,9 +227,24 @@ FroalaEditor.RegisterCommand('citationManager', {
     plugin: 'citationManager',
 })
 
-// Define button icons
-FroalaEditor.DefineIcon('citationManager', {NAME: 'folder', SVG_KEY: 'imageCaption'})
-// See https://froala.com/wysiwyg-editor/docs/concepts/custom/icon/ for making new icons
+// Define a edit button
+FroalaEditor.RegisterCommand('citationEdit', {
+    icon: 'citationManager',
+    title: 'Edit Citation',
+    undo: false,
+    focus: false,
+    modal: true,
+    callback(cmd: unknown, _val: unknown, _params: unknown) {
+        const debug = false
+        if (debug) {
+            console.log('clicked:', this.citationManager)
+        }
+        this.citationManager.onClick()
+    },
+    plugin: 'citationManager',
+})
+
+
 
 // Define a quick insert button
 FroalaEditor.RegisterQuickInsertButton('citation', {

--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@stratusjs/angularjs": "^0.3.2",
-    "@stratusjs/core": "^0.2.26",
+    "@stratusjs/core": "^0.3.1",
     "@stratusjs/runtime": "^0.11.10",
     "js-md5": "^0.7.3",
     "moment": "^2.24.0",

--- a/packages/angularjs-extras/src/components/citation.html
+++ b/packages/angularjs-extras/src/components/citation.html
@@ -1,8 +1,6 @@
 <span data-ng-cloak class="citation-popup" data-ng-class="{'opened': citationOpened}">
-    <span class="citation-title" data-ng-class="{'auto-counter': auto}" data-ng-bind="title + '.'"></span>
-    <!--<span class="citation-title" data-ng-bind="title + '.'"></span>-->
+    <span class="citation-title" data-ng-class="{'auto-counter': auto}" data-ng-transclude="title"></span>
     <span class="citation-popup-close" data-ng-click="toggleCitation()"><span class="citation-popup-close-btn"></span></span>
-    <span class="citation-text" data-ng-transclude></span>
+    <span class="citation-text" data-ng-transclude="content"></span>
 </span>
-<sup class="citation-title-sup" data-ng-class="{'auto-counter': auto}" data-ng-click="toggleCitation()" data-ng-bind="title"></sup>
-<!--<sup class="citation-title-sup" data-ng-click="toggleCitation()" data-ng-bind="title"></sup>-->
+<sup class="citation-title-sup" data-ng-class="{'auto-counter': auto}" data-ng-click="toggleCitation()" data-ng-transclude="title"></sup>

--- a/packages/angularjs-extras/src/components/citation.scss
+++ b/packages/angularjs-extras/src/components/citation.scss
@@ -44,6 +44,10 @@ stratus-citation {
     .citation-title {
       display: block;
       margin-bottom: 7px;
+      &::after {
+        /* Ensuring a ending marker is in the popup */
+        content: ".";
+      }
       &.auto-counter::before {
         /* Counting -here- so it only counting when class set to auto. this loads before the other counter */
         counter-increment: stratus-citation-counter;

--- a/packages/angularjs-extras/src/components/citation.ts
+++ b/packages/angularjs-extras/src/components/citation.ts
@@ -12,6 +12,7 @@ import {cookie} from '@stratusjs/core/environment'
 
 export type CitationComponentScope = angular.IScope & LooseObject<LooseFunction> & {
     title: string
+    content: string // HTML
     citationOpened: boolean
     auto: boolean
 
@@ -26,12 +27,13 @@ const componentName = 'citation'
 const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
 
 Stratus.Components.Citation = {
-    transclude: true,
-    bindings: {
-        title: '@',
+    transclude: {
+        content: 'stratusCitationContent',
+        title: '?stratusCitationTitle',
     },
     controller(
-        $scope: CitationComponentScope
+        $scope: CitationComponentScope,
+        $transclude: angular.ITranscludeFunction
     ) {
         // Initialize
         const $ctrl = this
@@ -43,10 +45,7 @@ Stratus.Components.Citation = {
 
         // Initialization
         $ctrl.$onInit = () => {
-            if (isEmpty($scope.title) && !isEmpty($ctrl.title)) {
-                $scope.title = $ctrl.title
-            }
-            if (!isEmpty($scope.title)) {
+            if ($transclude.isSlotFilled('title')) {
                 // We need to use the custom title
                 $scope.auto = false
             }


### PR DESCRIPTION
@stratusjs/angular 0.4.3 published
Changes:
- Format citations to latest templating
- Enable citation custom title editting
- Display citation custom titles

@stratusjs/angularjs-extras 0.11.2 published
Changes:
- Adjusts templating to account for multi-transcendence and the `<stratus-citation-title>` / `<stratus-citation-content>` inner elements
- Update Dependencies

Notes:
Usage is now with
```html
<stratus-citation>
  <stratus-citation-content>HTML popup content here.<stratus-citation-content>
  <stratus-citation-title>Custom Title Here<stratus-citation-title>
  <stratus-citation-notitle/>
</stratus-citation>
```

`<stratus-citation-notitle/>` or `<stratus-citation-title>` is only required in Froala as the editor requires some element if it's to annotate anything. The editor will add either one depending on if a title exists