### PR TITLE
@stratusjs/angular 0.5.11: Fix Link Dialog

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angular/src/editor/link-dialog.component.ts
+++ b/packages/angular/src/editor/link-dialog.component.ts
@@ -337,6 +337,11 @@ export class LinkDialogComponent extends ResponsiveComponent implements OnInit, 
     }
 
     onCancelClick(): void {
+        if (!this.eventManager) {
+            console.warn(`${moduleName}: event manager is not set.`)
+            return
+        }
+        this.eventManager.trigger('restore', null, this.editor)
         this.dialogRef.close()
         this.refresh()
     }

--- a/packages/angular/src/froala/plugins/inputButton.ts
+++ b/packages/angular/src/froala/plugins/inputButton.ts
@@ -96,7 +96,8 @@ export class InputButtonPlugin<EventData = string|LooseObject> implements Trigge
             console.warn(`${this.name}.trigger(): unable to inject html without a set editor.`)
             return
         }
-        if (name !== 'insert') {
+        // Ensure we only continue for 'insert' or 'restore' events
+        if (['insert', 'restore'].includes(name)) {
             console.warn(`${this.name}.trigger():`, name, 'event is not supported.')
             return
         }
@@ -107,6 +108,11 @@ export class InputButtonPlugin<EventData = string|LooseObject> implements Trigge
         // Attempt to Restore Selection
         if (this.autoRestoreSelection) {
             this.restoreSelection()
+        }
+        // Ensure we only continue for 'insert' events
+        if (name !== 'insert') {
+            console.warn(`${this.name}.trigger():`, name, 'event is not supported.')
+            return
         }
         // Insert our data into Froala on the caret
         this.insert ? this.insert(data): this.editor.html.insert(data)
@@ -127,7 +133,9 @@ export class InputButtonPlugin<EventData = string|LooseObject> implements Trigge
             return false
         }
         // Get focus back to the editor
-        this.editor.events.focus()
+        // Note: This is disabled because it makes the cursor jolt to the top
+        // console.log('[restoreSnapshot]is focused:', this.editor.core.hasFocus())
+        //this.editor.events.focus()
         // Restore last snapshot
         this.editor.snapshot.restore(this.snapshot)
         return true
@@ -147,7 +155,9 @@ export class InputButtonPlugin<EventData = string|LooseObject> implements Trigge
             return false
         }
         // Get focus back to the editor
-        this.editor.events.focus()
+        // Note: This is disabled because it makes the cursor jolt to the top
+        // console.log('[restoreSelection]is focused:', this.editor.core.hasFocus())
+        // this.editor.events.focus()
         // Restore last selection
         this.editor.selection.restore()
         return true


### PR DESCRIPTION
Adds:

- inputButton: `restore` event

Changes:

- Bump `@stratusjs/angular` to `0.5.11`

Fixes:

- Editor: Cursor/Selection lost during Link Creation
- Editor: Cursor/Selection lost during Link Dialog Cancellation