### PR TITLE
@stratusjs/Idx bundling + @stratusjs/map + @stratusjs/stripe fix missing modules

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -28,6 +28,8 @@
   "devDependencies": {
     "@mat-datetimepicker/core": "6.0.3",
     "@mat-datetimepicker/moment": "6.0.3",
+    "@stratusjs/map": "^0.6.1",
+    "@stratusjs/stripe": "^1.5.1",
     "core-js": "^3.19.0",
     "quill": "^1.3.7",
     "quill-autoformat": "^0.1.2",
@@ -56,7 +58,6 @@
     "@codemirror/lang-html": "^6.4.0",
     "@stratusjs/boot": "^0.3.2",
     "@stratusjs/core": "^0.5.2",
-    "@stratusjs/map": "^0.5.2",
     "@stratusjs/runtime": "^0.12.1",
     "angular-froala-wysiwyg": "^3.2.7",
     "codemirror": "^6.0.1",

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.16.6",
+  "version": "0.17.0",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./src/idx.js",
   "scripts": {

--- a/packages/idx/src/map/map.component.ts
+++ b/packages/idx/src/map/map.component.ts
@@ -16,6 +16,7 @@ import {numeralFormat} from '@stratusjs/angularjs-extras/filters/numeral'
 // Stratus Preload
 // tslint:disable-next-line:no-duplicate-imports
 import '@stratusjs/idx/idx'
+import '@stratusjs/map/map' // We need sa-map
 
 // Environment
 const min = !cookie('env') ? '.min' : ''

--- a/packages/idx/src/map/map.component.ts
+++ b/packages/idx/src/map/map.component.ts
@@ -35,6 +35,7 @@ export type IdxMapScope = IdxComponentScope & {
     list: IdxListScope
 
     instancePath: string
+    instanceFullPath: string
     googleMapsKey: string
     mapType: string
     zoom: number
@@ -186,7 +187,8 @@ Stratus.Components.IdxMap = {
         $scope.uid = safeUniqueId(packageName, moduleName, componentName)
         Stratus.Instances[$scope.uid] = $scope
         $scope.elementId = $attrs.elementId || $scope.uid
-        $scope.instancePath = `Stratus.Instances.${$scope.elementId}`
+        $scope.instancePath = $scope.elementId
+        $scope.instanceFullPath = `Stratus.Instances.${$scope.instancePath}`
 
         this.$onInit = () => {
             $scope.Idx = Idx

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/map",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Angular Google Map component to be used as an add-on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "@angular/google-maps": "^11.2.13",
-    "@stratusjs/angular": "^0.5.9"
+    "@stratusjs/angular": "^0.6.1"
   }
 }

--- a/packages/map/src/map.module.ts
+++ b/packages/map/src/map.module.ts
@@ -1,10 +1,18 @@
 import {StratusPackage} from '@stratusjs/angular/app.module'
-import { NgModule } from '@angular/core'
+import {NgModule} from '@angular/core'
+import {BrowserModule} from '@angular/platform-browser'
+import {CommonModule} from '@angular/common'
 import {GoogleMapsModule} from '@angular/google-maps'
+import {MaterialModules} from '../../angular/src/material'
 import {MapComponent} from './map.component'
 
-
 @NgModule({
+    imports: [
+        BrowserModule,
+        CommonModule,
+        GoogleMapsModule,
+        MaterialModules
+    ],
     // These determine what exists as a component within Angular system.
     declarations: [
         MapComponent
@@ -12,9 +20,6 @@ import {MapComponent} from './map.component'
     // This determines what is accessible via DOM as a component. These must be listed in `declarations`. (required in stratus)
     entryComponents: [
         MapComponent
-    ],
-    imports: [
-        GoogleMapsModule
     ],
     exports: [
         MapComponent

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/stripe",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Angular Stripe Elements components to be used as an add on to StratusJS",
   "main": "",
   "scripts": {

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -29,7 +29,7 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angular": "^0.4.10",
-    "@stratusjs/runtime": "^0.12.0"
+    "@stratusjs/angular": "^0.6.1",
+    "@stratusjs/runtime": "^0.12.1"
   }
 }

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -1,13 +1,23 @@
 import {StratusPackage} from '@stratusjs/angular/app.module'
-import { NgModule } from '@angular/core'
+import {NgModule} from '@angular/core'
+import {BrowserModule} from '@angular/platform-browser'
+import {CommonModule} from '@angular/common'
+import {FormsModule, ReactiveFormsModule} from '@angular/forms'
+import {MaterialModules} from '../../angular/src/material'
 import {StripePaymentMethodComponent} from './payment-method.component'
 import {StripePaymentMethodItemComponent} from './payment-method-item.component'
 import {StripePaymentMethodListComponent} from './payment-method-list.component'
 import {StripePaymentMethodSelectorComponent} from './payment-method-selector.component'
 import {StripeSetupIntentComponent} from './setup-intent.component'
 
-
 @NgModule({
+    imports: [
+        BrowserModule,
+        CommonModule,
+        FormsModule,
+        MaterialModules,
+        ReactiveFormsModule,
+    ],
     // These determine what exists as a component within Angular system.
     declarations: [
         StripePaymentMethodComponent,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -204,6 +204,39 @@ export default [
         config: false
       })
     ]
+  },
+  // ------------------------
+  // Idx Config
+  // ------------------------
+  {
+    input: {
+      include: [
+        './packages/idx/src/**/*.js'
+      ],
+      exclude: []
+    },
+    external: [
+      'angular',
+      'angular-material',
+      'angular-sanitize',
+      'lodash',
+      'moment',
+      '@stratusjs'
+    ],
+    output: {
+      // file: 'packages/idx/dist/idx.bundle.js',
+      dir: 'packages/idx/dist/',
+      format: 'system'
+    },
+    plugins: [
+      multi({
+        exports: true,
+        entryFileName: 'idx.bundle.js'
+      }),
+      nodeResolve({
+        // browser: true
+      })
+    ]
   }
   // ------------------------
   // Map Config


### PR DESCRIPTION
@stratusjs/Idx 0.17.0
Added:
- Bundling now to idx.bundle.js

Changes:
- Updated map component sa-map `callback` pathing due to Stratus being removed from global window

--------

@stratusjs/map 0.6.1 published
Changes:
- Fixes missing ngModules
- Allow checking `callback` paths within `Stratus.Instances` directly (fixes checks in @stratusjs/idx not being in global window anymore)

--------

@stratusjs/stripe 1.5.1 published
Changes:
- Fixes missing ngModules

------

@stratusjs/angular 0.6.1 published the @stratusjs/map + @stratusjs/stripe
