### PR TITLE
@stratusjs/angularjs-extras 0.13.0 @stratusjs/boot 1.1.0 stratus-tab-routing

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.12.14",
+  "version": "0.13.0",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -26,7 +26,7 @@
     "yarn": ">= 1.21.1"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.6.2",
+    "@stratusjs/angularjs": "^0.6.3",
     "@stratusjs/core": "^0.5.2",
     "@stratusjs/runtime": "^0.12.1",
     "js-md5": "^0.7.3",

--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -23,7 +23,7 @@
     "moment"
   ],
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "@stratusjs/angularjs": "^0.6.3",

--- a/packages/angularjs-extras/src/directives/tabRouting.ts
+++ b/packages/angularjs-extras/src/directives/tabRouting.ts
@@ -1,0 +1,213 @@
+/**
+ * @file TabRouting Directive @stratusjs/angularjs-extras/directives/tabRouting
+ * @description Provides On-Load and Tab switching support for URL sharing of md-tabs positions.
+ * @example <md-tabs stratus-tab-routing />
+ * @example <md-tabs stratus-tab-routing='{"urlLabel":"Section"}' />
+ */
+
+import {assignIn, head} from 'lodash'
+import {element, IAttributes, IAugmentedJQuery, ILocationService, IRootScopeService, IScope} from 'angular'
+import {Stratus} from '@stratusjs/runtime/stratus'
+import {safeUniqueId} from '@stratusjs/core/misc'
+import 'angular-material'
+
+export type TabRoutingScope = IScope & {
+    uid: string
+    initialized: boolean
+    options: {
+        urlLabel: string
+    }
+    mdTabController?: MdTabsController
+    tabIndexes: {[tabName: string]: number}
+
+    init(): Promise<void>
+    getTabNameOnUrl(): string | null
+    hijackMdTabsController(): boolean
+    onTabClick(tabName: string): void
+    processTabs(): void
+    selectTabName(tabName: string): boolean
+    setTabNameOnUrl(tabName: string): void
+}
+
+type MdTab = {
+    element: IAugmentedJQuery
+    hasContent: boolean
+    id: string
+    index: number
+    label: string // Tab title
+    template: string // html string
+    clickInjected?: boolean // custom variable being added
+    getIndex(): number
+    hasFocus(): boolean
+    isActive(): boolean
+    isLeft(): boolean
+    isRight(): boolean
+    shouldRender(): boolean
+}
+
+type MdTabsController = {
+    hasFocus: boolean
+    lastSelectedIndex: number
+    selectedIndex: number
+    tabs: MdTab[]
+
+    getFocusedTabId(): string
+    canPageBack(): boolean
+    canPageForward(): boolean
+    getTabElementIndex(tabEl: HTMLElement): number
+    insertTab(tabData: MdTab, index: number): MdTab
+    nextPage(): void
+    previousPage(): void
+    refreshIndex(): void
+    removeTab(tabData: MdTab): void
+    select(index: number, canSkipClick?: boolean): void
+}
+
+type MdTabsWrapperScope = IScope & {
+    $mdTabsCtrl: MdTabsController
+}
+
+// Environment
+const packageName = 'angularjs-extras'
+const moduleName = 'directives'
+const directiveName = 'tabRouting'
+
+Stratus.Directives.TabRouting = (
+    $location: ILocationService,
+    $rootScope: IRootScopeService
+) => {
+    return {
+        restrict: 'A',
+        // ensure we are nested on md-tabs
+        require: 'mdTabs',
+        link(
+            $scope: TabRoutingScope,
+            $element: IAugmentedJQuery,
+            $attrs: IAttributes,
+        ) {
+            // Initialize
+            $scope.uid = safeUniqueId(packageName, moduleName, directiveName)
+            Stratus.Instances[$scope.uid] = $scope
+            $scope.options = {
+                urlLabel: 'Tab'
+            }
+
+            const additionalOptions = $attrs.stratusTabRouting
+                ? $scope.$eval($attrs.stratusTabRouting)
+                : {}
+            assignIn($scope.options, additionalOptions)
+
+            const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+            $scope.init = async () => {
+                // Wait a moment to init for parent md-tabs to process tabs first
+                await sleep(500)
+                if (!$scope.hijackMdTabsController()) {
+                    console.warn(`${$scope.uid} unable to bind to MdTabsController.`)
+                    return
+                }
+                // TODO need some type of watcher in case tabs change or get added to
+                $scope.processTabs()
+
+                $scope.initialized = true
+
+                // Wait a moment to init then select a tab
+                await sleep(250)
+
+                // fetch the current URL route
+                let tabName = $scope.getTabNameOnUrl()
+
+                if (tabName) {
+                    // turn spaces into dashes and use lowercase throughout
+                    tabName = tabName.replace(/\s+/g, '-').toLowerCase()
+                    $scope.selectTabName(tabName)
+                }
+            }
+
+            $scope.hijackMdTabsController = () => {
+                const mdTabsWrapperEl: HTMLElement = head($element.find('md-tabs-wrapper'))
+                if (!mdTabsWrapperEl) {
+                    console.warn('TabRouting could not find md-tabs-wrapper nested in it\'s element. Ensure this directive is attached to md-tabs.')
+                    return false
+                }
+                const mdTabsWrapperScope: MdTabsWrapperScope = element(mdTabsWrapperEl).scope()
+                $scope.mdTabController = mdTabsWrapperScope.$mdTabsCtrl
+                return true
+            }
+
+            $scope.processTabs = () => {
+                $scope.tabIndexes = {}
+                $scope.mdTabController.tabs.forEach((tab) => {
+                    let tabName = tab.label
+                    // turn spaces into dashes and use lowercase throughout
+                    tabName = tabName.replace(/\s+/g, '-').toLowerCase()
+                    $scope.tabIndexes[tabName] = tab.getIndex()
+                    if (!tab.hasOwnProperty('clickInjected')) {
+                        tab.element.on('click', () => $scope.onTabClick(tabName))
+                        tab.clickInjected = true
+                    }
+                })
+            }
+
+            $scope.onTabClick = (tabName: string) => {
+                $scope.setTabNameOnUrl(tabName)
+            }
+
+            $scope.getTabNameOnUrl = (): string | null => {
+                // must end and begin with a / (or some other symbol) to delimiter variables
+                // /Tab/billing/
+                const path = $location.path() || ''
+                const regex = new RegExp(`\/${$scope.options.urlLabel}\/(.*?)\/`)
+                const matches = regex.exec(path)
+                let tabName
+                if (
+                    matches !== null &&
+                    matches[1] // option 1 is the first selection group
+                ) {
+                    // Save the variable
+                    tabName = matches[1]
+                }
+                return tabName
+            }
+
+            $scope.selectTabName = (tabName: string): boolean => {
+                if (
+                    $scope.tabIndexes &&
+                    $scope.tabIndexes.hasOwnProperty(tabName)
+                ) {
+                    $scope.mdTabController.select($scope.tabIndexes[tabName])
+                    return true
+                }
+                return false
+            }
+
+            $scope.setTabNameOnUrl = (tabName: string) => {
+                // grab the full url path
+                let path = $location.path() || ''
+                const regex = new RegExp(`\/${$scope.options.urlLabel}\/(.*?)\/`)
+                // Only get the Tab option if it even exists
+                const matches = regex.exec(path)
+                if (
+                    matches !== null &&
+                    matches[0] // option 0 is the whole /Tab/xxx/ selection if it exists
+                ) {
+                    // Save the variable
+                    const removeString = matches[0]
+                    path = path.replace(removeString, '')
+                }
+                if (!path.endsWith('/')) {
+                    // Ensure we always start with a / for delimiting.
+                    path += '/'
+                }
+                path += `${$scope.options.urlLabel}/${tabName}/`
+
+                // Set the new url options
+                $rootScope.$applyAsync(() => {
+                    $location.path(path).replace()
+                })
+            }
+
+            $scope.init().then()
+        }
+    }
+}

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -23,7 +23,7 @@
     "angularjs"
   ],
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "@stratusjs/core": "^0.5.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,7 +23,7 @@
     "backend"
   ],
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "tslib": "^1.11.1"

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -23,7 +23,7 @@
     "typescript"
   ],
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "tslib": "^2.4.0"

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/boot",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "This is the boot package for StratusJS.",
   "main": "dist/boot.min.js",
   "scripts": {},

