### PR TITLE
@stratusjs/angularjs-extras 0.12.14 @stratusjs/idx 0.18.4 published

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs-extras/src/components/citation.scss
+++ b/packages/angularjs-extras/src/components/citation.scss
@@ -49,8 +49,8 @@ stratus-citation {
     .citation-title {
       display: block;
       margin-bottom: 7px;
-      &::after {
-        /* Ensuring a ending marker is in the popup */
+      &.auto-counter::after {
+        /* Ensuring a ending marker is in the popup. Only affect auto numerated titles */
         content: ".";
       }
       &.auto-counter::before {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./dist/idx.bundle.js",
   "scripts": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "@stratusjs/angular": "^0.6.7",
     "@stratusjs/angularjs": "^0.6.2",
-    "@stratusjs/angularjs-extras": "^0.12.12",
+    "@stratusjs/angularjs-extras": "^0.12.14",
     "@stratusjs/boot": "^1.0.1",
     "@stratusjs/map": "^0.6.4",
     "@stratusjs/runtime": "^0.12.1",

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -178,6 +178,8 @@ export interface IdxService {
 
     // Scope helpers
 
+    countArraysNotEmpty(arrayList: any[][]): number
+
     getInput(elementId: string): JQLite
 
     getNestedPathValue(currentNest: object | any, pathPieces: string[]): any
@@ -3402,12 +3404,17 @@ const angularJsService = (
         }
     }
 
+    function countArraysNotEmpty(arrayList: any[][]) {
+        return arrayList.filter((e)=>e.length).length
+    }
+
     return {
         fetchMembers,
         fetchOffices,
         fetchProperties,
         fetchProperty,
         clearFieldInput,
+        countArraysNotEmpty,
         devLog,
         emit,
         emitManual,

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -227,7 +227,7 @@ export type IdxSearchScope = IdxComponentScope & {
     listInitialized: boolean
 
     refreshSearchWidgetOptions(listScope?: IdxListScope): void
-    search(): void
+    search(force?: boolean): void
 }
 
 export type SelectionGroup = {

--- a/packages/idx/src/member/search.component.ts
+++ b/packages/idx/src/member/search.component.ts
@@ -59,6 +59,7 @@ Stratus.Components.IdxMemberSearch = {
         Idx: IdxService,
     ) {
         // Initialize
+        const $ctrl = this
         $scope.uid = safeUniqueId(packageName, moduleName, componentName)
         $scope.elementId = $attrs.elementId || $scope.uid
         Stratus.Instances[$scope.elementId] = $scope
@@ -82,7 +83,7 @@ Stratus.Components.IdxMemberSearch = {
             }, 2000) */
 
             // $scope.options = $attrs.options && isJSON($attrs.options) ? JSON.parse($attrs.options) : {}
-            $scope.options = hydrate($attrs.options) || {}
+            $scope.options = hydrate($ctrl.options) || hydrate($attrs.options) || {}
 
             // Set default queries
             $scope.options.query ??= {}

--- a/packages/idx/src/member/search.component.ts
+++ b/packages/idx/src/member/search.component.ts
@@ -4,7 +4,6 @@
  * @see https://github.com/Sitetheory/stratus/wiki/Idx-Member-Search-Widget
  */
 
-// Runtime
 import {forEach} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {element, material, IAttributes, ITimeoutService, IScope, IQService, IWindowService} from 'angular'
@@ -15,10 +14,7 @@ import {cookie} from '@stratusjs/core/environment'
 import {IdxMemberListScope} from '@stratusjs/idx/member/list.component'
 
 // Stratus Preload
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/member/list.component'
+import '@stratusjs/angularjs-extras'
 
 // Environment
 const min = !cookie('env') ? '.min' : ''

--- a/packages/idx/src/property/details.component.html
+++ b/packages/idx/src/property/details.component.html
@@ -158,9 +158,9 @@
                             <span data-ng-bind="::model.data._Class"></span>
                         </li>
                         <li class="mls-service" data-ng-if="::model.data.ListingId || model.data.ListingKey" role="text">
-                            <span data-ng-if="::getMLSLogo('tiny')"><img data-ng-src="{{::getMLSLogo('tiny')}}" alt="MLS Logo"/></span>
-                            <span data-ng-bind="getMLSName()" property="maintainer"></span>#
-                            <span data-ng-bind="::model.data.ListingId || model.data.ListingKey" property="identifier"></span>
+                            <span data-ng-if="::getMLSLogo('tiny')" class="mls-logo"><img data-ng-src="{{::getMLSLogo('tiny')}}" alt="MLS Logo"/></span>
+                            <span data-ng-bind="getMLSName()" data-ng-if="::!getMLSLogo('tiny')" property="maintainer" class="mls-name"></span>#
+                            <span data-ng-bind="::model.data.ListingId || model.data.ListingKey" property="identifier" class="mls-number"></span>
                         </li>
                     </ul>
 

--- a/packages/idx/src/property/details.component.less
+++ b/packages/idx/src/property/details.component.less
@@ -240,12 +240,11 @@ stratus-idx-property-details {
             margin-bottom: 12px;
           }
           &.mls-service {
-            margin: 12px 0 40px;
+            margin: 20px 0 40px;
 
             img {
               max-height: 35px;
               width: unset;
-              margin: 20px 0;
             }
           }
         }

--- a/packages/idx/src/property/list.carousel.component.html
+++ b/packages/idx/src/property/list.carousel.component.html
@@ -72,7 +72,7 @@
                                     </div>
 
                                     <div class="mls-service-name" role="text">
-                                        <span data-ng-show="::getMLSLogo($parent.slideData._ServiceId, 'tiny')"><img data-ng-src="{{::getMLSLogo($parent.slideData._ServiceId, 'tiny')}}" class="mls-logo" alt="MLS Logo"/></span>
+                                        <span data-ng-show="::getMLSLogo($parent.slideData._ServiceId, 'tiny')" class="mls-logo"><img data-ng-src="{{::getMLSLogo($parent.slideData._ServiceId, 'tiny')}}" alt="MLS Logo"/></span>
                                         <span data-ng-bind="::getMLSName($parent.slideData._ServiceId)" data-ng-show="::!getMLSLogo($parent.slideData._ServiceId, 'tiny')" property="maintainer" class="mls-name"></span>#
                                         <span data-ng-bind="::$parent.slideData.ListingId || $parent.slideData.ListingKey" property="identifier" class="mls-number"></span>
                                     </div>

--- a/packages/idx/src/property/list.carousel.component.html
+++ b/packages/idx/src/property/list.carousel.component.html
@@ -40,12 +40,6 @@
                             <meta property="name" content="{{::getStreetAddress($parent.slideData)}}" />
                             <div class="property-content-container">
                                 <div class="property-content font-body">
-                                    <div class="mls-service-name" role="text">
-                                        <span data-ng-show="::getMLSLogo($parent.slideData._ServiceId, 'tiny')"><img data-ng-src="{{::getMLSLogo($parent.slideData._ServiceId, 'tiny')}}" alt="MLS Logo"/></span>
-                                        <span data-ng-bind="::getMLSName($parent.slideData._ServiceId)" property="maintainer"></span>#
-                                        <span data-ng-bind="::$parent.slideData.ListingId || $parent.slideData.ListingKey" property="identifier"></span>
-                                    </div>
-
                                     <div class="property-status-price-container">
                                         <span class="property-status" data-ng-bind="::Idx.getFriendlyStatus($parent.slideData, preferredStatus)"></span>
                                         <span class="property-price line-separator-left-more" data-ng-show="::$parent.slideData.ClosePrice || $parent.slideData.ListPrice" role="text" property="price">
@@ -77,6 +71,11 @@
                                         </span>
                                     </div>
 
+                                    <div class="mls-service-name" role="text">
+                                        <span data-ng-show="::getMLSLogo($parent.slideData._ServiceId, 'tiny')"><img data-ng-src="{{::getMLSLogo($parent.slideData._ServiceId, 'tiny')}}" class="mls-logo" alt="MLS Logo"/></span>
+                                        <span data-ng-bind="::getMLSName($parent.slideData._ServiceId)" data-ng-show="::!getMLSLogo($parent.slideData._ServiceId, 'tiny')" property="maintainer" class="mls-name"></span>#
+                                        <span data-ng-bind="::$parent.slideData.ListingId || $parent.slideData.ListingKey" property="identifier" class="mls-number"></span>
+                                    </div>
                                     <!-- FIXME property type might be required, will check regs -->
                                     <!--span data-ng-bind="::$parent.slideData.PropertySubType || $parent.slideData.PropertyType || $parent.slideData._Class" property="accommodationCategory"></span-->
                                 </div>

--- a/packages/idx/src/property/list.carousel.component.less
+++ b/packages/idx/src/property/list.carousel.component.less
@@ -151,19 +151,20 @@ stratus-idx-property-list .property-list-carousel {
 
           /* MLS service + number */
           .mls-service-name {
+            margin-top: 12px;
+            font-size: 11px;
             & > span {
               display: inline-block;
               vertical-align: middle;
-              margin: 0 5px;
+              margin: 0 0 0 5px;
             }
-            img {
+            .mls-logo {
               width: unset;
-              max-height: 25px;
+              height: 15px;
             }
           }
 
           .property-status-price-container {
-            margin-top: 12px;
             font-size: 26px;
             line-height: 26px;
             .property-status {

--- a/packages/idx/src/property/list.carousel.component.less
+++ b/packages/idx/src/property/list.carousel.component.less
@@ -158,7 +158,7 @@ stratus-idx-property-list .property-list-carousel {
               vertical-align: middle;
               margin: 0 0 0 5px;
             }
-            .mls-logo {
+            .mls-logo img {
               width: unset;
               height: 15px;
             }

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -19,6 +19,20 @@
         <md-progress-linear data-ng-show="collection.pending" md-mode="indeterminate"></md-progress-linear>
         <div data-ng-show="collection.completed && !collection.pending && collection.models.length === 0" class="no-results">
             We didn't find any properties that fit your criteria.<span> You might want to try a broader search.</span>
+            <div
+                    class="other-preset-filters"
+                    data-ng-if="query.where.OfficeNumber.length > 0 || query.where.AgentLicense.length > 0 || query.where.ListingId.length > 0"
+            >
+                This search includes <span data-ng-bind="Idx.countArraysNotEmpty([query.where.OfficeNumber, query.where.AgentLicense, query.where.ListingId])"></span>
+                other filter(s).
+            </div>
+            <md-button
+                    data-ng-click="query.where.Location = ''; query.where.City = []; query.where.CountyOrParish = []; query.where.MLSAreaMajor = []; query.where.Neighborhood = []; query.where.PostalCode = []; query.where.OfficeNumber = []; query.where.AgentLicense = []; query.where.ListingId = []; search()"
+                    aria-label="Clear Filters"
+            >
+                Clear All Filters
+            </md-button>
+
         </div>
         <section role="region" aria-label="Property Results List">
             <div data-ng-show="collection.completed && !collection.pending && collection.models.length > 0"

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -98,9 +98,9 @@
                                 </div>
                             </div>
                             <div class="mls-service-name" role="text">
-                                <span data-ng-if="::getMLSLogo(property._ServiceId, 'tiny')"><img data-ng-src="{{::getMLSLogo(property._ServiceId, 'tiny')}}" alt="MLS Logo"/></span>
-                                <span data-ng-bind="::getMLSName(property._ServiceId)" property="maintainer"></span>#
-                                <span data-ng-bind="::property.ListingId || property.ListingKey" property="identifier"></span>
+                                <span data-ng-if="::getMLSLogo(property._ServiceId, 'tiny')" class="mls-logo"><img data-ng-src="{{::getMLSLogo(property._ServiceId, 'tiny')}}" alt="MLS Logo"/></span>
+                                <span data-ng-bind="::getMLSName(property._ServiceId)" data-ng-show="::!getMLSName(property._ServiceId)" property="maintainer" class="mls-name"></span>#
+                                <span data-ng-bind="::property.ListingId || property.ListingKey" property="identifier" class="mls-number"></span>
                             </div>
                         </div>
                     </md-card>

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -367,10 +367,10 @@ stratus-idx-property-list .property-list-default {
           .mls-service-name {
             font-size: 11px;
             text-align: center;
+            margin-top: 10px;
             color: #666;
             img {
               width: unset;
-              margin: 10px auto;
               max-height: 15px;
             }
           }

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -358,7 +358,8 @@ Stratus.Components.IdxPropertyList = {
             // If string, check if a json and parse first. Otherwise be null or what it is
             $scope.query.order =
                 $scope.query.order && isString($scope.query.order) && isJSON($scope.query.order) ? JSON.parse($scope.query.order) :
-                    $attrs.queryOrder && isJSON($attrs.queryOrder) ? JSON.parse($attrs.queryOrder) : $scope.query.order || null
+                    $attrs.queryOrder && isJSON($attrs.queryOrder) ? JSON.parse($attrs.queryOrder) :
+                        $attrs.queryOrder || $scope.query.order || null
             $scope.query.page ||= null // will be set by Service
             $scope.query.perPage = $scope.query.perPage ||
                 ($attrs.queryPerPage && isString($attrs.queryPerPage) ? parseInt($attrs.queryPerPage, 10) : null) ||

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -57,6 +57,11 @@
                         data-ng-if="options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode > 0"
                         data-ng-bind="((options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length) ? ', ' : '') + _.join(_.union(options.query.where.CountyOrParish, options.query.where.MLSAreaMajor, options.query.where.Neighborhood, options.query.where.PostalCode), ', ')"
                 ></span>
+                <span
+                        class="other-preset-filters"
+                        data-ng-if="options.officeGroups.length > 0 || options.query.where.AgentLicense.length > 0 || options.query.where.ListingId.length > 0"
+                        data-ng-bind="'+'+Idx.countArraysNotEmpty([options.officeGroups, options.query.where.AgentLicense, options.query.where.ListingId])+' Other Filters'"
+                ></span>
             </div>
             <!-- TODO: We cannot currently get focus to work because we can't find the element: data-ng-click="angular.element('#filterLocation').focus()". In the future it would be nice to populate. FIX: Element doesn't not exist on load, should possibly be given as a widget option when Element is ready with relying on id. -->
             <!-- NOTE: We shouldn't supply ids unless they are given a unique number at the end as HTML does not allow duplicate ids -->

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -14,7 +14,7 @@
 
     <div class="search-row search-basic clearfix">
         <div class="search-input search-location"
-             data-ng-class="{'location-input-active': !(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.PostalCode.length > 0)}">
+             data-ng-class="{'location-input-active': !(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)}">
 
             <!-- If there are preset filters like City, MLS Area, Postal Code, which are subsets of Location, then we
             will show that we are filtering by those, and we will not show the Location field. They remain in the filter
@@ -24,12 +24,12 @@
             <!-- NOTE: some of these fields are arrays -->
             <md-icon class="search-icon"
                      data-ng-click="search()"
-                     data-ng-if="!(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.PostalCode.length > 0)"
+                     data-ng-if="!(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)"
                      md-svg-src="{{ localDir + 'images/icons/actionButtons/search.svg' }}"
             ></md-icon>
             <md-input-container
                     class="location-input md-block minimal"
-                    data-ng-if="!(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.PostalCode.length > 0)">
+                    data-ng-if="!(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)">
                 <label>City, Neighborhood, Zip</label>
 
                 <!-- NOTE: the data-ng-keyup should not be setting: && options.query.where.Location (seems useless???) -->
@@ -50,12 +50,12 @@
 
             <!-- TODO: make this gray in the CSS -->
             <div class="preset-location"
-                 data-ng-if="(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.PostalCode.length > 0)">
+                 data-ng-if="(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)">
                 <span data-ng-if="options.query.where.City.length > 0" data-ng-bind="options.query.where.City.join(', ')"></span>
                 <!-- NOTE: these are actually arrays so we union them then join split with a comma -->
                 <span
-                        data-ng-if="options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.PostalCode > 0"
-                        data-ng-bind="((options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length) ? ', ' : '') + _.join(_.union(options.query.where.CountyOrParish, options.query.where.MLSAreaMajor, options.query.where.PostalCode), ', ')"
+                        data-ng-if="options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode > 0"
+                        data-ng-bind="((options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length) ? ', ' : '') + _.join(_.union(options.query.where.CountyOrParish, options.query.where.MLSAreaMajor, options.query.where.Neighborhood, options.query.where.PostalCode), ', ')"
                 ></span>
             </div>
             <!-- TODO: We cannot currently get focus to work because we can't find the element: data-ng-click="angular.element('#filterLocation').focus()". In the future it would be nice to populate. FIX: Element doesn't not exist on load, should possibly be given as a widget option when Element is ready with relying on id. -->
@@ -63,8 +63,8 @@
             <!-- NOTE: three of these get cleared as arrays -->
             <a
                     class="custom-clear"
-                    data-ng-if="(options.query.where.Location.length || options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.PostalCode.length > 0)"
-                    data-ng-click="options.query.where.Location = ''; options.query.where.City = []; options.query.where.CountyOrParish = []; options.query.where.MLSAreaMajor = []; options.query.where.PostalCode = []; search()"
+                    data-ng-if="(options.query.where.Location.length || options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)"
+                    data-ng-click="options.query.where.Location = ''; options.query.where.City = []; options.query.where.CountyOrParish = []; options.query.where.MLSAreaMajor = []; options.query.where.Neighborhood = []; options.query.where.PostalCode = []; search()"
             >
                 <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/clear.svg' }}"></md-icon>
             </a>
@@ -326,7 +326,7 @@
 
             <div
                     class="extras"
-                    data-ng-show="options.query.where.OpenHouseOnly || options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.OfficeNumber.length || options.query.where.OfficeName.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length"
+                    data-ng-show="options.query.where.OpenHouseOnly || options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.OfficeNumber.length || options.query.where.OfficeName.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.Neighborhood.length || options.query.where.PostalCode.length"
             >
                 <h4>Extras</h4>
                 <!-- 'Openhouses Only' is only allowed when more filters are supplied due to speed restrictions -->

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -342,7 +342,7 @@
 
             </div>
 
-            <div data-ng-if="options.officeGroups.length">
+            <div data-ng-if="options.officeGroups.length || options.query.where.AgentLicense.length || options.query.where.ListingId.length">
                 <h4>Preset Filters</h4>
                 <div class="search-input" data-ng-if="options.officeGroups.length">
                     <!--h5>Office</h5-->
@@ -360,6 +360,42 @@
                         <md-chip-template>
                             <!-- add to enable editing: data-ng-click="displayOfficeGroupSelector(null, $index, $event)" -->
                             <span>{{$chip.name}}</span>
+                        </md-chip-template>
+                    </md-chips>
+                </div>
+                <div class="search-input" data-ng-if="options.query.where.AgentLicense.length">
+                    <h5>Agent License</h5>
+                    <md-chips
+                            class="agent-license-groups font-secondary"
+                            aria-label="Agent Licenses"
+                            data-ng-model="options.query.where.AgentLicense"
+                            data-md-enable-chip-edit="false"
+                            data-md-removable="true"
+                            data-delete-button-label="Remove License"
+                            data-delete-hint="Press delete to remove License"
+                            data-md-on-add="search()"
+                            data-md-on-remove="search()"
+                    >
+                        <md-chip-template>
+                            <span>{{$chip}}</span>
+                        </md-chip-template>
+                    </md-chips>
+                </div>
+                <div class="search-input" data-ng-if="options.query.where.ListingId.length">
+                    <h5>Listing Id</h5>
+                    <md-chips
+                            class="listing-id-groups font-secondary"
+                            aria-label="Listing Ids"
+                            data-ng-model="options.query.where.ListingId"
+                            data-md-enable-chip-edit="false"
+                            data-md-removable="true"
+                            data-delete-button-label="Remove ListingId"
+                            data-delete-hint="Press delete to remove ListingId"
+                            data-md-on-add="search()"
+                            data-md-on-remove="search()"
+                    >
+                        <md-chip-template>
+                            <span>{{$chip}}</span>
                         </md-chip-template>
                     </md-chips>
                 </div>

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -60,7 +60,7 @@
                 <span
                         class="other-preset-filters"
                         data-ng-if="options.officeGroups.length > 0 || options.query.where.AgentLicense.length > 0 || options.query.where.ListingId.length > 0"
-                        data-ng-bind="'+'+Idx.countArraysNotEmpty([options.officeGroups, options.query.where.AgentLicense, options.query.where.ListingId])+' Other Filters'"
+                        data-ng-bind="'+'+Idx.countArraysNotEmpty([options.officeGroups, options.query.where.AgentLicense, options.query.where.ListingId])+' Filter'+(Idx.countArraysNotEmpty([options.officeGroups, options.query.where.AgentLicense, options.query.where.ListingId]) > 1 ? '(s)' : '')"
                 ></span>
             </div>
             <!-- TODO: We cannot currently get focus to work because we can't find the element: data-ng-click="angular.element('#filterLocation').focus()". In the future it would be nice to populate. FIX: Element doesn't not exist on load, should possibly be given as a widget option when Element is ready with relying on id. -->

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -177,8 +177,7 @@
 
         <div class="search-more-filters" data-ng-if="!listInitialized">
             <!-- If there isn't a list, run the search() function to send to a pre-filled search page -->
-            <a class="open-filters-link"
-               data-ng-click="search()">
+            <a class="open-filters-link" data-ng-click="search(true)">
                 <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/filters.svg' }}"></md-icon>
                 <span class="btn-text"><span data-ng-bind="advancedSearchLinkName"></span></span>
             </a>

--- a/packages/idx/src/property/search.component.less
+++ b/packages/idx/src/property/search.component.less
@@ -169,6 +169,10 @@ stratus-idx-property-search[data-list-id^="property-list"],
           cursor: default;
           font-size: 16px;
           color: #999;
+          .other-preset-filters {
+            font-size: 10px;
+            color: rgb(220 100 70);
+          }
         }
         .custom-clear {
           transform: translateY(-50%);

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -675,7 +675,7 @@ Stratus.Components.IdxPropertySearch = {
          * Call a List widget to perform a search
          * TODO await until search is complete?
          */
-        $scope.search = $scope.searchProperties = (): void => {
+        $scope.search = (force?: boolean): void => {
             if (!$scope.initialized) {
                 console.warn($scope.uid, 'has not initialized and may not search yet')
                 return
@@ -705,7 +705,7 @@ Stratus.Components.IdxPropertySearch = {
             } else {
                 // console.log('comparing last', cloneDeep(lastQuery))
                 // console.log('comparing current', cloneDeep($scope.options.query))
-                if ($scope.hasQueryChanged()) {
+                if ($scope.hasQueryChanged() || force) {
                     lastQuery = cloneDeep($scope.options.query)
                     // console.warn('there was a change')
                     Idx.setUrlOptions('Search', $scope.options.query.where)

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -835,7 +835,6 @@ Stratus.Components.IdxPropertySearch = {
         $scope.on = (emitterName: string, callback: IdxEmitter) => Idx.on($scope.elementId, emitterName, callback)
 
         $scope.hasQueryChanged = (): boolean => !isEqual(clone(lastQuery), clone($scope.options.query))
-
         /**
          * Destroy this widget
          */


### PR DESCRIPTION
@stratusjs/angularjs-extras 0.12.14 published
Changes
- Auto Counter(non-custom title) now are the only titles with period prepended https://sitetheory.slack.com/archives/CUE5R9E21/p1681910770841149 

--------

@stratusjs/idx 0.18.4 published
Adds
- Neighborhoods/Offices/Agents to more filters for contorl https://app.asana.com/0/348823217261712/1204300726933726
- Note "no-results" and location input when "Other Filters" are enabled https://app.asana.com/0/348823217261712/1204300726933726

Changes
- property Carousel Fixes
- property Carousel Movement of MLS details to bottom of slides https://app.asana.com/0/596117517607240/1204421091310911
- property list/carousel/details mls credits sizing and alignments https://app.asana.com/0/596117517607240/1204421091310911
- property search fix Advanced search buttons https://app.asana.com/0/348823217261712/1204194612163769
- member/search fix initialized option for how sitetheory now laods edit pages

Notes
- FIXME Edit pages still do not sync data change after it loads