### PR TITLE
@stratusjs/boot 1.0.1 @stratusjs/angularjs-extras 0.12.12 @stratusjs/calendar 1.2.1

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -26,7 +26,7 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.6.2",
+    "@stratusjs/angularjs": "^0.6.7",
     "@stratusjs/core": "^0.5.2",
     "@stratusjs/runtime": "^0.12.1",
     "js-md5": "^0.7.3",

--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -26,7 +26,7 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.6.7",
+    "@stratusjs/angularjs": "^0.6.2",
     "@stratusjs/core": "^0.5.2",
     "@stratusjs/runtime": "^0.12.1",
     "js-md5": "^0.7.3",

--- a/packages/angularjs-extras/src/directives/src.ts
+++ b/packages/angularjs-extras/src/directives/src.ts
@@ -2,7 +2,7 @@
 // -----------------
 
 // Runtime
-import {filter, size} from 'lodash'
+import {filter, isString, size} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {
     element,
@@ -73,11 +73,12 @@ Stratus.Directives.Src = (
 
         /** Sets the image src/css background on a tag */
         $scope.setSrc = (tagType: string, src: string) => {
-            // FIXME: This is the problem?
-            if (tagType === 'img') {
-                $element.attr('src', src)
-            } else {
-                $element.css('background-image', `url(${src})`)
+            if (src && isString(src) && src.length > 0) {
+                if (tagType === 'img') {
+                    $element.attr('src', src)
+                } else {
+                    $element.css('background-image', `url(${src})`)
+                }
             }
         }
 

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/boot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This is the boot package for StratusJS.",
   "main": "dist/boot.min.js",
   "scripts": {},

--- a/packages/boot/src/config.ts
+++ b/packages/boot/src/config.ts
@@ -184,38 +184,6 @@
             'angular-drag-and-drop-lists': {
                 deps: ['angular']
             },
-
-            /* Calendar */
-            '@fullcalendar/daygrid': {
-                deps: [
-                    '@fullcalendar/core'
-                ]
-            },
-            '@fullcalendar/timegrid': {
-                deps: [
-                    '@fullcalendar/core'
-                ]
-            },
-            '@fullcalendar/list': {
-                deps: [
-                    '@fullcalendar/core'
-                ]
-            },
-            '@fullcalendar/moment': {
-                deps: [
-                    '@fullcalendar/core'
-                ]
-            },
-            '@fullcalendar/moment-timezone': {
-                deps: [
-                    '@fullcalendar/moment'
-                ]
-            },
-            '@stratusjs/calendar/customView': {
-                deps: [
-                    '@fullcalendar/core'
-                ]
-            }
         },
 
         // Package Directories
@@ -441,14 +409,8 @@
             'preact/hooks': stratusjsCalendarBundlePath, // Since when was this bundled in calendar? (its what works)
             'skrollr-native': `${boot.deployment}skrollr-typed/${boot.dev ? 'src' : 'dist'}/skrollr${boot.suffix}`,
 
-            // Calendar
-            ical: `${boot.deployment}ical.js/build/ical${boot.suffix}`,
-
             // Masonry TODO: Remove this...  Should not be in use anymore...
             'masonry-native': `${boot.deployment}masonry-layout/dist/masonry.pkgd${boot.suffix}`,
-
-            // Swiper Carousel
-            swiper: `${boot.deployment}swiper/swiper-bundle${boot.suffix}`,
 
             // Froala Directive and Libraries
             froala: `${boot.deployment}froala-editor/js/froala_editor.min`,

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/calendar",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AngularJS Calendar component and iCAL service to be used as an add on to StratusJS. Makes use of fullcalendar and iCAL",
   "scripts": {},
   "repository": {
@@ -34,8 +34,8 @@
     "@fullcalendar/moment": "^5.11.2",
     "@fullcalendar/moment-timezone": "^5.11.2",
     "@fullcalendar/timegrid": "^5.11.2",
-    "@stratusjs/angularjs": "^0.6.7",
-    "@stratusjs/angularjs-extras": "^0.12.11",
+    "@stratusjs/angularjs": "^0.6.2",
+    "@stratusjs/angularjs-extras": "^0.12.12",
     "@stratusjs/boot": "^1.0.1",
     "@stratusjs/runtime": "^0.12.1",
     "ical.js": "^1.5.0",

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/calendar",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AngularJS Calendar component and iCAL service to be used as an add on to StratusJS. Makes use of fullcalendar and iCAL",
   "scripts": {},
   "repository": {
@@ -34,9 +34,10 @@
     "@fullcalendar/moment": "^5.11.2",
     "@fullcalendar/moment-timezone": "^5.11.2",
     "@fullcalendar/timegrid": "^5.11.2",
-    "@stratusjs/angularjs": "^0.3.2",
-    "@stratusjs/angularjs-extras": "^0.9.4",
-    "@stratusjs/runtime": "^0.11.9",
+    "@stratusjs/angularjs": "^0.6.7",
+    "@stratusjs/angularjs-extras": "^0.12.11",
+    "@stratusjs/boot": "^1.0.1",
+    "@stratusjs/runtime": "^0.12.1",
     "ical.js": "^1.5.0",
     "tslib": "^2.4.0"
   }

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -6,8 +6,6 @@
 // TODO later when implementing new data source types, refer to https://fullcalendar.io/docs/google-calendar as a plugin example
 
 // credit to https://github.com/leonaard/icalendar2fullcalendar for ics conversion
-
-// Runtime
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {extend, isArray} from 'lodash'
 import {
@@ -26,16 +24,16 @@ import 'moment-range'
 import '@stratusjs/angularjs-extras'
 import {cookie} from '@stratusjs/core/environment'
 import {isJSON, safeUniqueId} from '@stratusjs/core/misc'
-import {Calendar, EventApi} from '@fullcalendar/core'
 import {ICalExpander} from '@stratusjs/calendar/iCal'
 
 // FullCalendar
+import {Calendar, EventApi} from '@fullcalendar/core'
 import '@fullcalendar/core/vdom'
-import * as momentPlugin from '@fullcalendar/moment'
-import * as momentTimezonePlugin from '@fullcalendar/moment-timezone'
-import * as fullCalendarDayGridPlugin from '@fullcalendar/daygrid'
-import * as fullCalendarTimeGridPlugin from '@fullcalendar/timegrid'
-import * as fullCalendarListPlugin from '@fullcalendar/list'
+import momentPlugin from '@fullcalendar/moment'
+import momentTimezonePlugin from '@fullcalendar/moment-timezone'
+import fullCalendarDayGridPlugin from '@fullcalendar/daygrid'
+import fullCalendarTimeGridPlugin from '@fullcalendar/timegrid'
+import fullCalendarListPlugin from '@fullcalendar/list'
 
 // Components
 import { customViewPluginConstructor } from '@stratusjs/calendar/customView'
@@ -206,11 +204,11 @@ Stratus.Components.Calendar = {
         $scope.options.eventSources = $scope.options.eventSources || []
 
         $scope.options.plugins = [
-            momentPlugin.default, // Plugins are ES6 imports and return with 'default'
-            momentTimezonePlugin.default, // Plugins are ES6 imports and return with 'default'
-            fullCalendarDayGridPlugin.default, // Plugins are ES6 imports and return with 'default'
-            fullCalendarTimeGridPlugin.default, // Plugins are ES6 imports and return with 'default'
-            fullCalendarListPlugin.default, // Plugins are ES6 imports and return with 'default'
+            momentPlugin, // Plugins are ES6 imports and return with 'default'
+            momentTimezonePlugin, // Plugins are ES6 imports and return with 'default'
+            fullCalendarDayGridPlugin, // Plugins are ES6 imports and return with 'default'
+            fullCalendarTimeGridPlugin, // Plugins are ES6 imports and return with 'default'
+            fullCalendarListPlugin, // Plugins are ES6 imports and return with 'default'
             customViewPluginConstructor($scope, $compile, $sce) // Plugins are ES6 imports and return with 'default'
         ]
 

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -20,7 +20,7 @@ import {
     material,
     element
 } from 'angular'
-import * as moment from 'moment'
+import moment from 'moment'
 import 'moment-range'
 
 import '@stratusjs/angularjs-extras'
@@ -39,9 +39,6 @@ import * as fullCalendarListPlugin from '@fullcalendar/list'
 
 // Components
 import { customViewPluginConstructor } from '@stratusjs/calendar/customView'
-
-// Stratus Utilities
-
 
 // Environment
 const min = !cookie('env') ? '.min' : ''
@@ -219,8 +216,8 @@ Stratus.Components.Calendar = {
 
         $scope.initialized = false
         $scope.fetched = false
-        $scope.startRange = moment.default()
-        $scope.endRange = moment.default()
+        $scope.startRange = moment()
+        $scope.endRange = moment()
         $scope.customViews = {} // Filled by the customPlugin to hold any custom Views currently displayed for storage and reuse
 
         /** This function builds the URL for a CSS Resource based on configuration path. */

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -9,14 +9,24 @@
 
 // Runtime
 import {Stratus} from '@stratusjs/runtime/stratus'
-
-// Libraries
-import _ from 'lodash'
-import angular from 'angular'
+import {extend, isArray} from 'lodash'
+import {
+    IAugmentedJQuery,
+    IAttributes,
+    ICompileService,
+    IHttpService,
+    ISCEService,
+    IScope,
+    material,
+    element
+} from 'angular'
 // tslint:disable-next-line:no-duplicate-imports
 import 'angular'
 import * as moment from 'moment'
 import 'moment-range'
+
+// Angular 1 Modules
+import 'angular-material'
 
 // FullCalendar
 import '@fullcalendar/core/vdom'
@@ -25,9 +35,6 @@ import * as momentTimezonePlugin from '@fullcalendar/moment-timezone'
 import * as fullCalendarDayGridPlugin from '@fullcalendar/daygrid'
 import * as fullCalendarTimeGridPlugin from '@fullcalendar/timegrid'
 import * as fullCalendarListPlugin from '@fullcalendar/list'
-
-// Angular 1 Modules
-import 'angular-material'
 
 // Services
 import '@stratusjs/angularjs/services/model'
@@ -40,8 +47,7 @@ import { customViewPluginConstructor } from '@stratusjs/calendar/customView'
 
 // Stratus Utilities
 import {cookie} from '@stratusjs/core/environment'
-import {isJSON} from '@stratusjs/core/misc'
-// tslint:disable-next-line:no-duplicate-imports
+import {isJSON, safeUniqueId} from '@stratusjs/core/misc'
 import {Calendar, EventApi} from '@fullcalendar/core'
 // tslint:disable-next-line:no-duplicate-imports
 import {ICalExpander} from '@stratusjs/calendar/iCal'
@@ -51,7 +57,7 @@ const min = !cookie('env') ? '.min' : ''
 const packageName = 'calendar'
 const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src`
 
-export type CalendarScope = angular.IScope & {
+export type CalendarScope = IScope & {
     elementId: string
     calendarId: string
     initialized: boolean
@@ -131,18 +137,18 @@ Stratus.Components.Calendar = {
         options: '@'
     },
     controller(
-        $scope: CalendarScope, // angular.IScope & any, // CalendarScope
-        $attrs: angular.IAttributes & any,
-        $element: JQLite,
-        $sce: angular.ISCEService,
-        $mdPanel: angular.material.IPanelService,
-        $mdDialog: angular.material.IDialogService,
-        $http: angular.IHttpService,
-        $compile: angular.ICompileService
+        $scope: CalendarScope,
+        $attrs: IAttributes,
+        $element: IAugmentedJQuery,
+        $sce: ISCEService,
+        $mdPanel: material.IPanelService,
+        $mdDialog: material.IDialogService,
+        $http: IHttpService,
+        $compile: ICompileService
     ) {
         // Initialize
         const $ctrl = this
-        $ctrl.uid = _.uniqueId(_.camelCase(packageName) + '_')
+        $ctrl.uid = safeUniqueId(packageName)
         Stratus.Instances[$ctrl.uid] = $scope
         $scope.elementId = $attrs.elementId || $ctrl.uid
 
@@ -185,7 +191,7 @@ Stratus.Components.Calendar = {
             customArticleMonth: 'article',
             customArticleYear: 'article'
         }
-        $scope.options.buttonText = _.extend({}, defaultButtonText, $scope.options.buttonText)
+        $scope.options.buttonText = extend({}, defaultButtonText, $scope.options.buttonText)
         $scope.options.defaultView = $scope.options.defaultView || 'dayGridMonth'
 
         // Not used yet @see https://fullcalendar.io/docs/header
@@ -345,7 +351,7 @@ Stratus.Components.Calendar = {
         $scope.displayEventDialog = (calEvent: EventApi, clickEvent: MouseEvent) => {
             $mdDialog.show({
                 templateUrl: `${localDir}/eventDialog${min}.html`,
-                parent: angular.element(document.body),
+                parent: element(document.body),
                 targetEvent: clickEvent,
                 clickOutsideToClose: true,
                 escapeToClose: false,
@@ -403,7 +409,7 @@ Stratus.Components.Calendar = {
             const headerCenter: any = 'title'
             let headerRight: any = 'month,weekGrid,dayGrid'
             // All this is assuming tha the default Header is not customized
-            if (_.isArray($scope.options.possibleViews)) {
+            if (isArray($scope.options.possibleViews)) {
                 // FIXME Other views don't have a proper 'name' yet. (such as lists), need a Naming scheme
                 headerRight = $scope.options.possibleViews.join(',')
             }

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -20,13 +20,14 @@ import {
     material,
     element
 } from 'angular'
-// tslint:disable-next-line:no-duplicate-imports
-import 'angular'
 import * as moment from 'moment'
 import 'moment-range'
 
-// Angular 1 Modules
-import 'angular-material'
+import '@stratusjs/angularjs-extras'
+import {cookie} from '@stratusjs/core/environment'
+import {isJSON, safeUniqueId} from '@stratusjs/core/misc'
+import {Calendar, EventApi} from '@fullcalendar/core'
+import {ICalExpander} from '@stratusjs/calendar/iCal'
 
 // FullCalendar
 import '@fullcalendar/core/vdom'
@@ -36,21 +37,11 @@ import * as fullCalendarDayGridPlugin from '@fullcalendar/daygrid'
 import * as fullCalendarTimeGridPlugin from '@fullcalendar/timegrid'
 import * as fullCalendarListPlugin from '@fullcalendar/list'
 
-// Services
-import '@stratusjs/angularjs/services/model'
-import '@stratusjs/angularjs/services/collection'
-import '@stratusjs/angularjs/services/registry'
-import '@stratusjs/calendar/iCal'
-
 // Components
 import { customViewPluginConstructor } from '@stratusjs/calendar/customView'
 
 // Stratus Utilities
-import {cookie} from '@stratusjs/core/environment'
-import {isJSON, safeUniqueId} from '@stratusjs/core/misc'
-import {Calendar, EventApi} from '@fullcalendar/core'
-// tslint:disable-next-line:no-duplicate-imports
-import {ICalExpander} from '@stratusjs/calendar/iCal'
+
 
 // Environment
 const min = !cookie('env') ? '.min' : ''
@@ -316,7 +307,7 @@ Stratus.Components.Calendar = {
                 url = `https://app004.sitetheory.io/${url}`
             }
 
-            const response: any = await $http.get(url)
+            const response = await $http.get(url)
             if (cookie('env')) {
                 console.log('fetched the events from:', url)
             }
@@ -405,9 +396,9 @@ Stratus.Components.Calendar = {
             if ($scope.options.header) {
                 return
             }
-            const headerLeft: any = 'prev,next today'
-            const headerCenter: any = 'title'
-            let headerRight: any = 'month,weekGrid,dayGrid'
+            const headerLeft = 'prev,next today'
+            const headerCenter = 'title'
+            let headerRight = 'month,weekGrid,dayGrid'
             // All this is assuming tha the default Header is not customized
             if (isArray($scope.options.possibleViews)) {
                 // FIXME Other views don't have a proper 'name' yet. (such as lists), need a Naming scheme
@@ -431,7 +422,7 @@ Stratus.Components.Calendar = {
          * 'render' force calendar to redraw - https://fullcalendar.io/docs/render
          */
         $ctrl.render = () => {
-            // return new Promise((resolve: any) => {
+            // return new Promise((resolve) => {
             $scope.calendarEl = document.getElementById($scope.calendarId)
 
             $scope.calendar = new Calendar($scope.calendarEl, {

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -323,7 +323,6 @@ Stratus.Components.Calendar = {
             const twoYearsFuture = new Date()
             twoYearsFuture.setDate(twoYearsFuture.getDate() + (365 * 2)) // add 2 years
             const events = iCalExpander.jsonEventsForFullCalendar(twoYearsPast, twoYearsFuture)
-            // console.log('jsonEventsForFullCalendar pulled event count', _.clone(events).length)
             $scope.calendar.addEventSource({
                 events
                 // TODO give Sitetheory options to color each event source

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -323,6 +323,7 @@ Stratus.Components.Calendar = {
             const twoYearsFuture = new Date()
             twoYearsFuture.setDate(twoYearsFuture.getDate() + (365 * 2)) // add 2 years
             const events = iCalExpander.jsonEventsForFullCalendar(twoYearsPast, twoYearsFuture)
+            // console.log('jsonEventsForFullCalendar pulled event count', _.clone(events).length)
             $scope.calendar.addEventSource({
                 events
                 // TODO give Sitetheory options to color each event source

--- a/packages/calendar/src/iCal.ts
+++ b/packages/calendar/src/iCal.ts
@@ -3,8 +3,6 @@
 
 // Runtime
 import {Stratus} from '@stratusjs/runtime/stratus'
-
-// Libraries
 import {forEach} from 'lodash'
 import {auto} from 'angular'
 import 'ical.js' // Global ICAL variable.... not able to be sandboxed yet

--- a/packages/calendar/src/iCal.ts
+++ b/packages/calendar/src/iCal.ts
@@ -5,10 +5,8 @@
 import {Stratus} from '@stratusjs/runtime/stratus'
 
 // Libraries
-import _ from 'lodash'
-import angular from 'angular'
-// tslint:disable-next-line:no-duplicate-imports
-import 'angular'
+import {forEach} from 'lodash'
+import {auto} from 'angular'
 import 'ical.js' // Global ICAL variable.... not able to be sandboxed yet
 import {LooseObject} from '@stratusjs/core/misc'
 
@@ -30,7 +28,7 @@ export class ICalExpander {
         // Hydrate Options
         opts = opts || {}
         // Only populate non-null values
-        _.forEach(opts, (key: string, value: any) => {
+        forEach(opts, (key: string, value: any) => {
             if (value === null) {
                 return
             }
@@ -382,7 +380,7 @@ export function registerTimezones(tzData: LooseObject<string>) {
 
 Stratus.Services.iCal = [
     '$provide',
-    ($provide: angular.auto.IProvideService) => {
+    ($provide: auto.IProvideService) => {
         $provide.factory(
             'iCal',
             [


### PR DESCRIPTION
**@stratusjs/boot 1.0.1** published
Changes
- Removed unused packages (or those pre-bundled)

-----

**@stratusjs/angularjs-extras** 0.12.12
Changes
- Fixes stratus-src referencing false or null URLs. Will not set `src` if empty

----

**@stratusjs/calendar 1.2.1** published
Changes
- Updated codebase to use the modern framework schema
- Typed
- Fix missing 'recurring' 'nonrecurring' events by adding extra checks in case invalid ICS formatting is provided

Notes
- The Google ICS file had been provided some malformed events by having it's recurrence-id self reference it's own event. We are now forcibly ignoring a recurrence when the Start time matches the recurrence