### PR TITLE
@stratusjs/stripe 1.7.0 @stratusjs/angular 0.7.5

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -28,7 +28,7 @@
     "@mat-datetimepicker/core": "6.0.3",
     "@mat-datetimepicker/moment": "6.0.3",
     "@stratusjs/map": "^0.6.5",
-    "@stratusjs/stripe": "^1.6.0",
+    "@stratusjs/stripe": "^1.7.0",
     "core-js": "^3.19.0",
     "quill": "^1.3.7",
     "quill-autoformat": "^0.1.2",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/stripe",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Angular Stripe Elements components to be used as an add on to StratusJS",
   "main": "",
   "scripts": {
@@ -29,7 +29,7 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/angular": "^0.7.3",
+    "@stratusjs/angular": "^0.7.5",
     "@stratusjs/runtime": "^0.12.1",
     "toastify-js": "^1.12.0"
   }

--- a/packages/stripe/src/payment-method-item-display.component.ts
+++ b/packages/stripe/src/payment-method-item-display.component.ts
@@ -11,14 +11,15 @@ import {
     Stratus
 } from '@stratusjs/runtime/stratus'
 import {Model} from '@stratusjs/angularjs/services/model'
+import {cookie} from '@stratusjs/core/environment'
 import {safeUniqueId} from '@stratusjs/core/misc'
 import {StripeComponent} from './stripe.service'
 
 // Local Setup
-// const min = !cookie('env') ? '.min' : ''
+const min = !cookie('env') ? '.min' : ''
 const packageName = 'stripe'
 const componentName = 'payment-method-item-display'
-// const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/`
+const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/`
 
 /**
  * @title Dialog for Nested Tree
@@ -31,9 +32,7 @@ export class StripePaymentMethodItemDisplayComponent extends StripeComponent imp
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
-    uid: string
-    initialized = false
-    @Input() elementId: string
+
     model: Model
     @Input() name?: string
     @Input() brand?: string
@@ -52,6 +51,17 @@ export class StripePaymentMethodItemDisplayComponent extends StripeComponent imp
         this.uid = safeUniqueId('sa', snakeCase(this.title))
         Stratus.Instances[this.uid] = this
         this.elementId = this.elementId || this.uid
+
+        // TODO: Assess & Possibly Remove when the System.js ecosystem is complete
+        // Load Component CSS until System.js can import CSS properly.
+        Stratus.Internals.CssLoader(`${localDir}${componentName}.component${min}.css`)
+            .then(() => {
+                this.styled = true
+            })
+            .catch(() => {
+                console.error('CSS Failed to load for Component:', this)
+                this.styled = false
+            })
 
         // Hydrate Root App Inputs
         this.hydrate(this.elementRef, this.sanitizer, keys<StripePaymentMethodItemDisplayComponent>())

--- a/packages/stripe/src/payment-method-item-display.component.ts
+++ b/packages/stripe/src/payment-method-item-display.component.ts
@@ -10,9 +10,9 @@ import {keys} from 'ts-transformer-keys'
 import {
     Stratus
 } from '@stratusjs/runtime/stratus'
-import {RootComponent} from '../../angular/src/core/root.component'
 import {Model} from '@stratusjs/angularjs/services/model'
 import {safeUniqueId} from '@stratusjs/core/misc'
+import {StripeComponent} from './stripe.service'
 
 // Local Setup
 // const min = !cookie('env') ? '.min' : ''
@@ -27,7 +27,7 @@ const componentName = 'payment-method-item-display'
     selector: `sa-${packageName}-${componentName}`,
     template: '<sa-stripe-payment-method-item *ngIf="initialized" [(model)]="model" [editable]="false"></sa-stripe-payment-method-item>',
 })
-export class StripePaymentMethodItemDisplayComponent extends RootComponent implements OnInit {
+export class StripePaymentMethodItemDisplayComponent extends StripeComponent implements OnInit {
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`

--- a/packages/stripe/src/payment-method-item.component.html
+++ b/packages/stripe/src/payment-method-item.component.html
@@ -3,7 +3,7 @@
         [attr.id]="elementId"
         [class.model-changed]="model.changed"
         [class.model-pending]="model.pending"
-        [class.expired]="isExpired()"
+        [class.expired]="isExpired() || model.data.status < 1"
 >
     <button
             tabindex="-1"

--- a/packages/stripe/src/payment-method-item.component.ts
+++ b/packages/stripe/src/payment-method-item.component.ts
@@ -10,7 +10,6 @@ import {keys} from 'ts-transformer-keys'
 import {
     Stratus
 } from '@stratusjs/runtime/stratus'
-import {RootComponent} from '../../angular/src/core/root.component'
 import {ConfirmDialogComponent} from '../../angular/src/confirm-dialog/confirm-dialog.component'
 import {Model} from '@stratusjs/angularjs/services/model'
 import {cookie} from '@stratusjs/core/environment'
@@ -19,6 +18,7 @@ import {
     MatDialog,
     MatDialogRef
 } from '@angular/material/dialog'
+import {StripeComponent} from './stripe.service'
 
 
 // Services
@@ -38,7 +38,7 @@ const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packag
     selector: `sa-${packageName}-${componentName}`,
     templateUrl: `${localDir}${componentName}.component${min}.html`,
 })
