### PR TITLE
Core 0.6.2: Fix `modelBase.toPatch()`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "This is the core package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/core/src/datastore/modelBase.ts
+++ b/packages/core/src/datastore/modelBase.ts
@@ -119,7 +119,12 @@ export class ModelBase<T = LooseObject> extends EventManager {
         if (!changeSet || _.isEmpty(changeSet)) {
             return patchData
         }
-        _.forEach(changeSet, (value: any, key: string) => _.set(patchData, key, _.get(this.data, key)))
+        _.forEach(changeSet, (value: any, key: string) => {
+            if (!_.has(this.data, key)) {
+                return
+            }
+            _.set(patchData, key, _.get(this.data, key))
+        })
         return patchData
     }
 


### PR DESCRIPTION
Fixes:

- Setting Object to `null` in `modelBase.toPatch()` returns Object with all values of `undefined`