### PR TITLE
@stratusjs/stripe 1.6.0 @stratusjs/angular 0.7.3

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -16,7 +16,6 @@
   "keywords": [
     "sitetheory",
     "stratus",
-    "underscore",
     "lodash",
     "javascript",
     "typescript",
@@ -29,7 +28,7 @@
     "@mat-datetimepicker/core": "6.0.3",
     "@mat-datetimepicker/moment": "6.0.3",
     "@stratusjs/map": "^0.6.5",
-    "@stratusjs/stripe": "^1.5.3",
+    "@stratusjs/stripe": "^1.6.0",
     "core-js": "^3.19.0",
     "quill": "^1.3.7",
     "quill-autoformat": "^0.1.2",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/stripe",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "description": "Angular Stripe Elements components to be used as an add on to StratusJS",
   "main": "",
   "scripts": {
@@ -29,7 +29,7 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/angular": "^0.6.8",
+    "@stratusjs/angular": "^0.7.3",
     "@stratusjs/runtime": "^0.12.1",
     "toastify-js": "^1.12.0"
   }

--- a/packages/stripe/src/payment-method-item-display.component.ts
+++ b/packages/stripe/src/payment-method-item-display.component.ts
@@ -1,0 +1,100 @@
+import {
+    Component,
+    ElementRef,
+    Input,
+    OnInit
+} from '@angular/core'
+import {DomSanitizer} from '@angular/platform-browser'
+import {snakeCase} from 'lodash'
+import {keys} from 'ts-transformer-keys'
+import {
+    Stratus
+} from '@stratusjs/runtime/stratus'
+import {RootComponent} from '../../angular/src/core/root.component'
+import {Model} from '@stratusjs/angularjs/services/model'
+import {safeUniqueId} from '@stratusjs/core/misc'
+
+// Local Setup
+// const min = !cookie('env') ? '.min' : ''
+const packageName = 'stripe'
+const componentName = 'payment-method-item-display'
+// const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/`
+
+/**
+ * @title Dialog for Nested Tree
+ */
+@Component({
+    selector: `sa-${packageName}-${componentName}`,
+    template: '<sa-stripe-payment-method-item *ngIf="initialized" [(model)]="model" [editable]="false"></sa-stripe-payment-method-item>',
+})
+export class StripePaymentMethodItemDisplayComponent extends RootComponent implements OnInit {
+
+    // Basic Component Settings
+    title = `${packageName}_${componentName}_component`
+    uid: string
+    initialized = false
+    @Input() elementId: string
+    model: Model
+    @Input() name?: string
+    @Input() brand?: string
+    @Input() last4?: string
+    @Input() expMonth?: number
+    @Input() expYear?: number
+
+    constructor(
+        private elementRef: ElementRef,
+        private sanitizer: DomSanitizer,
+    ) {
+        // Chain constructor
+        super()
+
+        // Initialization
+        this.uid = safeUniqueId('sa', snakeCase(this.title))
+        Stratus.Instances[this.uid] = this
+        this.elementId = this.elementId || this.uid
+
+        // Hydrate Root App Inputs
+        this.hydrate(this.elementRef, this.sanitizer, keys<StripePaymentMethodItemDisplayComponent>())
+    }
+
+    /**
+     * On load, attempt to prepare and render the Card element
+     */
+    async ngOnInit() {
+        if (
+            this.name &&
+            this.brand &&
+            this.last4 &&
+            this.expMonth &&
+            this.expYear
+        ) {
+            this.model = new Model()
+            this.model.data.name = this.name
+            this.model.data.brand = this.brand
+            this.model.data.last4 = this.last4
+            this.model.data.exp_month = this.expMonth
+            this.model.data.exp_year = this.expYear
+            this.model.changed = false
+            this.model.pending = false
+            this.model.completed = true
+            this.initialized = true
+        } else {
+            console.warn(`${this.uid} was missing data. not initializing`)
+            if (!this.name) {
+                console.warn(`${this.uid} was missing "name". Add with data-name="My Name"`)
+            }
+            if (!this.brand) {
+                console.warn(`${this.uid} was missing "brand". Add with data-brand="visa"`)
+            }
+            if (!this.last4) {
+                console.warn(`${this.uid} was missing "last4". Add with data-last-4="1234"`)
+            }
+            if (!this.expMonth) {
+                console.warn(`${this.uid} was missing "expMonth". Add with data-exp-month="4"`)
+            }
+            if (!this.expYear) {
+                console.warn(`${this.uid} was missing "expYear". Add with data-exp-year="2024"`)
+            }
+        }
+    }
+}

--- a/packages/stripe/src/payment-method-item.component.less
+++ b/packages/stripe/src/payment-method-item.component.less
@@ -6,6 +6,7 @@ sa-stripe-payment-method-item {
   mat-card.payment-method-container {
     position: relative;
     margin: 5px 1px;
+    max-width: 220px;
     background-color: @light-blue-color;
     &.expired {
       background-color: @medium-grey-color;

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -6,6 +6,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms'
 import {MaterialModules} from '../../angular/src/material'
 import {StripePaymentMethodComponent} from './payment-method.component'
 import {StripePaymentMethodItemComponent} from './payment-method-item.component'
+import {StripePaymentMethodItemDisplayComponent} from './payment-method-item-display.component'
 import {StripePaymentMethodListComponent} from './payment-method-list.component'
 import {StripePaymentMethodSelectorComponent} from './payment-method-selector.component'
 import {StripeSetupIntentComponent} from './setup-intent.component'
@@ -22,6 +23,7 @@ import {StripeSetupIntentComponent} from './setup-intent.component'
     declarations: [
         StripePaymentMethodComponent,
         StripePaymentMethodItemComponent,
+        StripePaymentMethodItemDisplayComponent,
         StripePaymentMethodListComponent,
         StripePaymentMethodSelectorComponent,
         StripeSetupIntentComponent,
@@ -30,6 +32,7 @@ import {StripeSetupIntentComponent} from './setup-intent.component'
     entryComponents: [
         StripePaymentMethodComponent,
         StripePaymentMethodItemComponent,
+        StripePaymentMethodItemDisplayComponent,
         StripePaymentMethodListComponent,
         StripePaymentMethodSelectorComponent,
         StripeSetupIntentComponent,
@@ -37,6 +40,7 @@ import {StripeSetupIntentComponent} from './setup-intent.component'
     exports: [
         StripePaymentMethodComponent,
         StripePaymentMethodItemComponent,
+        StripePaymentMethodItemDisplayComponent,
         StripePaymentMethodListComponent,
         StripePaymentMethodSelectorComponent,
         StripeSetupIntentComponent,
@@ -49,6 +53,7 @@ export class StripeModule {}
 export const StripePackage: StratusPackage = {
     stratusModule: StripeModule,
     stratusComponents: {
+        'sa-stripe-payment-method-item-display': StripePaymentMethodItemDisplayComponent,
         'sa-stripe-payment-method-list': StripePaymentMethodListComponent,
         'sa-stripe-payment-method-selector': StripePaymentMethodSelectorComponent
     }


### PR DESCRIPTION
@stratusjs/stripe 1.6.0
Adds
- sa-stripe-payment-method-item-display
- - Specific Wrapper for sa-stripe-payment-method-item for display payment methods in universal way
Changes
- css Width limit on sa-stripe-payment-method-item to prevent "stretching" in certain instances

-----

@stratusjs/angular 0.7.3
- Recompile + Publish Stripe