-export class StripePaymentMethodItemComponent extends RootComponent implements OnInit {
+export class StripePaymentMethodItemComponent extends StripeComponent implements OnInit {
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`

--- a/packages/stripe/src/payment-method-item.component.ts
+++ b/packages/stripe/src/payment-method-item.component.ts
@@ -18,12 +18,7 @@ import {
     MatDialog,
     MatDialogRef
 } from '@angular/material/dialog'
-import {StripeComponent} from './stripe.service'
-
-
-// Services
-// import {StripeService} from '@stratusjs/stripe/stripe.service'
-
+import {StripeComponent, StripeService} from './stripe.service'
 
 // Local Setup
 const min = !cookie('env') ? '.min' : ''
@@ -55,7 +50,7 @@ export class StripePaymentMethodItemComponent extends StripeComponent implements
         private dialog: MatDialog,
         private elementRef: ElementRef,
         private sanitizer: DomSanitizer,
-        // private Stripe: StripeService,
+        private Stripe: StripeService,
     ) {
         // Chain constructor
         super()
@@ -142,15 +137,8 @@ export class StripePaymentMethodItemComponent extends StripeComponent implements
                 if (!dialogResult) {
                     return
                 }
-                let collection
-                if (this.model.collection) {
-                    collection = this.model.collection
-                }
                 await this.model.destroy()
-                if (collection) {
-                    // Refetch to get current PMs
-                    collection.fetch()
-                }
+                this.Stripe.fetchCollections() // re-fetch ALL stripe collections just in case (will close the select box too)
             })
         return dialog
     }

--- a/packages/stripe/src/payment-method-item.component.ts
+++ b/packages/stripe/src/payment-method-item.component.ts
@@ -41,6 +41,9 @@ export class StripePaymentMethodItemComponent extends StripeComponent implements
     @Input() elementId: string
     @Input() model: Model
 
+    // Registry Attributes
+    @Input() urlRoot = '/Api'
+
     // States
     @Input() editable = false
     styled = false
@@ -80,7 +83,9 @@ export class StripePaymentMethodItemComponent extends StripeComponent implements
      */
     async ngOnInit() {
         this.initialized = true
-
+        if (this.urlRoot) {
+            this.model.urlRoot = `${this.urlRoot}${this.model.target ? '/' + this.model.target : ''}`
+        }
     }
 
     getCardLogoUrl(brand: string) {

--- a/packages/stripe/src/payment-method-item.component.ts
+++ b/packages/stripe/src/payment-method-item.component.ts
@@ -37,17 +37,11 @@ export class StripePaymentMethodItemComponent extends StripeComponent implements
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
-    uid: string
-    @Input() elementId: string
     @Input() model: Model
+    @Input() editable = false
 
     // Registry Attributes
     @Input() urlRoot = '/Api'
-
-    // States
-    @Input() editable = false
-    styled = false
-    initialized = false
 
     constructor(
         private dialog: MatDialog,

--- a/packages/stripe/src/payment-method-list.component.html
+++ b/packages/stripe/src/payment-method-list.component.html
@@ -8,7 +8,7 @@
                 *ngFor="let paymentMethod of collection.models"
                 [attr.tabindex]="paymentMethod.data.id"
         >
-            <sa-stripe-payment-method-item [(model)]="paymentMethod" [editable]="true"></sa-stripe-payment-method-item>
+            <sa-stripe-payment-method-item [(model)]="paymentMethod" [editable]="true" [urlRoot]="urlRoot"></sa-stripe-payment-method-item>
         </mat-list-item>
         <mat-list-item
                 [hidden]="!collection.completed || collection.pending"

--- a/packages/stripe/src/payment-method-list.component.html
+++ b/packages/stripe/src/payment-method-list.component.html
@@ -1,44 +1,25 @@
 <div [attr.id]="elementId">
-    <mat-progress-bar *ngIf="paymentCollection.pending" mode="indeterminate"></mat-progress-bar>
-    <div *ngIf="paymentCollection.completed && !paymentCollection.pending && paymentCollection.models.length === 0" class="no-results">
-        No Payment Method on file.
-    </div>
-    <sa-stripe-payment-method-item
-            *ngFor="let paymentMethod of paymentCollection.models"
-            [attr.tabindex]="paymentMethod.data.id"
-            [(model)]="paymentMethod"
-    ></sa-stripe-payment-method-item>
-    <sa-stripe-setup-intent
-            [hidden]="!paymentCollection.completed || paymentCollection.pending"
-            data-detailed-billing-info="true"
-            [defaultBillingInfo]="defaultBillingInfo"
-            [urlRoot]="urlRoot"
-            [paymentMethodApiPath]="paymentMethodApiPath"
-            [addCardButtonText]="addCardButtonText"
-    ></sa-stripe-setup-intent>
-
-    <!--delete dialog popup -->
-    <!--script type="text/ng-template" id="delete-payment-method-dialog">
-        <md-dialog aria-label="Delete Payment Method">
-            <md-dialog-content class="md-dialog-content">
-                <h2 class="md-title">Warning</h2>
-                <p>Are you sure you want to delete this Payment Method? (this doesn't work yet)</p>
-            </md-dialog-content>
-            <md-dialog-actions>
-                <button mat-button
-                        class="md-icon-button btn-delete"
-                        aria-label="Confirm Delete"
-                        (click)="hide()"
-                >
-                    <mat-icon
-                            [svgIcon]="getSvg('sitetheorycore/images/icons/actionButtons/delete.svg') | async"
-                            aria-hidden="true"
-                    ></mat-icon>
-                </button>
-                <button mat-button aria-label="Cancel" (click)="hide()">
-                    Cancel
-                </button>
-            </md-dialog-actions>
-        </md-dialog>
-    </script-->
+    <mat-progress-bar *ngIf="collection.pending" mode="indeterminate"></mat-progress-bar>
+    <mat-list>
+        <mat-list-item *ngIf="collection.completed && !collection.pending && collection.models.length === 0" class="no-results">
+            No Payment Method on file.
+        </mat-list-item>
+        <mat-list-item
+                *ngFor="let paymentMethod of collection.models"
+                [attr.tabindex]="paymentMethod.data.id"
+        >
+            <sa-stripe-payment-method-item [(model)]="paymentMethod" [editable]="true"></sa-stripe-payment-method-item>
+        </mat-list-item>
+        <mat-list-item
+                [hidden]="!collection.completed || collection.pending"
+        >
+            <sa-stripe-setup-intent
+                    data-detailed-billing-info="true"
+                    [defaultBillingInfo]="defaultBillingInfo"
+                    [urlRoot]="urlRoot"
+                    [paymentMethodApiPath]="paymentMethodApiPath"
+                    [addCardButtonText]="addCardButtonText"
+            ></sa-stripe-setup-intent>
+        </mat-list-item>
+    </mat-list>
 </div>

--- a/packages/stripe/src/payment-method-list.component.less
+++ b/packages/stripe/src/payment-method-list.component.less
@@ -1,4 +1,10 @@
 sa-stripe-payment-method-list {
+  .mat-list-item {
+    height: unset !important;
+    .mat-list-item-content {
+      display: block !important;
+    }
+  }
   .no-results {
     text-align: center;
     padding-bottom: 10px;

--- a/packages/stripe/src/payment-method-list.component.ts
+++ b/packages/stripe/src/payment-method-list.component.ts
@@ -14,11 +14,10 @@ import {keys} from 'ts-transformer-keys'
 import {
     Stratus
 } from '@stratusjs/runtime/stratus'
-import {RootComponent} from '../../angular/src/core/root.component'
 import {Collection, CollectionOptions} from '@stratusjs/angularjs/services/collection'
 import {cookie} from '@stratusjs/core/environment'
 import {safeUniqueId} from '@stratusjs/core/misc'
-import {StripeService} from './stripe.service'
+import {StripeComponent, StripeService} from './stripe.service'
 
 
 
@@ -35,7 +34,7 @@ const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packag
     selector: `sa-${packageName}-${componentName}`,
     templateUrl: `${localDir}${componentName}.component${min}.html`,
 })
-export class StripePaymentMethodListComponent extends RootComponent implements OnInit { // AfterViewInit
+export class StripePaymentMethodListComponent extends StripeComponent implements OnInit { // AfterViewInit
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
@@ -140,7 +139,7 @@ export class StripePaymentMethodListComponent extends RootComponent implements O
      */
     async ngOnInit() {
         await this.fetchPaymentMethods()
-        this.Stripe.registerCollection(this.paymentCollection)
+        this.Stripe.registerCollection(this, this.paymentCollection)
         this.initialized = true
 
     }

--- a/packages/stripe/src/payment-method-list.component.ts
+++ b/packages/stripe/src/payment-method-list.component.ts
@@ -18,7 +18,6 @@ import {Collection, CollectionOptions} from '@stratusjs/angularjs/services/colle
 import {cookie} from '@stratusjs/core/environment'
 import {safeUniqueId} from '@stratusjs/core/misc'
 import {StripeListComponent, StripeService} from './stripe.service'
-import {Model} from '@stratusjs/angularjs/services/model'
 
 
 
@@ -39,12 +38,6 @@ export class StripePaymentMethodListComponent extends StripeListComponent implem
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
-    uid: string
-    @Input() elementId: string
-
-    // States
-    styled = false
-    initialized = false
 
     // Registry Attributes
     @Input() urlRoot: string = '/Api'

--- a/packages/stripe/src/payment-method-list.component.ts
+++ b/packages/stripe/src/payment-method-list.component.ts
@@ -17,7 +17,8 @@ import {
 import {Collection, CollectionOptions} from '@stratusjs/angularjs/services/collection'
 import {cookie} from '@stratusjs/core/environment'
 import {safeUniqueId} from '@stratusjs/core/misc'
-import {StripeComponent, StripeService} from './stripe.service'
+import {StripeListComponent, StripeService} from './stripe.service'
+import {Model} from '@stratusjs/angularjs/services/model'
 
 
 
@@ -34,7 +35,7 @@ const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packag
     selector: `sa-${packageName}-${componentName}`,
     templateUrl: `${localDir}${componentName}.component${min}.html`,
 })
-export class StripePaymentMethodListComponent extends StripeComponent implements OnInit { // AfterViewInit
+export class StripePaymentMethodListComponent extends StripeListComponent implements OnInit { // AfterViewInit
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
@@ -47,6 +48,7 @@ export class StripePaymentMethodListComponent extends StripeComponent implements
 
     // Registry Attributes
     @Input() urlRoot: string = '/Api'
+    // @Input() registryModel: boolean | string // inputs are strings.. // false will disable Registry
     @Input() paymentMethodApiPath: string = 'PaymentMethod'
 
     // Component Attributes
@@ -64,8 +66,13 @@ export class StripePaymentMethodListComponent extends StripeComponent implements
     @Input() defaultBillingAddress2?: string
     defaultBillingInfo: stripe.BillingDetails = {address: {}}
 
-    // Component data
-    paymentCollection: Collection
+    // Stratus Data Connectivity
+    // registry = new Registry()
+    // fetched: Promise<boolean|Collection>
+    // Observable Connection
+    // dataSub: Observable<[]>
+    // onChange = new Subject()
+    // subscriber: Subscriber<any>
 
     constructor(
         private elementRef: ElementRef,
@@ -106,7 +113,7 @@ export class StripePaymentMethodListComponent extends StripeComponent implements
         }
 
         // TODO needs to make use of Observables
-        this.paymentCollection = new Collection(apiOptions)
+        this.collection = new Collection(apiOptions)
 
         if (this.defaultBillingName) {
             this.defaultBillingInfo.name = this.defaultBillingName
@@ -138,18 +145,12 @@ export class StripePaymentMethodListComponent extends StripeComponent implements
      * On load, attempt to prepare and render the Card element
      */
     async ngOnInit() {
-        await this.fetchPaymentMethods()
-        this.Stripe.registerCollection(this, this.paymentCollection)
+        this.Stripe.registerCollection(this, this.collection)
+        this.Stripe.fetchCollections(this.uid).then()
         this.initialized = true
-
-    }
-
-    /*ngAfterViewInit() {
-        // this.paymentItemComponentPortal = new ComponentPortal(StripePaymentMethodItemComponent)
-    }*/
-
-    async fetchPaymentMethods() {
-        await this.paymentCollection.fetch()
-        await this.refresh()
+        this.Stripe.emit('init', this) // Note this component is ready
+        this.Stripe.on(this.uid, 'collectionUpdated', (_source, _collection: [Collection]) => {
+            this.refresh()
+        })
     }
 }

--- a/packages/stripe/src/payment-method-selector.component.html
+++ b/packages/stripe/src/payment-method-selector.component.html
@@ -14,14 +14,13 @@
             [hidden]="!collection.completed || collection.pending || collection.models.length === 0"
             style="width: 100%;" [class.payment-selected]="form.controls[fieldName].value"
     >
-        <mat-label>Payment Method</mat-label>
+        <mat-label [textContent]="form.controls[fieldName].value ? 'Payment Method' : selectCardButtonText"></mat-label>
         <mat-select
                 #paymentSelect
                 [panelClass]="'sa-stripe-payment-method-selector-select-override'"
                 formControlName="{{fieldName}}"
                 [compareWith]="objectComparisonFunction"
         >
-            <!-- TODO fine a way to display certain data formatted. `form.controls.dataNumber.value` is the saved id -->
             <mat-select-trigger>
                 <sa-stripe-payment-method-item *ngIf="form.controls[fieldName].value" [(model)]="form.controls[fieldName].value"></sa-stripe-payment-method-item>
                 <!--{{form.controls.dataNumber.value && form.controls.dataNumber.value.data ? form.controls.dataNumber.value.data.id : 'Not Selected'}}-->

--- a/packages/stripe/src/payment-method-selector.component.html
+++ b/packages/stripe/src/payment-method-selector.component.html
@@ -33,7 +33,11 @@
             >
                 No Payment Method on file.
             </mat-option>
-            <mat-option class="current-selection" *ngIf="form.controls[fieldName].value">
+            <mat-option
+                    class="current-selection"
+                    *ngIf="form.controls[fieldName].value"
+                    [disabled]="form.controls[fieldName].value.data.status < 1"
+            >
                 Current Method
                 <sa-stripe-payment-method-item [(model)]="form.controls[fieldName].value"></sa-stripe-payment-method-item>
             </mat-option>

--- a/packages/stripe/src/payment-method-selector.component.html
+++ b/packages/stripe/src/payment-method-selector.component.html
@@ -16,6 +16,7 @@
     >
         <mat-label>Payment Method</mat-label>
         <mat-select
+                #paymentSelect
                 [panelClass]="'sa-stripe-payment-method-selector-select-override'"
                 formControlName="{{fieldName}}"
                 [compareWith]="objectComparisonFunction"

--- a/packages/stripe/src/payment-method-selector.component.html
+++ b/packages/stripe/src/payment-method-selector.component.html
@@ -2,6 +2,7 @@
         [attr.id]="elementId"
         [formGroup]="form"
 >
+    <mat-progress-bar *ngIf="collection.pending" mode="indeterminate"></mat-progress-bar>
     <sa-stripe-setup-intent
             *ngIf="collection.completed && !collection.pending && collection.models.length === 0"
             data-detailed-billing-info="true"

--- a/packages/stripe/src/payment-method-selector.component.html
+++ b/packages/stripe/src/payment-method-selector.component.html
@@ -3,7 +3,7 @@
         [formGroup]="form"
 >
     <sa-stripe-setup-intent
-            *ngIf="paymentCollection.completed && !paymentCollection.pending && paymentCollection.models.length === 0"
+            *ngIf="collection.completed && !collection.pending && collection.models.length === 0"
             data-detailed-billing-info="true"
             [defaultBillingInfo]="defaultBillingInfo"
             [urlRoot]="urlRoot"
@@ -11,7 +11,7 @@
             [addCardButtonText]="addCardButtonText"
     ></sa-stripe-setup-intent>
     <mat-form-field
-            [hidden]="!paymentCollection.completed || paymentCollection.pending || paymentCollection.models.length === 0"
+            [hidden]="!collection.completed || collection.pending || collection.models.length === 0"
             style="width: 100%;" [class.payment-selected]="form.controls[fieldName].value"
     >
         <mat-label>Payment Method</mat-label>
@@ -27,7 +27,7 @@
             </mat-select-trigger>
             <mat-option
                     class="no-results"
-                    *ngIf="paymentCollection.completed && !paymentCollection.pending && paymentCollection.models.length === 0"
+                    *ngIf="collection.completed && !collection.pending && collection.models.length === 0"
                     [disabled]="true"
             >
                 No Payment Method on file.
@@ -36,14 +36,14 @@
                 <sa-stripe-payment-method-item [(model)]="form.controls[fieldName].value"></sa-stripe-payment-method-item>
             </mat-option>
             <mat-option
-                    *ngFor="let paymentMethod of paymentCollection.models"
+                    *ngFor="let paymentMethod of collection.models"
                     [value]="paymentMethod"
                     [disabled]="isPMExpired(paymentMethod)"
             >
                 <sa-stripe-payment-method-item [(model)]="paymentMethod" [editable]="true"></sa-stripe-payment-method-item>
             </mat-option>
             <mat-option
-                    [hidden]="!paymentCollection.completed || paymentCollection.pending"
+                    [hidden]="!collection.completed || collection.pending"
                     [disabled]="true"
             >
                 <sa-stripe-setup-intent

--- a/packages/stripe/src/payment-method-selector.component.html
+++ b/packages/stripe/src/payment-method-selector.component.html
@@ -34,6 +34,7 @@
                 No Payment Method on file.
             </mat-option>
             <mat-option class="current-selection" *ngIf="form.controls[fieldName].value">
+                Current Method
                 <sa-stripe-payment-method-item [(model)]="form.controls[fieldName].value"></sa-stripe-payment-method-item>
             </mat-option>
             <mat-option

--- a/packages/stripe/src/payment-method-selector.component.html
+++ b/packages/stripe/src/payment-method-selector.component.html
@@ -2,7 +2,18 @@
         [attr.id]="elementId"
         [formGroup]="form"
 >
-    <mat-form-field style="width: 100%;" [class.payment-selected]="form.controls[fieldName].value">
+    <sa-stripe-setup-intent
+            *ngIf="paymentCollection.completed && !paymentCollection.pending && paymentCollection.models.length === 0"
+            data-detailed-billing-info="true"
+            [defaultBillingInfo]="defaultBillingInfo"
+            [urlRoot]="urlRoot"
+            [paymentMethodApiPath]="paymentMethodApiPath"
+            [addCardButtonText]="addCardButtonText"
+    ></sa-stripe-setup-intent>
+    <mat-form-field
+            [hidden]="!paymentCollection.completed || paymentCollection.pending || paymentCollection.models.length === 0"
+            style="width: 100%;" [class.payment-selected]="form.controls[fieldName].value"
+    >
         <mat-label>Payment Method</mat-label>
         <mat-select
                 [panelClass]="'sa-stripe-payment-method-selector-select-override'"

--- a/packages/stripe/src/payment-method-selector.component.less
+++ b/packages/stripe/src/payment-method-selector.component.less
@@ -1,6 +1,10 @@
 @medium-grey-color: #c5c5c5;
 sa-stripe-payment-method-selector,
 .sa-stripe-payment-method-selector-select-override {
+  [hidden] {
+    /* full hide */
+    display: none !important;
+  }
   /* select-override.mat-select is for controlling select popup options */
   &.mat-select-panel {
     max-height: 50vh;

--- a/packages/stripe/src/payment-method-selector.component.ts
+++ b/packages/stripe/src/payment-method-selector.component.ts
@@ -67,6 +67,7 @@ export class StripePaymentMethodSelectorComponent extends StripeListComponent im
 
     // Component Attributes
     @Input() addCardButtonText: string = 'Add Payment Method'
+    @Input() selectCardButtonText: string = 'Select Default Payment Method'
     @Input() disabled: boolean | string = false // inputs are strings..
     @Input() property: string
     @Input() detailedBillingInfo?: boolean
@@ -268,10 +269,7 @@ export class StripePaymentMethodSelectorComponent extends StripeListComponent im
         this.Stripe.on(this.uid, 'collectionUpdated', (_source, _collection: [Collection]) => {
             // console.log('selector collectionUpdated!!!!', _source, _collection)
             this.refresh()
-            if (this.paymentSelect && this.paymentSelect.panelOpen) {
-                // Let's close the selector if we've had updates so we can see that new data (or remove it completely)
-                this.paymentSelect.close()
-            }
+            this.selectorListClose()
         })
         this.Stripe.on(
             'Stripe',
@@ -445,6 +443,28 @@ export class StripePaymentMethodSelectorComponent extends StripeListComponent im
         if (paymentMethod.data.exp_year < year) {return true}
         if (paymentMethod.data.exp_year > year) {return false}
         return paymentMethod.data.exp_month < month
+    }
+
+    selectorListClose(ev?: any) {
+        if (ev) {
+            ev.preventDefault()
+            // ev.stopPropagation()
+        }
+        if (this.paymentSelect && this.paymentSelect.panelOpen) {
+            // Let's close the selector if we've had updates so we can see that new data (or remove it completely)
+            this.paymentSelect.close()
+        }
+    }
+
+    selectorListOpen(ev?: any) {
+        if (ev) {
+            ev.preventDefault()
+            // ev.stopPropagation()
+        }
+        if (this.paymentSelect && !this.paymentSelect.panelOpen) {
+            // Let's close the selector if we've had updates so we can see that new data (or remove it completely)
+            this.paymentSelect.open()
+        }
     }
 
 }

--- a/packages/stripe/src/payment-method-selector.component.ts
+++ b/packages/stripe/src/payment-method-selector.component.ts
@@ -9,6 +9,7 @@ import {
     OnInit,
     ViewChild
 } from '@angular/core'
+import {MatSelect} from '@angular/material/select'
 // import {ComponentPortal} from '@angular/cdk/portal'
 import {DomSanitizer} from '@angular/platform-browser'
 import {snakeCase} from 'lodash'
@@ -27,8 +28,6 @@ import {Observable, ObservableInput, Subscriber, timer} from 'rxjs'
 import {catchError, debounce} from 'rxjs/operators'
 import {FormBuilder, FormControl, FormGroup} from '@angular/forms'
 import Toastify from 'toastify-js'
-
-// import {EventBase} from '@stratusjs/core/events/eventBase'
 
 // Local Setup
 const min = !cookie('env') ? '.min' : ''
@@ -97,10 +96,7 @@ export class StripePaymentMethodSelectorComponent extends StripeListComponent im
         [this.fieldName]: new FormControl(), // optionally disabled on init to avoid known issues
         [this.fieldNameId]: new FormControl({disabled: true})
     })
-
-
-    // Component data
-    // collection: Collection
+    @ViewChild('paymentSelect', {static: false}) paymentSelect: MatSelect
 
     // paymentItemComponentPortal: ComponentPortal<StripePaymentMethodItemComponent>
 
@@ -273,17 +269,15 @@ export class StripePaymentMethodSelectorComponent extends StripeListComponent im
         this.Stripe.on(this.uid, 'collectionUpdated', (source, collection: Collection) => {
             // console.log('selector collectionUpdated!!!!', source, collection)
             this.refresh()
+            if (this.paymentSelect && this.paymentSelect.panelOpen) {
+                // Let's close the selector if we've had updates so we can see that new data (or remove it completely)
+                this.paymentSelect.close()
+            }
         })
 
         // TODO need a change watcher on the selector
         // console.log('inited selector, this is model', this.model)
     }
-
-    /*async fetchPaymentMethods() {
-        await this.collection.fetch()
-        console.log('selector fetchPaymentMethods')
-        await this.refresh()
-    }*/
 
     valueChanged(value: Model) {
         if (value) {

--- a/packages/stripe/src/payment-method-selector.component.ts
+++ b/packages/stripe/src/payment-method-selector.component.ts
@@ -245,7 +245,7 @@ export class StripePaymentMethodSelectorComponent extends RootComponent implemen
             (value?: Model) => {
                 // Avoid saving until the Model is truly available
                 if (!value || !value.completed) {
-                // if (!this.model.completed) {
+                    // if (!this.model.completed) {
                     return
                 }
 
@@ -255,7 +255,7 @@ export class StripePaymentMethodSelectorComponent extends RootComponent implemen
                     this.property,
                     this.normalizeOut(innerHTML || value)
                 )*/
-            })
+            }).then()
 
         await this.fetchPaymentMethods()
         // TODO grey out until loaded?
@@ -379,7 +379,7 @@ export class StripePaymentMethodSelectorComponent extends RootComponent implemen
         } */
         // console.log('will run subscriber next', dataNumber)
         this.subscriber.next(dataNumber)
-        // TODO: Add a returned Promise to ensure async/await can use this defer directly.
+        // ???: Add a returned Promise to ensure async/await can use this defer directly. (Observer can't use promise)
     }
 
     // dataRef(): number|null {

--- a/packages/stripe/src/payment-method-selector.component.ts
+++ b/packages/stripe/src/payment-method-selector.component.ts
@@ -43,15 +43,8 @@ const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packag
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class StripePaymentMethodSelectorComponent extends StripeListComponent implements OnInit {
-
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
-    // uid: string
-    @Input() elementId: string
-
-    // States
-    styled = false
-    initialized = false
 
     // Registry Attributes
     @Input() target: string

--- a/packages/stripe/src/payment-method.component.ts
+++ b/packages/stripe/src/payment-method.component.ts
@@ -18,11 +18,10 @@ import {keys} from 'ts-transformer-keys'
 import {
     Stratus
 } from '@stratusjs/runtime/stratus'
-import {RootComponent} from '../../angular/src/core/root.component'
 import {Model, ModelOptions} from '@stratusjs/angularjs/services/model'
 import {cookie} from '@stratusjs/core/environment'
 import {safeUniqueId} from '@stratusjs/core/misc'
-import {StripeService} from './stripe.service'
+import {StripeComponent, StripeService} from './stripe.service'
 
 // Local Setup
 const min = !cookie('env') ? '.min' : ''
@@ -39,7 +38,7 @@ const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packag
     templateUrl: `${localDir}${componentName}.component${min}.html`,
     // changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class StripePaymentMethodComponent extends RootComponent implements OnDestroy, OnInit {
+export class StripePaymentMethodComponent extends StripeComponent implements OnDestroy, OnInit {
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`

--- a/packages/stripe/src/payment-method.component.ts
+++ b/packages/stripe/src/payment-method.component.ts
@@ -42,8 +42,6 @@ export class StripePaymentMethodComponent extends StripeComponent implements OnD
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
-    uid: string
-    @Input() elementId: string
 
     // Dependencies
     _: any
@@ -53,8 +51,6 @@ export class StripePaymentMethodComponent extends StripeComponent implements OnD
     @Input() paymentMethodApiPath: string = 'PaymentMethod'
 
     // States
-    styled = false
-    initialized = false
     cardComplete = false
     cardSaved = false
     formPending = false

--- a/packages/stripe/src/payment-method.component.ts
+++ b/packages/stripe/src/payment-method.component.ts
@@ -249,23 +249,25 @@ export class StripePaymentMethodComponent extends StripeComponent implements OnD
                 payment_method: setupIntent.payment_method
             }
             await model.save()
-            // TODO check if Sitetheory refreshed
             // hide form and Display a success message
-            // $scope.$applyAsync(() => {
             this.cardSaved = true
             this.formPending = false
             // Reload any collections listing PMs
-            this.Stripe.fetchCollections()
-            // FIXME autoselect this card
-            // })
+            await this.Stripe.fetchCollections()
+            // emit this new card to auto-select it
+            const cardDetails = {
+                type: 'card',
+                name: this.billingInfo.name,
+                email: this.billingInfo.email
+            }
+            // console.log('noting a new card', cardDetails)
+            this.Stripe.emitManual('paymentMethodCreated', 'Stripe', this, cardDetails)
         } else {
             // handle everything else
-            // $scope.$applyAsync(() => {
             this.formPending = false
             console.error('something went wrong. no error, no success', setupIntent)
             const displayError = document.getElementById(`${this.elementId}-errors`)
             displayError.textContent = 'An unknown Error has occurred'
-            // })
         }
     }
 

