### PR TITLE
@stratusjs/swiper 1.2.2 @stratusjs/idx 0.20.0

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./dist/idx.bundle.js",
   "scripts": {
@@ -31,11 +31,11 @@
   },
   "dependencies": {
     "@stratusjs/angular": "^0.7.1",
-    "@stratusjs/angularjs": "^0.6.2",
-    "@stratusjs/angularjs-extras": "^0.12.14",
-    "@stratusjs/boot": "^1.0.1",
-    "@stratusjs/map": "^0.6.4",
+    "@stratusjs/angularjs": "^0.6.5",
+    "@stratusjs/angularjs-extras": "^0.13.0",
+    "@stratusjs/boot": "^1.1.0",
+    "@stratusjs/map": "^0.6.5",
     "@stratusjs/runtime": "^0.12.1",
-    "@stratusjs/swiper": "^1.2.1"
+    "@stratusjs/swiper": "^1.2.2"
   }
 }

--- a/packages/idx/src/disclaimer/disclaimer.component.ts
+++ b/packages/idx/src/disclaimer/disclaimer.component.ts
@@ -15,10 +15,6 @@ import {cookie} from '@stratusjs/core/environment'
 import {IdxComponentScope, IdxEmitter, IdxService, MLSService} from '@stratusjs/idx/idx'
 import moment from 'moment'
 
