### PR TITLE
@stratusjs/angular 0.4.8 & @stratusjs/angularjs 0.4.1: Link Manager & Generic Controller Enhancements

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -55,7 +55,7 @@
     "@angular/platform-browser-dynamic": "^12.2.16",
     "@angular/router": "^12.2.16",
     "@stratusjs/boot": "^0.3.0",
-    "@stratusjs/core": "^0.3.1",
+    "@stratusjs/core": "^0.4.0",
     "@stratusjs/map": "^0.4.3",
     "@stratusjs/runtime": "^0.11.14",
     "angular-froala-wysiwyg": "^3.2.7",

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -781,8 +781,8 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
         linkEditButtons: [
             'linkOpen',
             // 'linkStyle',
-            'linkEdit',
-            // 'linkManager',
+            // 'linkEdit',
+            'linkManagerEdit',
             'linkRemove',
         ],
         linkInsertButtons: [

--- a/packages/angular/src/froala/plugins/linkManager.ts
+++ b/packages/angular/src/froala/plugins/linkManager.ts
@@ -98,7 +98,22 @@ FroalaEditor.RegisterCommand('linkManager', {
     plugin: 'linkManager',
 }),
 FroalaEditor.DefineIcon('linkManager', {NAME: 'folder', SVG_KEY: 'insertLink'}),
+
+// Link Edit Icon
+FroalaEditor.RegisterCommand('linkManagerEdit', {
+    title: 'Edit Link',
+    undo: false,
+    focus: false,
+    modal: true,
+    callback() {
+        console.log('linkManagerEdit clicked:', this)
+        this.linkManager.onClick(undefined, FroalaEditor.PLUGINS.link(this).get())
+    },
+    plugin: 'linkManager',
+}),
 FroalaEditor.DefineIcon('linkManagerEdit', {NAME: 'edit', SVG_KEY: 'edit'}),
+
+// Other Icons
 FroalaEditor.DefineIcon('linkManagerInsert', {NAME: 'plus', SVG_KEY: 'add'}),
 FroalaEditor.DefineIcon('linkManagerDelete', {NAME: 'trash', SVG_KEY: 'remove'})
 

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs/src/controllers/generic.ts
+++ b/packages/angularjs/src/controllers/generic.ts
@@ -67,24 +67,7 @@ Stratus.Controllers.Generic = [
         $scope.Stratus = Stratus
         $scope._ = _
         $scope.$window = $window
-        $scope.setUrlParams = (options: any) => {
-            if (!_.isObject(options)) {
-                return
-            }
-            let substance = false
-            _.forEach(options, (value: any) => {
-                if (_.isUndefined(value) || value === null) {
-                    return
-                }
-                if (!_.isString(value) || value.length > 0) {
-                    substance = true
-                }
-            })
-            // TODO: I do not think that this should automatically force the URL to update
-            if (substance) {
-                window.location.replace(setUrlParams(options))
-            }
-        }
+        $scope.setUrlParams = setUrlParams
         $scope.$log = $log
 
         // Inject Javascript Objects


### PR DESCRIPTION
Adds:

- `linkManager` Functional Button for Link Edits

Changes:

- `generic` setUrlParams hoisted without modifications
- Bump `@stratusjs/angular` to `0.4.8`
- Bump `@stratusjs/angularjs` to `0.4.1`