--- a/packages/stripe/src/payment-method.component.ts
+++ b/packages/stripe/src/payment-method.component.ts
@@ -256,6 +256,7 @@ export class StripePaymentMethodComponent extends StripeComponent implements OnD
             this.formPending = false
             // Reload any collections listing PMs
             this.Stripe.fetchCollections()
+            // FIXME autoselect this card
             // })
         } else {
             // handle everything else

--- a/packages/stripe/src/setup-intent.component.ts
+++ b/packages/stripe/src/setup-intent.component.ts
@@ -24,6 +24,7 @@ import {
     StripePaymentMethodComponent,
     StripePaymentMethodDialogData
 } from './payment-method.component'
+import {StripeComponent} from './stripe.service'
 
 // Local Setup
 // const min = !cookie('env') ? '.min' : ''
@@ -36,7 +37,7 @@ const componentName = 'setup-intent'
     // templateUrl: `${localDir}/${parentModuleName}/${moduleName}.component.html`,
     template: '<button mat-raised-button (click)="addPaymentMethod($event)" [disabled]="newPaymentMethodPending || newPaymentMethodPrompt" [textContent]="addCardButtonText"></button>',
 })
-export class StripeSetupIntentComponent extends RootComponent implements OnInit {
+export class StripeSetupIntentComponent extends StripeComponent implements OnInit {
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`

--- a/packages/stripe/src/setup-intent.component.ts
+++ b/packages/stripe/src/setup-intent.component.ts
@@ -41,8 +41,6 @@ export class StripeSetupIntentComponent extends StripeComponent implements OnIni
 
     // Basic Component Settings
     title = `${packageName}_${componentName}_component`
-    uid: string
-    @Input() elementId: string
 
     // States
     styled = false

--- a/packages/stripe/src/stripe.service.ts
+++ b/packages/stripe/src/stripe.service.ts
@@ -1,14 +1,27 @@
-import { Injectable } from '@angular/core'
-import {isEmpty, isNil, isString} from 'lodash'
+import {Injectable, Input, NgZone} from '@angular/core'
+import {RootComponent} from '@stratusjs/angular/core/root.component'
+import {isEmpty, isNil, isString, uniqueId} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {Collection} from '@stratusjs/angularjs/services/collection'
-import {safeUniqueId} from '@stratusjs/core/misc'
+import {LooseObject, safeUniqueId} from '@stratusjs/core/misc'
 import Toastify from 'toastify-js'
 
 interface StripeVariables {
     stripe?: stripe.Stripe
     stripeElements?: stripe.elements.Elements
 }
+
+export class StripeComponent extends RootComponent {
+    title: string
+    uid: string
+    @Input() elementId: string
+}
+export class StripeListComponent<T = LooseObject> extends StripeComponent {
+    collection: Collection<T>
+}
+export type StripeEmitter = (source: StripeComponent, ...variables: any) => any
+export type StripeEmitterInit = StripeEmitter & ((source: StripeComponent) => any)
+export type StripeEmitterCollectionUpdated = StripeEmitter & ((source: StripeListComponent, collection?: Collection) => any)
 
 @Injectable({
     providedIn: 'root'
@@ -21,12 +34,42 @@ export class StripeService {
         paymentMethodType: stripe.elements.elementsType
         element: stripe.elements.Element
     }
-    collections: Collection[] = []
+    private instanceOnEmitters: {
+        [emitterUid: string]: {
+            // [onMethodName: string]: StripeEmitter[]
+            [onMethodName: string]: {[uid: string]: StripeEmitter}
+            init?: {[uid: string]: StripeEmitterInit}
+            collectionUpdated?: {[uid: string]: StripeEmitterCollectionUpdated}
+        }
+    } = {
+        /*idx_property_list_7: {
+            somethingChangedFake: [
+                (source) => {
+                    console.log('The something updated in this scope', source)
+                }
+            ],
+            collectionUpdated: [
+                (source: IdxComponentScope, collection: Collection) => {
+                    console.log('The collection in this scope updated', source)
+                    console.log('collection is now', collection)
+                }
+            ]
+        }*/
+    }
+    // collections: Collection[] = []
+    collections: {
+        [uid:string]: {
+            uid: string
+            component: StripeComponent
+            collection: Collection
+        }
+    } = {}
     initializing = false
     initialized = false
 
     constructor(
         // private http: HttpClient
+        private ngZone: NgZone
     ) {
         // Initialization
         Stratus.Services.Stripe = this
@@ -151,14 +194,33 @@ export class StripeService {
         return this.Stripe.stripe.confirmCardSetup(clientSecret, stripeData, options)
     }
 
-    registerCollection(collection: Collection) {
-        this.collections.push(collection)
+    registerCollection(component: StripeComponent, collection: Collection) {
+        this.collections[component.uid] = {uid: component.uid, component, collection}
     }
 
-    fetchCollections() {
-        this.collections.forEach((collection) => {
-            collection.fetch().then()
-            // console.log('refetching this collection')
+    fetchCollections(uid?: string) {
+        let uids: string[] = []
+        if(
+            isString(uid) &&
+            uid.length > 0
+        ) {
+            uids = [uid]
+        } else {
+            uids = Object.keys(this.collections)
+        }
+
+        uids.forEach((uidName) => {
+            if (Object.prototype.hasOwnProperty.call(this.collections, uidName)) {
+                this.collections[uidName].collection.fetch().then(() => {
+                    // console.log('Service refetched this collection', uidName, this.collections[uidName].collection)
+                    this.emitManual(
+                        'collectionUpdated',
+                        uidName,
+                        this.collections[uidName].component,
+                        this.collections[uidName].collection
+                    )
+                })
+            }
         })
     }
 
@@ -251,5 +313,83 @@ export class StripeService {
             this.currentElement = undefined
             // console.warn('Destroying StripeElement', id)
         }
+    }
+
+    emit(
+        emitterName: string,
+        component: StripeComponent,
+        ...variables: any
+    ) {
+        this.emitManual(emitterName, component.elementId, component, variables)
+    }
+
+    emitManual(
+        emitterName: string,
+        uid: string,
+        component: StripeComponent,
+        ...variables: any
+    ) {
+        if (
+            Object.prototype.hasOwnProperty.call(this.instanceOnEmitters, uid) &&
+            Object.prototype.hasOwnProperty.call(this.instanceOnEmitters[uid], emitterName)
+        ) {
+            Object.values(this.instanceOnEmitters[uid][emitterName]).forEach((emitter) => {
+                try {
+                    emitter(component, variables)
+                } catch (e) {
+                    console.error(e, 'issue sending back emitter on', uid, emitterName, emitter)
+                }
+            })
+        }
+
+        if (emitterName === 'init') {
+            // Let's prep the requests for 'init' so they immediate call if this scope has already init
+            this.instanceOnEmitters[uid] ??= {}
+            this.instanceOnEmitters[uid][emitterName] ??= {}
+        }
+    }
+
+    removeOnManual(
+        emitterName: string,
+        emitterId: string,
+        onId: string,
+    ) {
+        if (
+            Object.prototype.hasOwnProperty.call(this.instanceOnEmitters, emitterId) &&
+            Object.prototype.hasOwnProperty.call(this.instanceOnEmitters[emitterId], emitterName) &&
+            Object.prototype.hasOwnProperty.call(this.instanceOnEmitters[emitterId][emitterName], onId)
+        ) {
+            delete this.instanceOnEmitters[emitterId][emitterName][onId]
+        }
+    }
+
+    on(
+        uid: string,
+        emitterName: string,
+        callback: StripeEmitter
+    ) {
+        // console.log('a request has been made to watch for', uid, 'to emit', emitterName)
+        // Let's check if an init request has already missed it's opportunity to init
+        if (
+            emitterName === 'init' &&
+            Object.prototype.hasOwnProperty.call(this.instanceOnEmitters, uid) &&
+            Object.prototype.hasOwnProperty.call(this.instanceOnEmitters[uid], emitterName) &&
+            Object.prototype.hasOwnProperty.call(Stratus.Instances, uid)
+        ) {
+            // init has already happened.... so let's send back the emit of 'init' right now!
+            // emit('init', Stratus.Instances[uid]) // wait, would this send the init a second time? maybe just send it to this callback
+            callback(Stratus.Instances[uid])
+            return
+        }
+
+        if (!Object.prototype.hasOwnProperty.call(this.instanceOnEmitters, uid)) {
+            this.instanceOnEmitters[uid] = {}
+        }
+        if (!Object.prototype.hasOwnProperty.call(this.instanceOnEmitters[uid], emitterName)) {
+            this.instanceOnEmitters[uid][emitterName] = {}
+        }
+        const onId = uniqueId() // TODO make a named connection to the requesting scope??
+        this.instanceOnEmitters[uid][emitterName][onId] = callback
+        return (): void => {this.removeOnManual(uid, emitterName, onId)}
     }
 }

--- a/packages/stripe/src/stripe.service.ts
+++ b/packages/stripe/src/stripe.service.ts
@@ -15,6 +15,8 @@ export class StripeComponent extends RootComponent {
     title: string
     uid: string
     @Input() elementId: string
+    styled = false
+    initialized = false
 }
 export class StripeListComponent<T = LooseObject> extends StripeComponent {
     collection: Collection<T>


### PR DESCRIPTION
**@stratusjs/stripe 1.7.0 published**
Adds
* Pub/sub on/emit trigger a system
* payment-method-list
* * Add usable 'just' a list for display without selection
* payment-method-selector
* * auto-select any newly added payment methods
* * add progress bar
* payment-method-item
* * add card payment deletion path option (urlRoot)

Changes
* payment-method-selector
* * if no Cards to display, use add button instead
* * close select box on add/remove so it may update
* * refetch latest pms after a delete
* * label the current method better
* * disable card if it was deleted but still in the system
* consolidated reused items throughout

------

**@stratusjs/angular 0.7.5 published**
* Published last stripe changes