### PR TITLE
@stratusjs/angularjs-extras 0.12.4

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -26,9 +26,9 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.6.0",
-    "@stratusjs/core": "^0.5.0",
-    "@stratusjs/runtime": "^0.12.0",
+    "@stratusjs/angularjs": "^0.6.2",
+    "@stratusjs/core": "^0.5.2",
+    "@stratusjs/runtime": "^0.12.1",
     "js-md5": "^0.7.3",
     "moment": "^2.24.0",
     "moment-range": "^4.0.2",

--- a/packages/angularjs-extras/src/components/citation.html
+++ b/packages/angularjs-extras/src/components/citation.html
@@ -1,6 +1,6 @@
-<span data-ng-cloak class="citation-popup" data-ng-class="{'opened': citationOpened}">
+<span data-ng-cloak data-ng-if="initialized" class="citation-popup" data-ng-class="{'opened': citationOpened}">
     <span class="citation-title" data-ng-class="{'auto-counter': auto}" data-ng-transclude="title"></span>
     <span class="citation-popup-close" data-ng-click="toggleCitation()"><span class="citation-popup-close-btn"></span></span>
     <span class="citation-text" data-ng-transclude="content"></span>
 </span>
-<sup class="citation-title-sup" data-ng-class="{'auto-counter': auto}" data-ng-click="toggleCitation()" data-ng-transclude="title"></sup>
+<sup data-ng-if="initialized" class="citation-title-sup" data-ng-class="{'auto-counter': auto}" data-ng-click="toggleCitation()" data-ng-transclude="title"></sup>

--- a/packages/angularjs-extras/src/components/citation.scss
+++ b/packages/angularjs-extras/src/components/citation.scss
@@ -5,6 +5,11 @@
 stratus-citation {
   position: relative;
   display: inline;
+  > stratus-citation-content,
+  > stratus-citation-title {
+    /* This content has yet to load/process, so hide for now */
+    display: none;
+  }
   .citation-title-sup {
     color: #f85b3b; /* handle generic color better */
     cursor: pointer;

--- a/packages/angularjs-extras/src/components/citation.scss
+++ b/packages/angularjs-extras/src/components/citation.scss
@@ -63,6 +63,7 @@ stratus-citation {
       opacity: 1;
       z-index: 9;
     }
+
     @media (max-width: 767px) {
       position: fixed;
       left: 10%;

--- a/packages/angularjs-extras/src/components/citation.scss
+++ b/packages/angularjs-extras/src/components/citation.scss
@@ -63,5 +63,13 @@ stratus-citation {
       opacity: 1;
       z-index: 9;
     }
+    @media (max-width: 767px) {
+      position: fixed;
+      left: 10%;
+      right: 10%;
+      bottom: 50%;
+      width: 80%;
+      transform: translateY(50%);
+    }
   }
 }

--- a/packages/angularjs-extras/src/components/citation.ts
+++ b/packages/angularjs-extras/src/components/citation.ts
@@ -1,19 +1,17 @@
 // Runtime
-import {camelCase, uniqueId} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
-import * as angular from 'angular'
-
-// Angular 1 Modules
-import 'angular-material'
+import {IAugmentedJQuery, IScope, ITranscludeFunction} from 'angular'
 
 // Stratus Dependencies
-import {LooseFunction, LooseObject} from '@stratusjs/core/misc'
+import {safeUniqueId} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
-export type CitationComponentScope = angular.IScope & LooseObject<LooseFunction> & {
+export type CitationComponentScope = IScope & {
+    // testId: string
     uid: string
-    title: string
-    content: string // HTML
+    initialized: boolean
+    // title: string
+    // content: string // HTML
     citationOpened: boolean
     auto: boolean
 
@@ -29,27 +27,36 @@ const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packag
 
 Stratus.Components.Citation = {
     transclude: {
-        content: 'stratusCitationContent',
+        content: '?stratusCitationContent',
         title: '?stratusCitationTitle',
     },
     controller(
         $scope: CitationComponentScope,
-        $transclude: angular.ITranscludeFunction
+        $element: IAugmentedJQuery,
+        $transclude: ITranscludeFunction,
+        // $attrs: IAttributes
     ) {
         // Initialize
-        const $ctrl = this
-        $scope.uid = uniqueId(camelCase(packageName) + '_' + camelCase(moduleName) + '_' + camelCase(componentName) + '_')
+        $scope.uid = safeUniqueId(packageName, moduleName, componentName)
         Stratus.Instances[$scope.uid] = $scope
         $scope.auto = true
+        $scope.initialized = false
+        // $scope.testId = $attrs.testId || '0'
 
-        Stratus.Internals.CssLoader(`${localDir}${componentName}${min}.css`)
+        Stratus.Internals.CssLoader(`${localDir}${componentName}${min}.css`).then()
 
         // Initialization
-        $ctrl.$onInit = () => {
+        this.$onInit = () => {
+            if (!$transclude.isSlotFilled('content')) {
+                console.warn('Warning, stratus-citation had no content', $scope, $element)
+                return // don't load
+            }
             if ($transclude.isSlotFilled('title')) {
                 // We need to use the custom title
                 $scope.auto = false
             }
+            $scope.$applyAsync(() => {$scope.initialized = true})
+            // console.log('initted', $scope, $element)
         }
         $scope.toggleCitation = () => {
             $scope.citationOpened = !$scope.citationOpened

--- a/packages/angularjs-extras/src/directives/baseNew.ts
+++ b/packages/angularjs-extras/src/directives/baseNew.ts
@@ -22,6 +22,7 @@ import {LooseObject} from '@stratusjs/core/misc'
 export type StratusDirective = ({
     restrict: 'A' | string
     require?: 'ngModel' | string
+    transclude?: boolean | LooseObject<string>
     scope?: LooseObject<string>
     template?: string | (($attrs?: IAttributes) => string)
     compile?($element: IAugmentedJQuery, $attrs: IAttributes): void


### PR DESCRIPTION
@stratusjs/angularjs-extras 0.12.4 published
Adds
- stratus-bind-html options to allow safer logic/data added directly to stratusHtmlBind attribute
- stratus-citation popup @media query for mobile use

Changes
- stratus-citation Add initializer and prevent transcluding elements before ready
- stratus-bind-html fix data compiled if used in conjunction with ng-bind-html (will add delay for race conditions)
- stratus-bind-html added warnings on page if ng-bind-html is used

Notes
Rather than performing logic such as 
`data-stratus-bind-html data-ng-bind-html="::getHTML(model.data.version.text)"`
should now be
`data-stratus-bind-html="::model.data.version.text"`

This will be safer to avoid race conditions and faster as will happen as soon as ready.