### PR TITLE
@stratusjs/angular 0.5.8: CodeMirror Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@babel/parser": "^7.9.4",
     "@babel/types": "^7.9.5",
     "@codemirror/lang-html": "^6.4.0",
+    "@codemirror/theme-one-dark": "^6.1.0",
     "@fullcalendar/common": "^5.11.3",
     "@fullcalendar/core": "^5.11.3",
     "@fullcalendar/daygrid": "^5.11.3",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angular/src/editor/code-mirror-bridge.ts
+++ b/packages/angular/src/editor/code-mirror-bridge.ts
@@ -27,6 +27,7 @@ export class CodeMirrorBridge {
     uid: string
     editorView: EditorView
     extensions?: Extension
+    dom: HTMLTextAreaElement
     constructor(opts?: CodeMirrorBridgeOptions) {
         // Initialization
         this.uid = uniqueId(`code_mirror_bridge_`)
@@ -39,6 +40,7 @@ export class CodeMirrorBridge {
         this.extensions = opts.extensions
     }
     fromTextArea(el: HTMLTextAreaElement, opts: LooseObject) {
+        this.dom = el
         this.editorView = new EditorView({
             doc: el.value,
             extensions: this.extensions || [],

--- a/packages/angular/src/editor/editor.component.scss
+++ b/packages/angular/src/editor/editor.component.scss
@@ -50,3 +50,12 @@ md-tabs {
 div.fr-quick-insert.fr-visible {
 
 }
+
+// CodeMirror 6 CSS for Froala
+// Note: This needs !important to override the built-in !important
+.fr-box .ͼ1.cm-editor {
+  display: none !important;
+}
+.fr-box.fr-code-view .ͼ1.cm-editor {
+  display: block !important;
+}

--- a/packages/angular/src/editor/editor.component.scss
+++ b/packages/angular/src/editor/editor.component.scss
@@ -59,3 +59,20 @@ div.fr-quick-insert.fr-visible {
 .fr-box.fr-code-view .ͼ1.cm-editor {
   display: flex !important;
 }
+
+// These are the selectors you'd want to overwrite to make the editor completely dark.
+/* *
+.dark-theme {
+  &.fr-box.fr-basic {
+    .fr-wrapper {
+      background-color: #454545;
+    }
+    .fr-element {
+      color: #BFB9B1;
+    }
+  }
+  .fr-second-toolbar {
+    background-color: #353535;
+  }
+}
+/* */

--- a/packages/angular/src/editor/editor.component.scss
+++ b/packages/angular/src/editor/editor.component.scss
@@ -57,5 +57,5 @@ div.fr-quick-insert.fr-visible {
   display: none !important;
 }
 .fr-box.fr-code-view .ͼ1.cm-editor {
-  display: block !important;
+  display: flex !important;
 }

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -121,8 +121,6 @@ import {
 } from 'ts-transformer-keys'
 
 // Froala External Requirements (Before Plugins are Loaded)
-import {EditorView, basicSetup, minimalSetup} from 'codemirror'
-import {html} from '@codemirror/lang-html'
 import 'html2pdf'
 import 'font-awesome'
 
@@ -176,8 +174,16 @@ import 'froala-image-tui'
 import '../froala/plugins/citationManager'
 import '../froala/plugins/linkManager'
 import '../froala/plugins/mediaManager'
-import {FroalaEditorDirective} from 'angular-froala-wysiwyg'
 // import '../froala/plugins/menuButton'
+
+// Froala Directive
+import {FroalaEditorDirective} from 'angular-froala-wysiwyg'
+
+// CodeMirror Requirements
+import {basicSetup} from 'codemirror'
+import {Extension} from '@codemirror/state'
+import {html} from '@codemirror/lang-html'
+import {oneDarkTheme} from '@codemirror/theme-one-dark'
 
 // Local Setup
 const systemPackage = '@stratusjs/angular'
@@ -504,24 +510,22 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
         // fromTextArea
         codeMirror: {
             fromTextArea: (el: HTMLTextAreaElement, opts: LooseObject) => {
+                const extensions: Array<Extension> = [
+                    basicSetup,
+                    html({
+                        // extraTags: [
+                        //     'sa-editor'
+                        // ],
+                        // extraGlobalAttributes: [
+                        //     'stratus-src'
+                        // ],
+                    }),
+                ]
+                if (cookie('dark')) {
+                    extensions.push(oneDarkTheme)
+                }
                 // Note: We're instantiating a Bridge Class to act as an intermediate for Froala's legacy implementation.
-                return new CodeMirrorBridge({
-                    extensions: [
-                        basicSetup,
-                        // minimalSetup,
-                        html({
-                            // extraTags: [
-                            //     'sa-editor'
-                            // ],
-                            // extraGlobalAttributes: [
-                            //     'stratus-src'
-                            // ],
-                        }),
-                        // TODO: Make this an optional extension, based on options
-                        // This is included in basicSetup
-                        // EditorView.lineWrapping
-                    ]
-                }).fromTextArea(el, opts)
+                return new CodeMirrorBridge({extensions}).fromTextArea(el, opts)
             }
         },
         codeMirrorOptions: {
@@ -951,6 +955,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
         ],
         scrollableContainer: Stratus.Environment.get('viewPort') || 'body',
         spellcheck: true,
+        theme: cookie('dark') ? 'dark' : null,
         toolbarSticky: true,
         toolbarButtons: {
             moreText: {
@@ -1056,6 +1061,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             // `${codeMirrorDir}lib/codemirror.css`,
             `${froalaDir}css/froala_editor.pkgd${min}.css`,
             // `${froalaDir}css/froala_style${min}.css`,
+            `${froalaDir}css/themes/dark${min}.css`,
             `${froalaDir}css/third_party/embedly${min}.css`,
             `${froalaDir}css/third_party/font_awesome${min}.css`,
             `${froalaDir}css/third_party/image_tui${min}.css`,

--- a/packages/angular/src/editor/editor.component.ts
+++ b/packages/angular/src/editor/editor.component.ts
@@ -502,13 +502,13 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
             wrap_line_length: 0
         },
         // fromTextArea
-        codeMirror: !cookie('codemirror') ? null : {
+        codeMirror: {
             fromTextArea: (el: HTMLTextAreaElement, opts: LooseObject) => {
                 // Note: We're instantiating a Bridge Class to act as an intermediate for Froala's legacy implementation.
                 return new CodeMirrorBridge({
                     extensions: [
-                        // basicSetup,
-                        minimalSetup,
+                        basicSetup,
+                        // minimalSetup,
                         html({
                             // extraTags: [
                             //     'sa-editor'
@@ -518,6 +518,7 @@ export class EditorComponent extends RootComponent implements OnInit, TriggerInt
                             // ],
                         }),
                         // TODO: Make this an optional extension, based on options
+                        // This is included in basicSetup
                         // EditorView.lineWrapping
                     ]
                 }).fromTextArea(el, opts)


### PR DESCRIPTION
Adds:

- CodeMirror: Dark Mode
- Froala: Dark Mode

Changes:

- Editor: CodeMirror from Minimal to Full Featured
- Editor: CodeMirror to Display by Default
- CodeMirrorBridge: DOM Variable

Changes:

- Bump `@stratusjs/angular` to `0.5.8`

Fixes:

- Editor: CodeMirror Display out of Code View