-// Stratus Preload
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-
 // Environment
 const min = !cookie('env') ? '.min' : ''
 const packageName = 'idx'

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -1898,11 +1898,11 @@ const angularJsService = (
                 },
                 ListPriceMin: {
                     type: 'numberEqualGreater',
-                    apiField: 'ListPrice'
+                    apiField: '_BestPrice'
                 },
                 ListPriceMax: {
                     type: 'numberEqualLess',
-                    apiField: 'ListPrice'
+                    apiField: '_BestPrice'
                 },
                 Bathrooms: {
                     type: 'numberEqualGreater'

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -19,8 +19,8 @@ import {
     IQService,
     IWindowService
 } from 'angular'
-import {Model, ModelOptions, ModelSyncOptions} from '@stratusjs/angularjs/services/model' // Needed as Class
-import {Collection, CollectionSyncOptions} from '@stratusjs/angularjs/services/collection' // Needed as Class
+import {Model, ModelOptions, ModelSyncOptions} from '@stratusjs/angularjs/services/model'
+import {Collection, CollectionSyncOptions} from '@stratusjs/angularjs/services/collection'
 import {
     isJSON,
     LooseFunction,
@@ -34,10 +34,6 @@ import {IdxPropertySearchScope} from '@stratusjs/idx/property/search.component'
 import {IdxMemberListScope} from '@stratusjs/idx/member/list.component'
 
 // Stratus Preload
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/angularjs/services/model' // Needed as $provider
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/angularjs/services/collection' // Needed as $provider
 import '@stratusjs/idx/listTrac'
 
 export interface IdxService {

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -607,13 +607,7 @@ interface SearchObject {
         'numberEqualLess' | // Input is a string/number, needs to equal or less than another number field
         'andOr', // Input is a string/number, needs to evaluate on any of the supplied statements contained
     apiField?: string, // Used if the widgetField name is different from the field in database
-    andOr?: Array<{
-        apiField: string,
-        type: 'valueEquals'
-            | 'stringLike'
-            | 'stringLikeArray'
-            | 'stringIncludesArray'
-    }>
+    andOr?: Omit<SearchObject, 'andOr'>[]
 }
 
 export type IdxEmitter = (source: IdxComponentScope, var1?: any, var2?: any, var3?: any) => any
@@ -1062,7 +1056,7 @@ const angularJsService = (
 
     /**
      * Return a Disclaimer scope
-     * @param disclaimerUid? - uid of Disclaimer
+     * @param disclaimerUid - uid of Disclaimer
      */
     function getDisclaimerInstance(disclaimerUid?: string): {[uid: string]: IdxDisclaimerScope} | null {
         return disclaimerUid ? (

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -623,7 +623,7 @@ export type IdxEmitterSearched = IdxEmitter & ((source: IdxComponentScope, query
 
 // All Service functionality
 const angularJsService = (
-    $injector: auto.IInjectorService,
+    // $injector: auto.IInjectorService,
     $http: IHttpService,
     $location: ILocationService,
     $mdToast: material.IToastService,
@@ -2565,7 +2565,7 @@ const angularJsService = (
         const apiModelSingular = getSingularApiModelName(apiModel)
 
         // Prepare the same Collection for each List
-        const collection: Collection<T> = await createOrSyncCollectionVariable<T>(uid, moduleName, collectionVarName)
+        const collection: Collection<T> = createOrSyncCollectionVariable<T>(uid, moduleName, collectionVarName)
 
         // Set API paths to fetch listing data for each MLS Service
         const filterQuery = compileFilterFunction(options)

--- a/packages/idx/src/map/map.component.ts
+++ b/packages/idx/src/map/map.component.ts
@@ -14,9 +14,7 @@ import {MapComponent, MarkerSettings} from '@stratusjs/map/map.component'
 import {numeralFormat} from '@stratusjs/angularjs-extras/filters/numeral'
 
 // Stratus Preload
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-import '@stratusjs/map/map' // We need sa-map
+import '@stratusjs/angular' // sa-map
 
 // Environment
 const min = !cookie('env') ? '.min' : ''

--- a/packages/idx/src/member/details.component.ts
+++ b/packages/idx/src/member/details.component.ts
@@ -17,10 +17,7 @@ import {isJSON, LooseObject, safeUniqueId} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
 // Stratus Preload
-import '@stratusjs/angularjs-extras/filters/math'
-import '@stratusjs/angularjs-extras/filters/moment'
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
+import '@stratusjs/angularjs-extras' // filters/math + filters/moment
 
 // Environment
 const min = !cookie('env') ? '.min' : ''

--- a/packages/idx/src/member/list.component.ts
+++ b/packages/idx/src/member/list.component.ts
@@ -26,12 +26,6 @@ import {Collection} from '@stratusjs/angularjs/services/collection' // Needed as
 import {isJSON, LooseObject, safeUniqueId} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
-// Stratus Preload
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-import '@stratusjs/idx/disclaimer/disclaimer.component'
-import '@stratusjs/idx/member/details.component'
-
 // Environment
 const min = !cookie('env') ? '.min' : ''
 const packageName = 'idx'

--- a/packages/idx/src/office/list.component.ts
+++ b/packages/idx/src/office/list.component.ts
@@ -31,11 +31,6 @@ import {Collection} from '@stratusjs/angularjs/services/collection'
 import {isJSON, LooseObject, safeUniqueId} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
-// Stratus Preload
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-import '@stratusjs/idx/disclaimer/disclaimer.component'
-
 // Environment
 const min = !cookie('env') ? '.min' : ''
 const packageName = 'idx'

--- a/packages/idx/src/office/search.component.ts
+++ b/packages/idx/src/office/search.component.ts
@@ -29,13 +29,6 @@ import {isJSON, safeUniqueId} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 import {IdxOfficeListScope} from '@stratusjs/idx/office/list.component'
 
-// Stratus Preload
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/office/list.component'
-import '@stratusjs/idx/disclaimer/disclaimer.component'
-
 // Environment
 const min = !cookie('env') ? '.min' : ''
 const packageName = 'idx'

--- a/packages/idx/src/property/admin/search.filter.component.html
+++ b/packages/idx/src/property/admin/search.filter.component.html
@@ -47,11 +47,26 @@
                                 data-delete-hint="Press delete to remove City"
                         ></md-chips>
                     </div>
+                    <div class="search-input deprecated" data-flex="50"
+                         data-ng-if="options.query.where.CountyOrParish && options.query.where.CountyOrParish.length">
+                        <md-chips
+                                class="county font-secondary"
+                                aria-label="Counties to Limit (deprecated)"
+                                data-ng-model="options.query.where.CountyOrParish"
+                                data-md-enable-chip-edit="true"
+                                data-md-add-on-blur="true"
+                                data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                data-placeholder="County (deprecated)"
+                                data-secondary-placeholder="+County (deprecated)"
+                                data-delete-button-label="Remove County (deprecated)"
+                                data-delete-hint="Press delete to remove County (deprecated)"
+                        ></md-chips>
+                    </div>
                     <div class="search-input" data-flex="50">
                         <md-chips
                                 class="county font-secondary"
                                 aria-label="Counties to Limit"
-                                data-ng-model="options.query.where.CountyOrParish"
+                                data-ng-model="options.query.where.eCountyOrParish"
                                 data-md-enable-chip-edit="true"
                                 data-md-add-on-blur="true"
                                 data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
@@ -64,7 +79,7 @@
                 </div>
                 <div data-layout="row">
                     <div
-                            class="search-input" data-flex="50"
+                            class="search-input deprecated" data-flex="50"
                             data-ng-if="options.query.where.MLSAreaMajor && options.query.where.MLSAreaMajor.length"
                     >
                         <md-chips
@@ -80,11 +95,26 @@
                                 data-delete-hint="Press delete to remove Area (deprecated)"
                         ></md-chips>
                     </div>
-                    <div class="search-input" data-flex="50">
+                    <div class="search-input deprecated" data-flex="50"
+                         data-ng-if="options.query.where.Neighborhood && options.query.where.Neighborhood.length">
                         <md-chips
                                 class="neighborhood font-secondary"
                                 aria-label="Neighborhoods to Limit"
                                 data-ng-model="options.query.where.Neighborhood"
+                                data-md-enable-chip-edit="true"
+                                data-md-add-on-blur="true"
+                                data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                data-placeholder="Neighborhood (deprecated)"
+                                data-secondary-placeholder="+Neighborhood (deprecated)"
+                                data-delete-button-label="Remove Neighborhood (deprecated)"
+                                data-delete-hint="Press delete to remove Neighborhood (deprecated)"
+                        ></md-chips>
+                    </div>
+                    <div class="search-input" data-flex="50">
+                        <md-chips
+                                class="neighborhood font-secondary"
+                                aria-label="Neighborhoods to Limit"
+                                data-ng-model="options.query.where.eNeighborhood"
                                 data-md-enable-chip-edit="true"
                                 data-md-add-on-blur="true"
                                 data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"

--- a/packages/idx/src/property/details.component.less
+++ b/packages/idx/src/property/details.component.less
@@ -376,7 +376,7 @@ stratus-idx-property-details .property-details-default {
           width: 30px;
           height: 28px;
           opacity: 0.5;
-          background: url('images/btn-download.png') no-repeat center top; // FIXME path
+          background: url('../src/property/images/btn-download.png') no-repeat center top;
           background-size: 30px;
           &:hover {
             transform: scale(1.1);

--- a/packages/idx/src/property/list.carousel.component.less
+++ b/packages/idx/src/property/list.carousel.component.less
@@ -57,7 +57,7 @@ stratus-idx-property-list .property-list-carousel {
     padding: 200px 40px 0;
     font-size: 24px;
     text-align: center;
-    background: url('images/no-results.png') no-repeat center 80px;
+    background: url('../src/property/images/no-results.png') no-repeat center 80px;
     background-size: 80px;
   }
 

--- a/packages/idx/src/property/list.carousel.component.less
+++ b/packages/idx/src/property/list.carousel.component.less
@@ -1,9 +1,10 @@
 /*
-Nothing should be outside 'stratus-idx-property-list' or it will leak into other modules
-Additionally 'stratus-idx-property-list .property-list-carousel' ensures still CSS only affects the carousel template and not others
-z-index can cause a bleeding effect on popups (z-index 100 equates to the top most item for angular, use the lowest number possible and work up)
-TODO Need to size this based on column and window
-FIXME we CANNOT rely of media queries, it needs to know the sizing of the element or else widgets may never get properly sized. (if used as modular widgets)
+- Nothing should be outside 'stratus-idx-property-list' or it will leak into other modules
+- Additionally 'stratus-idx-property-list .property-list-carousel' ensures still CSS only affects the carousel template and not others
+- z-index can cause a bleeding effect on popups (z-index 100 equates to the top most item for angular, use the lowest number possible and work up)
+- TODO Need to size this based on column and window
+- FIXME we CANNOT rely of media queries, it needs to know the sizing of the element or else widgets may never get properly sized. (if used as modular widgets)
+- Path to local image directory is "../src/property/images/"
 */
 @tablet: ~"(max-width: 959px)";
 @phone: ~"(max-width: 600px)";

--- a/packages/idx/src/property/list.component.less
+++ b/packages/idx/src/property/list.component.less
@@ -13,7 +13,7 @@ stratus-idx-property-list .property-list-default {
     padding: 200px 40px 0;
     font-size: 24px;
     text-align: center;
-    background: url('images/no-results.png') no-repeat center 80px;
+    background: url('../src/property/images/no-results.png') no-repeat center 80px;
     background-size: 80px;
   }
 

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -31,12 +31,7 @@ import {isJSON, safeUniqueId} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
 // Stratus Preload
-import '@stratusjs/angularjs-extras/directives/src'
-import '@stratusjs/idx/disclaimer/disclaimer.component'
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-import '@stratusjs/idx/map/map.component'
-import '@stratusjs/idx/property/details.component'
+import '@stratusjs/angularjs-extras' // directives/src
 
 // Environment
 const min = !cookie('env') ? '.min' : ''

--- a/packages/idx/src/property/list.component.ts
+++ b/packages/idx/src/property/list.component.ts
@@ -570,12 +570,17 @@ Stratus.Components.IdxPropertyList = {
                 // Check and remove incompatible where combinations. Basically if Location or neighborhood are used, remove the others
                 if (!isEmpty(query.where.Location)) {
                     query.where.City = []
+                    query.where.eCity = []
                     query.where.UnparsedAddress = ''
                     query.where.Neighborhood = []
+                    query.where.eNeighborhood = []
                     query.where.CityRegion = []
+                    query.where.eCityRegion = []
                     query.where.PostalCode = []
                     query.where.MLSAreaMajor = []
+                    query.where.eMLSAreaMajor = []
                     query.where.SubdivisionName = []
+                    query.where.eSubdivisionName = []
                 }
 
                 // Page checks

--- a/packages/idx/src/property/search.classic.component.html
+++ b/packages/idx/src/property/search.classic.component.html
@@ -107,7 +107,7 @@
                         </md-checkbox>
                     </div>
 
-                    <div data-ng-show="options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.OfficeNumber.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length">
+                    <div data-ng-show="options.query.where.eNeighborhood.length || options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.officeGroups.length || options.query.where.eCity.length || options.query.where.City.length || options.query.where.eCountyOrParish.length || options.query.where.CountyOrParish.length || options.query.where.eMLSAreaMajor.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length">
                         <!-- 'Openhouses Only' is only allowed when more filters are supplied due to speed restrictions -->
                         <md-checkbox
                                 class="show-open-houses"
@@ -170,10 +170,24 @@
                     </div>
 
                     <!-- Only Include if these were preset in a Property Filter pages and we need the ability to remove them -->
-                    <div data-ng-if="options.query.where.City.length || options.query.where.MLSAreaMajor.length || options.PostalCode.length">
+                    <div data-ng-if="options.query.where.eCity.length || options.query.where.City.length || options.query.where.eMLSAreaMajor.length || options.query.where.MLSAreaMajor.length || options.PostalCode.length">
                         <div class="sale-status-border dotted-spaced-underline"></div>
                         <h3 data-layout-align="space-around center">Preset Filters</h3>
                         <div class="specific-filters" data-layout="row" data-layout-align="space-around center" aria-label="Specific Areas">
+                            <div class="search-input" data-ng-if="options.query.where.eCity.length">
+                                <md-chips
+                                        class="city-id font-secondary"
+                                        aria-label="Cities to Limit"
+                                        data-ng-model="options.query.where.eCity"
+                                        data-md-enable-chip-edit="true"
+                                        data-md-add-on-blur="true"
+                                        data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                        data-placeholder="City"
+                                        data-secondary-placeholder="+City"
+                                        data-delete-button-label="Remove City"
+                                        data-delete-hint="Press delete to remove City"
+                                ></md-chips>
+                            </div>
                             <div class="search-input" data-ng-if="options.query.where.City.length">
                                 <md-chips
                                         class="city-id font-secondary"
@@ -188,18 +202,32 @@
                                         data-delete-hint="Press delete to remove City"
                                 ></md-chips>
                             </div>
+                            <div class="search-input" data-ng-if="options.query.where.eMLSAreaMajor.length">
+                                <md-chips
+                                        class="area-id font-secondary"
+                                        aria-label="Areas to Limit"
+                                        data-ng-model="options.query.where.eMLSAreaMajor"
+                                        data-md-enable-chip-edit="true"
+                                        data-md-add-on-blur="true"
+                                        data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                        data-placeholder="Area"
+                                        data-secondary-placeholder="+Area"
+                                        data-delete-button-label="Remove Area"
+                                        data-delete-hint="Press delete to remove Area"
+                                ></md-chips>
+                            </div>
                             <div class="search-input" data-ng-if="options.query.where.MLSAreaMajor.length">
                                 <md-chips
                                         class="area-id font-secondary"
-                                        aria-label="Neighborhoods to Limit"
+                                        aria-label="Areas to Limit"
                                         data-ng-model="options.query.where.MLSAreaMajor"
                                         data-md-enable-chip-edit="true"
                                         data-md-add-on-blur="true"
                                         data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
-                                        data-placeholder="Neighborhood"
-                                        data-secondary-placeholder="+Neighborhood"
-                                        data-delete-button-label="Remove Neighborhood"
-                                        data-delete-hint="Press delete to remove Neighborhood"
+                                        data-placeholder="Area"
+                                        data-secondary-placeholder="+Area"
+                                        data-delete-button-label="Remove Area"
+                                        data-delete-hint="Press delete to remove Area"
                                 ></md-chips>
                             </div>
                             <div class="search-input" data-ng-if="options.query.where.PostalCode.length">

--- a/packages/idx/src/property/search.compact.component.html
+++ b/packages/idx/src/property/search.compact.component.html
@@ -154,7 +154,7 @@
                     </div>
 
                     <md-checkbox
-                            data-ng-show="options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.OfficeNumber.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length"
+                            data-ng-show="options.query.where.eNeighborhood.length || options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.officeGroups.length || options.query.where.eCity.length || options.query.where.City.length || options.query.where.eCountyOrParish.length || options.query.where.CountyOrParish.length || options.query.where.eMLSAreaMajor.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length"
                             class="show-open-houses font-secondary"
                             data-ng-model="options.query.where.OpenHouseOnly"
                             aria-label="Open Houses Only"
@@ -214,10 +214,24 @@
                     </div>
 
                     <!-- Only Include if these were preset in a Property Filter pages and we need the ability to remove them -->
-                    <div data-ng-if="options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length">
+                    <div data-ng-if="options.query.where.eCity.length || options.query.where.City.length || options.query.where.eCountyOrParish.length || options.query.where.CountyOrParish.length || options.query.where.eMLSAreaMajor.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length">
                         <div class="sale-status-border dotted-spaced-underline"></div>
                         <h3 data-layout-align="space-around center">Preset Filters</h3>
                         <div class="specific-filters" data-layout="row" data-layout-align="space-around center" aria-label="Specific Areas">
+                            <div class="search-input" data-ng-if="options.query.where.eCity.length">
+                                <md-chips
+                                        class="city-id font-secondary"
+                                        aria-label="Cities to Limit"
+                                        data-ng-model="options.query.where.eCity"
+                                        data-md-enable-chip-edit="true"
+                                        data-md-add-on-blur="true"
+                                        data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                        data-placeholder="City"
+                                        data-secondary-placeholder="+City"
+                                        data-delete-button-label="Remove City"
+                                        data-delete-hint="Press delete to remove City"
+                                ></md-chips>
+                            </div>
                             <div class="search-input" data-ng-if="options.query.where.City.length">
                                 <md-chips
                                         class="city-id font-secondary"
@@ -230,6 +244,20 @@
                                         data-secondary-placeholder="+City"
                                         data-delete-button-label="Remove City"
                                         data-delete-hint="Press delete to remove City"
+                                ></md-chips>
+                            </div>
+                            <div class="search-input" data-ng-if="options.query.where.eCountyOrParish.length">
+                                <md-chips
+                                        class="area-id font-secondary"
+                                        aria-label="Counties to Limit"
+                                        data-ng-model="options.query.where.eCountyOrParish"
+                                        data-md-enable-chip-edit="true"
+                                        data-md-add-on-blur="true"
+                                        data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                        data-placeholder="County"
+                                        data-secondary-placeholder="+County"
+                                        data-delete-button-label="Remove County"
+                                        data-delete-hint="Press delete to remove County"
                                 ></md-chips>
                             </div>
                             <div class="search-input" data-ng-if="options.query.where.CountyOrParish.length">
@@ -246,6 +274,20 @@
                                         data-delete-hint="Press delete to remove County"
                                 ></md-chips>
                             </div>
+                            <div class="search-input" data-ng-if="options.query.where.eMLSAreaMajor.length">
+                                <md-chips
+                                        class="area-id font-secondary"
+                                        aria-label="Areas to Limit"
+                                        data-ng-model="options.query.where.eMLSAreaMajor"
+                                        data-md-enable-chip-edit="true"
+                                        data-md-add-on-blur="true"
+                                        data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                        data-placeholder="Area Major"
+                                        data-secondary-placeholder="+Area"
+                                        data-delete-button-label="Remove Area"
+                                        data-delete-hint="Press delete to remove Area"
+                                ></md-chips>
+                            </div>
                             <div class="search-input" data-ng-if="options.query.where.MLSAreaMajor.length">
                                 <md-chips
                                         class="area-id font-secondary"
@@ -258,6 +300,20 @@
                                         data-secondary-placeholder="+Area"
                                         data-delete-button-label="Remove Area"
                                         data-delete-hint="Press delete to remove Area"
+                                ></md-chips>
+                            </div>
+                            <div class="search-input" data-ng-if="options.query.where.eNeighborhood.length">
+                                <md-chips
+                                        class="area-id font-secondary"
+                                        aria-label="Neighborhoods to Limit"
+                                        data-ng-model="options.query.where.eNeighborhood"
+                                        data-md-enable-chip-edit="true"
+                                        data-md-add-on-blur="true"
+                                        data-md-separator-keys="[$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA]"
+                                        data-placeholder="Neighborhood"
+                                        data-secondary-placeholder="+Neighborhood"
+                                        data-delete-button-label="Remove Neighborhood"
+                                        data-delete-hint="Press delete to remove Neighborhood"
                                 ></md-chips>
                             </div>
                             <div class="search-input" data-ng-if="options.query.where.Neighborhood.length">

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -14,7 +14,7 @@
 
     <div class="search-row search-basic clearfix">
         <div class="search-input search-location"
-             data-ng-class="{'location-input-active': !(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)}">
+             data-ng-class="{'location-input-active': !isPresetLocationSet()}">
 
             <!-- If there are preset filters like City, MLS Area, Postal Code, which are subsets of Location, then we
             will show that we are filtering by those, and we will not show the Location field. They remain in the filter
@@ -24,24 +24,23 @@
             <!-- NOTE: some of these fields are arrays -->
             <md-icon class="search-icon"
                      data-ng-click="search()"
-                     data-ng-if="!(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)"
+                     data-ng-if="!isPresetLocationSet()"
                      md-svg-src="{{ localDir + 'images/icons/actionButtons/search.svg' }}"
             ></md-icon>
+            <!-- NOTE: the data-ng-keyup should not be setting: && options.query.where.Location (seems useless???) -->
+            <!-- NOTE: data-ng-keyup will run $event.keyCode == 13 && search(). If $event.keyCode is not Enter, search() cannot be reached -->
             <md-input-container
                     class="location-input md-block minimal"
-                    data-ng-if="!(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)">
+                    data-ng-if="!isPresetLocationSet()">
                 <label>City, Neighborhood, Zip</label>
-
-                <!-- NOTE: the data-ng-keyup should not be setting: && options.query.where.Location (seems useless???) -->
-                <!-- NOTE: data-ng-keyup will run $event.keyCode == 13 && search(). If $event.keyCode is not Enter, search() cannot be reached -->
                 <input
-                       data-ng-model="options.query.where.Location"
-                       data-ng-blur="search()"
-                       type="text"
-                       size="22"
-                       maxlength="250"
-                       data-ng-keyup="$event.keyCode == 13 && search()"
-                       autocomplete="off"
+                        data-ng-model="options.query.where.Location"
+                        data-ng-blur="search()"
+                        type="text"
+                        size="22"
+                        maxlength="250"
+                        data-ng-keyup="$event.keyCode == 13 && search()"
+                        autocomplete="off"
                 >
             </md-input-container>
 
@@ -50,26 +49,17 @@
 
             <!-- TODO: make this gray in the CSS -->
             <div class="preset-location"
-                 data-ng-if="(options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)">
-                <span data-ng-if="options.query.where.City.length > 0" data-ng-bind="options.query.where.City.join(', ')"></span>
-                <!-- NOTE: these are actually arrays so we union them then join split with a comma -->
-                <span
-                        data-ng-if="options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode > 0"
-                        data-ng-bind="((options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length) ? ', ' : '') + _.join(_.union(options.query.where.CountyOrParish, options.query.where.MLSAreaMajor, options.query.where.Neighborhood, options.query.where.PostalCode), ', ')"
-                ></span>
-                <span
-                        class="other-preset-filters"
-                        data-ng-if="options.officeGroups.length > 0 || options.query.where.AgentLicense.length > 0 || options.query.where.ListingId.length > 0"
-                        data-ng-bind="'+'+Idx.countArraysNotEmpty([options.officeGroups, options.query.where.AgentLicense, options.query.where.ListingId])+' Filter'+(Idx.countArraysNotEmpty([options.officeGroups, options.query.where.AgentLicense, options.query.where.ListingId]) > 1 ? '(s)' : '')"
-                ></span>
+                 data-ng-if="isPresetLocationSet()">
+                <span data-ng-bind="presetLocationText"></span>
+                <span class="other-preset-filters" data-ng-show="presetOtherFiltersText" data-ng-bind="presetOtherFiltersText"></span>
             </div>
             <!-- TODO: We cannot currently get focus to work because we can't find the element: data-ng-click="angular.element('#filterLocation').focus()". In the future it would be nice to populate. FIX: Element doesn't not exist on load, should possibly be given as a widget option when Element is ready with relying on id. -->
             <!-- NOTE: We shouldn't supply ids unless they are given a unique number at the end as HTML does not allow duplicate ids -->
             <!-- NOTE: three of these get cleared as arrays -->
             <a
                     class="custom-clear"
-                    data-ng-if="(options.query.where.Location.length || options.query.where.City.length > 0 || options.query.where.CountyOrParish.length > 0 || options.query.where.MLSAreaMajor.length > 0 || options.query.where.Neighborhood.length > 0 || options.query.where.PostalCode.length > 0)"
-                    data-ng-click="options.query.where.Location = ''; options.query.where.City = []; options.query.where.CountyOrParish = []; options.query.where.MLSAreaMajor = []; options.query.where.Neighborhood = []; options.query.where.PostalCode = []; search()"
+                    data-ng-if="(options.query.where.Location.length || isPresetLocationSet())"
+                    data-ng-click="resetLocationQuery(); search()"
             >
                 <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/clear.svg' }}"></md-icon>
             </a>

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -321,7 +321,7 @@
 
             <div
                     class="extras"
-                    data-ng-show="options.query.where.OpenHouseOnly || options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.query.where.OfficeNumber.length || options.query.where.OfficeName.length || options.query.where.City.length || options.query.where.CountyOrParish.length || options.query.where.MLSAreaMajor.length || options.query.where.Neighborhood.length || options.query.where.PostalCode.length"
+                    data-ng-show="options.query.where.OpenHouseOnly || options.query.where.eNeighborhood.length || options.query.where.Neighborhood.length || options.query.where.Location.length || options.query.where.AgentLicense.length || options.officeGroups.length || options.query.where.eCity.length || options.query.where.City.length || options.query.where.eCountyOrParish.length || options.query.where.CountyOrParish.length || options.query.where.eMLSAreaMajor.length || options.query.where.MLSAreaMajor.length || options.query.where.PostalCode.length"
             >
                 <h4>Extras</h4>
                 <!-- 'Openhouses Only' is only allowed when more filters are supplied due to speed restrictions -->

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -43,13 +43,7 @@ import {isJSON, LooseObject, safeUniqueId} from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
 // Stratus Preload
-import '@stratusjs/angularjs-extras/directives/stringToNumber'
-import '@stratusjs/angularjs-extras/filters/numeral'
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/idx'
-import '@stratusjs/idx/office/list.component' // Office needs to load for the office selector
-// tslint:disable-next-line:no-duplicate-imports
-import '@stratusjs/idx/office/search.component' // Office needs to load for the office selector
+import '@stratusjs/angularjs-extras' // directives/stringToNumber + filters/numeral
 
 type NameValuePair = {
     name: string

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -248,8 +248,6 @@ Stratus.Components.IdxPropertySearch = {
             Idx.setTokenURL($attrs.tokenUrl)
         }
 
-        Stratus.Internals.CssLoader(`${localDir}${$attrs.template || componentName}.component${min}.css`).then()
-
         // Default values
         let defaultQuery: LooseObject
         let lastQuery: CompileFilterOptions

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -57,6 +57,7 @@ const moduleName = 'property'
 const componentName = 'search'
 // There is not a very consistent way of pathing in Stratus at the moment
 const localDir = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/src/${moduleName}/`
+const localDistStyle = `${Stratus.BaseUrl}${Stratus.DeploymentPath}@stratusjs/${packageName}/dist/${packageName}.bundle.min.css`
 
 type ListingTypeSelectionSetting = {
     name: string
@@ -247,6 +248,8 @@ Stratus.Components.IdxPropertySearch = {
         if ($attrs.tokenUrl) {
             Idx.setTokenURL($attrs.tokenUrl)
         }
+
+        Stratus.Internals.CssLoader(localDistStyle).then()
 
         // Default values
         let defaultQuery: LooseObject

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -23,7 +23,8 @@ import _, {
     isString,
     isUndefined,
     map,
-    throttle
+    throttle,
+    union
 } from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {element, material, IAttributes, ITimeoutService, IQService, IWindowService} from 'angular'
@@ -74,7 +75,7 @@ export type IdxPropertySearchScope = IdxSearchScope & {
     listLinkUrl: string
     // Can be 'simple' (location only), 'basic' (beds/baths, price, etc), 'advanced' (dropdown filters)
     searchType: 'simple' | 'basic' | 'advanced'
-    // Href to a url
+    // Href to an url
     advancedSearchUrl: string
     advancedSearchLinkName: string
     advancedFiltersStatus: boolean
@@ -113,6 +114,8 @@ export type IdxPropertySearchScope = IdxSearchScope & {
         agentGroups: SelectionGroup[]
         officeGroups: SelectionGroup[]
     }
+    presetLocationText: string // Will be formed based on the original query where
+    presetOtherFiltersText?: string // Will be formed based on the original query Agent, Office Group, and Listing ID
     displayFilterFullHeight: boolean
     variableSyncing: object | any
     filterMenu?: material.IPanelRef & any // material.IPanelRef // disabled because we need to set reposition()
@@ -122,10 +125,13 @@ export type IdxPropertySearchScope = IdxSearchScope & {
     canDisplayListingTypeButton(listType: ListingTypeSelectionSetting): boolean
     displayOfficeGroupSelector(searchTerm?: string, editIndex?: number, ev?: any): void
     getMLSVariables(reset?: boolean): MLSService[]
+    getPresetLocations(): string[]
     hasQueryChanged(): boolean
-    /** @deprecated use _.includes */
     inArray(item: any, array: any[]): boolean
     isIntersecting(itemArray: any[], array: any[]): boolean
+    isPresetLocationSet(): boolean
+    resetLocationQuery(): void
+    parsePresetLocationText(): void
     selectDefaultListingType(listingGroup?: string): void
     setQuery(newQuery?: CompileFilterOptions): void
     setWhere(newWhere?: WhereOptions): void
@@ -150,7 +156,7 @@ Stratus.Components.IdxPropertySearch = {
         initNow: '=',
         /**
          * Type: string
-         * To determine what datasources the Idx widgets are able to pull from and their temporary credentials, a
+         * To determine what datasource the Idx widgets are able to pull from and their temporary credentials, a
          * `token-url` directs to the location that manages this widget's subscription and provides what Idx servers it
          * has access to.
          */
@@ -159,7 +165,7 @@ Stratus.Components.IdxPropertySearch = {
         tokenOnLoad: '@',
         /**
          * Type: string
-         * Id of Property List widget to attach and control. The counterpart Property List widget's `element-id` must be
+         * ID of Property List widget to attach and control. The counterpart Property List widget's `element-id` must be
          * defined and the same as this `list-id` (See Property List). Multiple Search widgets may attach to the same
          * List widget but, a Search widget may only control a single List widget.
          */
@@ -167,7 +173,7 @@ Stratus.Components.IdxPropertySearch = {
         /**
          * Type: string
          * Default: '/property/list'
-         * If a List widget does not share the same page as this Search widget or they are not connected via
+         * If a List widget does not share the same page as this Search widget, or they are not connected via
          * `list-id`/`element-id`, searching will instead load a new page to where ever the List widget may be found
          * (Url provided here).
          */
@@ -259,12 +265,13 @@ Stratus.Components.IdxPropertySearch = {
         $scope.advancedFiltersStatus = false
         $scope.advancedSearchUrl = ''
         $scope.advancedSearchLinkName = 'Advanced Search'
+        $scope.presetLocationText = ''
         // Used by template
         $scope.$mdConstant = $mdConstant
 
         /**
          * All actions that happen first when the component loads
-         * Needs to be placed in a function, as the functions below need to the initialized first
+         * Need to be placed in a function, as the functions below need to the initialized first
          */
         const init = async () => {
             $scope.widgetName = $attrs.widgetName || ''
@@ -415,7 +422,7 @@ Stratus.Components.IdxPropertySearch = {
             $scope.$applyAsync(() => {
                 $scope.initialized = true
             })
-            // await $scope.variableSync() sync is moved to teh timeout above so it can still work with List widgets
+            // await $scope.variableSync() sync is moved to teh timeout above, so it can still work with List widgets
             Idx.emit('init', $scope)
         }
 
@@ -465,6 +472,59 @@ Stratus.Components.IdxPropertySearch = {
                 // console.log('watched ListingType', $scope.options.query.ListingType, $scope.options.selection.ListingType.group)
             }
         })
+
+        $scope.resetLocationQuery = (): void => {
+            $scope.options.query.where.Location = ''
+            $scope.options.query.where.City = []
+            $scope.options.query.where.eCity = []
+            $scope.options.query.where.CountyOrParish = []
+            $scope.options.query.where.eCountyOrParish = []
+            $scope.options.query.where.MLSAreaMajor = []
+            $scope.options.query.where.eMLSAreaMajor = []
+            $scope.options.query.where.Neighborhood = []
+            $scope.options.query.where.eNeighborhood = []
+            $scope.options.query.where.PostalCode = []
+
+            $scope.parsePresetLocationText()
+        }
+
+        $scope.getPresetLocations = (): string[] => {
+            const currentWhere = $scope.options.query.where
+            return union(
+                currentWhere.City,
+                currentWhere.eCity,
+                currentWhere.CountyOrParish,
+                currentWhere.eCountyOrParish,
+                currentWhere.MLSAreaMajor,
+                currentWhere.eMLSAreaMajor,
+                currentWhere.Neighborhood,
+                currentWhere.eNeighborhood,
+                currentWhere.PostalCode,
+            )
+        }
+
+        $scope.isPresetLocationSet = (): boolean => {
+            return $scope.getPresetLocations().length > 0
+        }
+
+        $scope.parsePresetLocationText = (): void => {
+            $scope.presetLocationText = $scope.getPresetLocations().join(', ')
+            $scope.presetOtherFiltersText = null
+            if (
+                $scope.options.officeGroups.length > 0 ||
+                $scope.options.query.where.AgentLicense.length > 0 ||
+                $scope.options.query.where.ListingId.length > 0
+            ) {
+                const filterCounts = Idx.countArraysNotEmpty([
+                    $scope.options.officeGroups,
+                    $scope.options.query.where.AgentLicense as string[],
+                    $scope.options.query.where.ListingId as string[]
+                ])
+                if (filterCounts > 0) {
+                    $scope.presetOtherFiltersText = `+${filterCounts} Filter${filterCounts > 1 ? 's' : ''}`
+                }
+            }
+        }
 
         /**
          * Sync Gutensite form variables to a Stratus scope
@@ -524,7 +584,6 @@ Stratus.Components.IdxPropertySearch = {
             return $scope.options.forRent === listType.lease && $scope.options.selection.ListingType.group[listType.group]
         }
 
-        /** @deprecated use _.includes */
         $scope.inArray = (item: any, array: any[]) => includes(array, item)
 
         $scope.isIntersecting = (itemArray: any[], array: any[]): boolean => {
@@ -639,6 +698,7 @@ Stratus.Components.IdxPropertySearch = {
                     $scope.options.query.where[key] = [$scope.options.query.where[key]]
                 }
             })
+            $scope.parsePresetLocationText()
             // console.log('setWhere', clone($scope.options.query.where))
         }
 
@@ -651,6 +711,7 @@ Stratus.Components.IdxPropertySearch = {
                 }
                 // console.log('setting lastQuery setWhereDefaults', cloneDeep($scope.options.query))
                 lastQuery = cloneDeep($scope.options.query)
+                $scope.parsePresetLocationText()
             })
         }
 
@@ -690,8 +751,8 @@ Stratus.Components.IdxPropertySearch = {
             }
             if (listScope) {
                 // $scope.options.query.service = [1]
-                // $scope.options.query.where.Page = 1 // just a fall back, as it gets 'Page 2'
-                // $scope.options.query.page = 1 // just a fall back, as it gets 'Page 2'
+                // $scope.options.query.where.Page = 1 // just a fallback, as it gets 'Page 2'
+                // $scope.options.query.page = 1 // just a fallback, as it gets 'Page 2'
                 // console.log('sending search', clone($scope.options.query))
 
                 /* const searchQuery: CompileFilterOptions = {
@@ -753,7 +814,7 @@ Stratus.Components.IdxPropertySearch = {
                 ` data-list-id="office-group-selector-${$scope.elementId}"` +
                 ` data-options='${JSON.stringify(options)}'` +
                 ` data-sync-instance="${$scope.elementId}"` + // search needs to update this scope
-                ` data-sync-instance-variable="options.officeGroups"` + // search needs find this variable in this scope to update
+                ` data-sync-instance-variable="options.officeGroups"` + // search needs to find this variable in this scope to update
                 ` data-sync-instance-variable-index="${editIndex}"` +
                 '></stratus-idx-office-search>' +
                 '<stratus-idx-office-list' +
@@ -796,7 +857,7 @@ Stratus.Components.IdxPropertySearch = {
                     $scope.validateOfficeGroups()
                     // IDX.setUrlOptions('Listing', {})
                     // IDX.refreshUrlOptions(defaultOptions)
-                    // Revery page title back to what it was
+                    // Revert page title back to what it was
                     // IDX.setPageTitle()
                     // Let's destroy it to save memory
                     // $timeout(IDX.unregisterDetailsInstance('property_member_detail_popup'), 10)

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -32,6 +32,6 @@
     "@stratusjs/angularjs-extras": "^0.12.10",
     "@stratusjs/boot": "^1.0.0",
     "@stratusjs/runtime": "^0.12.1",
-    "swiper": "^9.1.1"
+    "swiper": "^10.3.0"
   }
 }

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/swiper",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "AngularJS Swiper Carousel component to be used as an add on to StratusJS",
   "main": "",
   "scripts": {
@@ -28,7 +28,7 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.6.3",
+    "@stratusjs/angularjs": "^0.6.4",
     "@stratusjs/angularjs-extras": "^0.13.0",
     "@stratusjs/boot": "^1.1.0",
     "@stratusjs/runtime": "^0.12.1",

--- a/packages/swiper/package.json
+++ b/packages/swiper/package.json
@@ -28,9 +28,9 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.6.2",
-    "@stratusjs/angularjs-extras": "^0.12.10",
-    "@stratusjs/boot": "^1.0.0",
+    "@stratusjs/angularjs": "^0.6.3",
+    "@stratusjs/angularjs-extras": "^0.13.0",
+    "@stratusjs/boot": "^1.1.0",
     "@stratusjs/runtime": "^0.12.1",
     "swiper": "^10.3.0"
   }

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -7,13 +7,14 @@
 import {clone, findKey, get, has, isArray, isBoolean, isNull, isUndefined} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {IAttributes, IAugmentedJQuery, IController, IScope, ITimeoutService, IWindowService} from 'angular'
+import {Swiper} from 'swiper'
 import {
-    Swiper, SwiperOptions,
     // Modules
     A11y, Autoplay, Navigation, Pagination, Scrollbar, Zoom, // + Thumbs
     // Effects
     EffectCoverflow, EffectCube, EffectFade, EffectFlip // EffectCards, EffectCreative
-} from 'swiper'
+} from 'swiper/modules'
+import {SwiperOptions} from 'swiper/types/swiper-options'
 import {PaginationOptions} from 'swiper/types/modules/pagination'
 import {AutoplayOptions} from 'swiper/types/modules/autoplay'
 // Stratus Dependencies

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -651,7 +651,13 @@ Stratus.Components.SwiperCarousel = {
 
                 // FIXME there is a delay on the navigation buytton when the transition has completely finished
                 // FIXME possibly set a bypass and force next/prev slide anyways by testing this event
-                // $scope.swiper.on('navigationNext', () => {})
+                /*$scope.swiper.on('navigationNext', () => {
+                    // check if($scope.swiper.animating)
+                    console.log('hit navigationNext')
+                }) // slideNextTransitionEnd
+                $scope.swiper.on('slideNextTransitionEnd', () => {
+                    console.log('hit slideNextTransitionEnd')
+                })*/
 
                 /*
                 Issue: When loading a page, the first time a set of Swiper slideshows are called, it will load fine.

--- a/packages/swiper/src/carousel.component.ts
+++ b/packages/swiper/src/carousel.component.ts
@@ -648,6 +648,11 @@ Stratus.Components.SwiperCarousel = {
                 // console.log('parameters:', $scope.swiperParameters, $ctrl)
                 $scope.swiper = new Swiper($scope.swiperContainer, $scope.swiperParameters)
                 // console.log('created $scope.swiper', clone($scope.swiper))
+
+                // FIXME there is a delay on the navigation buytton when the transition has completely finished
+                // FIXME possibly set a bypass and force next/prev slide anyways by testing this event
+                // $scope.swiper.on('navigationNext', () => {})
+
                 /*
                 Issue: When loading a page, the first time a set of Swiper slideshows are called, it will load fine.
                 However, if a set is loaded a second time, the slides seem to fail to initialize and the next/prev buttons do not register.


### PR DESCRIPTION
@stratusjs/swiper 1.2.2 published
Changes:
- Swiper upgraded to 10.3
- Swiper package latest requirements

@stratusjs/idx 0.20.0 published
Adds:
- Fields for handling and using equal queries instead of regex. Affecting:
- - Location
- - Neighborhood
- - City
- - CityRegion
- - CountyOrParish
- - MLSAreaMajor
- - SubdivisionName

Changes:
- Fix Typings, warnings, various errors
- Remove unused/extra imports
- Fix image css pathing
- Will query BestPrice instead of ListPrice (allows for Closed status searching)
- Refactor Filter display logic with simpler functionality

Removes:
- Deprecated usage of existing Regex queries, except for Location