### PR TITLE
@stratusjs/idx 0.19.1 (and log of missing Stripe 1.8.0 Angular 0.7.6 PR?)

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./dist/idx.bundle.js",
   "scripts": {

--- a/packages/idx/src/member/details.component.ts
+++ b/packages/idx/src/member/details.component.ts
@@ -147,7 +147,7 @@ Stratus.Components.IdxMemberDetails = {
                 memberQuery.service &&
                 (memberQuery.where.MemberKey || memberQuery.where.MemberStateLicense)
             ) {
-                await Idx.fetchMembers($scope, 'collection', memberQuery, true, 'MemberDetailsList')
+                await Idx.fetchMembers($scope.elementId, 'collection', memberQuery, true, 'MemberDetailsList')
             } else {
                 console.error('No Service Id or Member Key/License is fetch from')
             }

--- a/packages/idx/src/member/list.component.ts
+++ b/packages/idx/src/member/list.component.ts
@@ -236,7 +236,7 @@ Stratus.Components.IdxMemberList = {
                 try {
                     // resolve(Idx.fetchProperties($scope, 'collection', $scope.query, refresh))
                     // Grab the new property listings
-                    const results = await Idx.fetchMembers($scope, 'collection', $scope.options, refresh)
+                    const results = await Idx.fetchMembers($scope.elementId, 'collection', $scope.options, refresh)
                     Idx.emit('searched', $scope, clone($scope.query))
                     resolve(results)
                 } catch (e) {

--- a/packages/idx/src/office/list.component.ts
+++ b/packages/idx/src/office/list.component.ts
@@ -342,7 +342,7 @@ Stratus.Components.IdxOfficeList = {
                 try {
                     // resolve(Idx.fetchProperties($scope, 'collection', $scope.query, refresh))
                     // Grab the new property listings
-                    const results = await Idx.fetchOffices($scope, 'collection', $scope.query, refresh)
+                    const results = await Idx.fetchOffices($scope.elementId, 'collection', $scope.query, refresh)
                     lastQuery = cloneDeep($scope.query)
                     Idx.emit('searched', $scope, clone($scope.query))
                     resolve(results)

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -652,7 +652,7 @@ Stratus.Components.IdxPropertyList = {
                     try {
                         // resolve(Idx.fetchProperties($scope, 'collection', $scope.query, refresh))
                         // Grab the new property listings
-                        const results = await Idx.fetchProperties($scope, 'collection', $scope.query, refresh)
+                        const results = await Idx.fetchProperties($scope.elementId, 'collection', $scope.query, refresh)
                         lastQuery = cloneDeep($scope.query)
                         // $applyAsync will automatically be applied
                         Idx.emit('searched', $scope, clone($scope.query))

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/stripe",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Angular Stripe Elements components to be used as an add on to StratusJS",
   "main": "",
   "scripts": {
@@ -29,7 +29,7 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/angular": "^0.7.5",
+    "@stratusjs/angular": "^0.7.6",
     "@stratusjs/runtime": "^0.12.1",
     "toastify-js": "^1.12.0"
   }


### PR DESCRIPTION
@stratusjs/idx 0.19.1
Changes
- Fix for List components sharing/stealing collections when multiple components existed

-------------
-------------

This PR doesn't contain the Stripe 1.8.0 Angular 0.7.6 changes, but those commits some how bypassed PR protections. changes below:

[@stratusjs/idx fix single instance stealing/updating all instance's c…](https://github.com/Sitetheory/stratus/commit/c67760614728e5f6e4941ddf35b68b11e6ad05de) 

commits:
- [@stratusjs/stripe sa-stripe-payment-method-item/sa-stripe-payment-method-selector template options](https://github.com/Sitetheory/stratus/commit/c67760614728e5f6e4941ddf35b68b11e6ad05de)
- [@stratusjs/angular boot sa-stripe-payment-method-item-display](https://github.com/Sitetheory/stratus/commit/0d62bd9427c6285ae9dcbab0530cddb1860beacd)
- [@stratusjs/stripe sa-stripe-payment-method-item-display doesn't use any extra css](https://github.com/Sitetheory/stratus/commit/6199ac9d0bd2d46e753c329dc2661e4d840244cf)

@stratusjs/stripe 1.8.0
Adds
- `templateStyle` options to `payment-method-item-display` and `payment-method-selector` allowing need temp[lating options for various sitetheory locations

Removes
- uneeded css loading

@stratusjs/angular 0.7.6
Adds
- `sa-stripe-payment-method-item-display` auto-boot option

Changes
- @stratusjs/stripe 1.8.0