### PR TITLE
@stratusjs/idx 0.17.3 Neighborhood clearing

### DIFF
--- a/packages/boot/src/config.js
+++ b/packages/boot/src/config.js
@@ -27,7 +27,7 @@
     shim: {},
 
     // Package Directories
-    packages: [],
+    packages: {},
 
     // Relative Paths
     paths: {

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -263,6 +263,7 @@ export interface WhereOptions extends LooseObject {
     CityRegion?: string[] | string,
     CountyOrParish?: string[] | string,
     MLSAreaMajor?: string[] | string,
+    Subdivision?: string[] | string,
     ListPriceMin?: number | any,
     ListPriceMax?: number | any,
     Bathrooms?: number | any, // Previously BathroomsFullMin
@@ -653,6 +654,7 @@ const angularJsService = (
         ListingType: [],
         CountyOrParish: [],
         MLSAreaMajor: [],
+        Subdivision: [],
         Neighborhood: [],
         PostalCode: [],
         // NOTE: at this point we don't know if CityRegion is used (or how it differs from MLSAreaMajor)

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -550,13 +550,7 @@ Stratus.Components.IdxPropertyList = {
                     query.where.CityRegion = []
                     query.where.PostalCode = []
                     query.where.MLSAreaMajor = []
-                }
-                if (!isEmpty(query.where.Neighborhood)) {
-                    query.where.City = []
-                    query.where.UnparsedAddress = ''
-                    query.where.CityRegion = []
-                    query.where.PostalCode = []
-                    query.where.MLSAreaMajor = []
+                    query.where.Subdivison = []
                 }
 
                 // Page checks


### PR DESCRIPTION
@stratusjs/idx 0.17.3 publish
Changes
- Stop clearing filters on search when `Neighborhood` is entered
- Adds unused/possible future uses of Subdivision

@stratusjs/boot
Changes
- Sync formatting of config.js to limit browser complaints when they are merged