### PR TITLE
@stratusjs/angular 0.5.5: Editor Improvements

### DIFF
--- a/dist-names.sh
+++ b/dist-names.sh
@@ -5,11 +5,21 @@
 #############################################
 
 # todo: make this dynamic XD
-packages=( angular angularjs angularjs-extras calendar core idx map strip swiper )
+packages=(
+  angular
+  angularjs
+  angularjs-extras
+  calendar
+  core
+  idx
+  map
+  stripe
+  swiper
+)
 for package in "${packages[@]}"
 do
-	if [[ -f "packages/$package/dist/multi-entry.js" ]]; then
-      echo "Rename packages/$package/dist/multi-entry.js -> packages/$package/dist/$package.bundle.js"
-      mv "packages/$package/dist/multi-entry.js" "packages/$package/dist/$package.bundle.js"
+	if [[ -f "packages/${package}/dist/multi-entry.js" ]]; then
+      echo "Rename packages/${package}/dist/multi-entry.js -> packages/${package}/dist/$(echo "$package" | tr '[:upper:]' '[:lower:]').bundle.js"
+      mv "packages/${package}/dist/multi-entry.js" "packages/${package}/dist/$(echo "$package" | tr '[:upper:]' '[:lower:]').bundle.js"
   fi
 done

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angular/src/editor/code-mirror-bridge.ts
+++ b/packages/angular/src/editor/code-mirror-bridge.ts
@@ -1,9 +1,15 @@
 // Stratus Core
 import {LooseFunction, LooseObject} from '@stratusjs/core/misc'
-import {Extension} from '@codemirror/state'
+
+// Stratus Runtime
+import {Stratus} from '@stratusjs/runtime/stratus'
+
+// Libraries
+import {uniqueId} from 'lodash'
 
 // CodeMirror
 import {basicSetup, EditorView} from 'codemirror'