--- a/packages/boot/src/config.ts
+++ b/packages/boot/src/config.ts
@@ -244,6 +244,7 @@
             'stratus.directives.singleClick': stratusjsAngularJsExtrasBundlePath,
             'stratus.directives.src': stratusjsAngularJsExtrasBundlePath,
             'stratus.directives.stringToNumber': stratusjsAngularJsExtrasBundlePath,
+            'stratus.directives.tabRouting': stratusjsAngularJsExtrasBundlePath,
             'stratus.directives.timestampToDate': stratusjsAngularJsExtrasBundlePath,
             'stratus.directives.trigger': stratusjsAngularJsExtrasBundlePath,
             'stratus.directives.validate': stratusjsAngularJsExtrasBundlePath,

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -24,7 +24,7 @@
     "ical"
   ],
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "@fullcalendar/common": "^5.11.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "typescript"
   ],
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Sitetheory/stratus#readme",
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "@angular/google-maps": "^11.2.13",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -23,7 +23,7 @@
     "runtime"
   ],
   "engines": {
-    "yarn": ">= 1.21.1"
+    "npm": ">= 8.19.3"
   },
   "dependencies": {
     "@stratusjs/core": "^0.5.0",


### PR DESCRIPTION
General
Changes:
- Removed yarn from future builds for npm

@stratusjs/angularjs-extras 0.13.0
Adds:
- stratus-tab-routing directive
- - md-tabs url routing functionality

Video Example:
[![Watch the video](https://cdn-cf-east.streamable.com/image/egidt5-screenshot570390.jpg)](https://streamable.com/egidt5)


@stratusjs/boot 1.1.0
Adds:
- stratus-tab-routing directive config