+import {Extension} from '@codemirror/state'
 
 // Data Type Interfaces
 interface CodeMirrorPos {
@@ -18,12 +24,18 @@ interface CodeMirrorBridgeOptions {
     extensions?: Extension
 }
 export class CodeMirrorBridge {
+    uid: string
     editorView: EditorView
     extensions?: Extension
     constructor(opts?: CodeMirrorBridgeOptions) {
+        // Initialization
+        this.uid = uniqueId(`code_mirror_bridge_`)
+        Stratus.Instances[this.uid] = this
+        // Verify Options
         if (!opts || !(typeof opts === 'object')) {
             return
         }
+        // Hoist Options
         this.extensions = opts.extensions
     }
     fromTextArea(el: HTMLTextAreaElement, opts: LooseObject) {
@@ -50,13 +62,11 @@ export class CodeMirrorBridge {
         console.warn('CodeMirror Bridge has not implemented a clearHistory function.')
     }
     on(event: string, func: LooseFunction) {
-        // TODO: Implement this, if we find a CodeMirror 6 equivalent or necessity.
-        console.warn('bind attempt:', {event, func})
-        console.warn('CodeMirror Bridge has not implemented an on(event) function.')
+        this.editorView.contentDOM.addEventListener(event, func)
     }
-    setSize(width?: string|number, height?: string|number) {
-        // TODO: Implement this, if we find a CodeMirror 6 equivalent or necessity.
-        console.warn('CodeMirror Bridge has not implemented a setSize function.')
+    setSize(width?: string, height?: string) {
+        this.editorView.dom.style.width = width || ''
+        this.editorView.dom.style.height = height || ''
     }
     getValue() {
         return this.editorView.state.doc.toString()
@@ -79,7 +89,6 @@ export class CodeMirrorBridge {
         })
     }
     toTextArea() {
-        // TODO: Implement this, if we find a CodeMirror 6 equivalent or necessity.
-        console.warn('CodeMirror Bridge has not implemented a toTextArea function.')
+        this.editorView.destroy()
     }
 }

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -121,7 +121,7 @@ import {
 } from 'ts-transformer-keys'
 
 // Froala External Requirements (Before Plugins are Loaded)
-import {EditorView, basicSetup} from 'codemirror'
+import {EditorView, basicSetup, minimalSetup} from 'codemirror'
 import {html} from '@codemirror/lang-html'
 import 'html2pdf'
 import 'font-awesome'
@@ -506,12 +506,13 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             wrap_line_length: 0
         },
         // fromTextArea
-        codeMirror: {
+        codeMirror: !cookie('codemirror') ? null : {
             fromTextArea: (el: HTMLTextAreaElement, opts: LooseObject) => {
                 // Note: We're instantiating a Bridge Class to act as an intermediate for Froala's legacy implementation.
                 return new CodeMirrorBridge({
                     extensions: [
-                        basicSetup,
+                        // basicSetup,
+                        minimalSetup,
                         html({
                             // extraTags: [
                             //     'sa-editor'
@@ -521,7 +522,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
                             // ],
                         }),
                         // TODO: Make this an optional extension, based on options
-                        EditorView.lineWrapping
+                        // EditorView.lineWrapping
                     ]
                 }).fromTextArea(el, opts)
             }
@@ -637,6 +638,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
         ],
         htmlAllowedEmptyTags: [
             'textarea', 'a', 'iframe', 'object', 'video', 'style', 'script',
+            'form',
             // '.fa', '.fr-emoticon', '.fr-inner',
             // 'path', 'line',
             'hr', 'div',
@@ -671,7 +673,29 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             // AngularJS Material Secondary Tags
             'md-svg-src',
             // Stratus AngularJS Tags
+            'stratus-base',
+            'stratus-citation',
             'stratus-citation-notitle',
+            'stratus-content-selector',
+            'stratus-date-time',
+            'stratus-error-message',
+            'stratus-facebook',
+            'stratus-filter',
+            'stratus-help',
+            'stratus-image-carousel',
+            'stratus-json-editor',
+            'stratus-media-details',
+            'stratus-media-library',
+            'stratus-media-selector',
+            'stratus-media-short-details',
+            'stratus-media-uploader',
+            'stratus-option-value',
+            'stratus-pagination',
+            'stratus-permissions',
+            'stratus-publish',
+            'stratus-search',
+            'stratus-tag',
+            'stratus-twitter-feed',
             // Stratus Angular+ Tags
             'sa-boot',
             'sa-editor',
@@ -865,7 +889,9 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             'sa-.+'
         ],
         pasteDeniedTags: [
-            'form', 'input', 'label',
+            'form',
+            'input',
+            'label',
             'style'
         ],
         pastePlain: false,

--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs-extras/src/filters/truncateHtml.ts
+++ b/packages/angularjs-extras/src/filters/truncateHtml.ts
@@ -1,0 +1,30 @@
+// TruncateHtml Filter
+// -----------------
+
+import {
+    Stratus
+} from '@stratusjs/runtime/stratus'
+import {
+    truncate,
+    LooseObject
+} from '@stratusjs/core/misc'
+import {extend, isObject, isString} from 'lodash'
+
+// This filter truncates a string
+Stratus.Filters.TruncateHtml = () =>
+    (input: number, options?: LooseObject) => {
+        if (!isString(input)) {
+            return input
+        }
+        const tempScope: {
+            limit?: number,
+            suffix?: string
+        }  = {
+            limit: 100, // 100 is the default from original misc/truncate
+            suffix: '...' // '...' is the default from original misc/truncate
+        }
+        if (isObject(options)) {
+            extend(tempScope, options)
+        }
+        return truncate(input, tempScope.limit, tempScope.suffix)
+    }

--- a/packages/core/src/misc.ts
+++ b/packages/core/src/misc.ts
@@ -322,7 +322,7 @@ export function safeUniqueId(...names: string[]): string {
 }
 
 /**
- * @deprecated use _.truncate() instead
+ * _.truncate() is faster if target doesn't contain html
  * https://lodash.com/docs/4.17.15#truncate
  *
  * @param target string to truncate


### PR DESCRIPTION
Adds:

- `CodeMirrorBridge`: Stratus Initialization
- `CodeMirrorBridge`: `on()` Event Listeners
- `CodeMirrorBridge`: `setSize()` Function
- `CodeMirrorBridge`: `toTextArea()` (Destroy) Function
- `Editor`: `htmlAllowedEmptyTags` with Stratus Components
- `truncateHtml`: filter that preserves html

Changes:

- Bump `@stratusjs/angular` to `0.5.5`
- Bump `@stratusjs/angularjs-extras` to `0.12.6`
- `CodeMirror`: enabled with `codemirror` cookie
- `CodeMirror`: minimalSetup while testing

Removes:

- Core: Deprecation for `truncate()`

Fixes:

- POSIX Standards for `dist-names.sh`