### PR TITLE
@stratusjs/idx 0.21.1

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./dist/idx.bundle.js",
   "scripts": {

--- a/packages/idx/src/idx.ts
+++ b/packages/idx/src/idx.ts
@@ -2004,7 +2004,8 @@ const angularJsService = (
                         // TODO: search UnparsedAddress if it exists for the service, OR the API will parse
                         // TODO: it into StreetNumber, StreetName, StreetSuffix, depending on what's provided
                         // TODO: and all those are LIKE (but all must match LIKE)
-                        {apiField: 'UnparsedAddress', type: 'stringLikeArray'},
+                        // Disabled UnparsedAddress as it is regex and not equals
+                        // {apiField: 'UnparsedAddress', type: 'stringLikeArray'},
                         {apiField: 'ListingId', type: 'stringIncludesArray'},
                     ]
                 },

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -34,9 +34,10 @@
                     data-ng-if="!isPresetLocationSet()">
                 <label>City, Neighborhood, Zip</label>
                 <input
+                        class="input-eLocation"
                         data-ng-if="!options.query.where.Location"
                         data-ng-model="options.query.where.eLocation"
-                        data-ng-blur="search()"
+                        data-ng-blur="options.query.where.eLocation.length && search()"
                         type="text"
                         size="22"
                         maxlength="250"
@@ -44,6 +45,7 @@
                         autocomplete="off"
                 >
                 <input
+                        class="input-Location"
                         data-ng-if="options.query.where.Location"
                         data-ng-model="options.query.where.Location"
                         data-ng-blur="search()"
@@ -72,7 +74,7 @@
             <a
                     class="custom-clear"
                     data-ng-if="(options.query.where.eLocation.length || options.query.where.Location.length || isPresetLocationSet())"
-                    data-ng-click="resetLocationQuery();"
+                    data-ng-click="resetLocationQuery(); focusElement('.location-input .input-eLocation')"
             >
                 <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/clear.svg' }}"></md-icon>
             </a>

--- a/packages/idx/src/property/search.component.html
+++ b/packages/idx/src/property/search.component.html
@@ -72,7 +72,7 @@
             <a
                     class="custom-clear"
                     data-ng-if="(options.query.where.eLocation.length || options.query.where.Location.length || isPresetLocationSet())"
-                    data-ng-click="resetLocationQuery(); search()"
+                    data-ng-click="resetLocationQuery();"
             >
                 <md-icon md-svg-src="{{ localDir + 'images/icons/actionButtons/clear.svg' }}"></md-icon>
             </a>

--- a/packages/idx/src/property/search.component.ts
+++ b/packages/idx/src/property/search.component.ts
@@ -28,7 +28,7 @@ import _, {
     union
 } from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
-import {element, material, IAttributes, ITimeoutService, IQService, IWindowService, ISCEService} from 'angular'
+import {element, material, IAttributes, ITimeoutService, IQService, IWindowService, ISCEService, IAugmentedJQuery} from 'angular'
 import 'angular-material'
 import {
     CompileFilterOptions,
@@ -128,6 +128,7 @@ export type IdxPropertySearchScope = IdxSearchScope & {
     // Functions
     canDisplayListingTypeButton(listType: ListingTypeSelectionSetting): boolean
     displayOfficeGroupSelector(searchTerm?: string, editIndex?: number, ev?: any): void
+    focusElement(selector: string): void
     getMLSVariables(reset?: boolean): MLSService[]
     getOtherPresetFilterCount(): number
     getPresetLocations(): string[]
@@ -240,6 +241,7 @@ Stratus.Components.IdxPropertySearch = {
     },
     controller(
         $attrs: IAttributes,
+        $element: IAugmentedJQuery,
         $q: IQService,
         $mdConstant: any, // mdChips item
         $mdDialog: material.IDialogService,
@@ -559,6 +561,21 @@ Stratus.Components.IdxPropertySearch = {
             const filterCounts = $scope.getOtherPresetFilterCount()
             if (filterCounts > 0) {
                 $scope.presetOtherFiltersCountText = `+${filterCounts} Filter${filterCounts > 1 ? 's' : ''}`
+            }
+        }
+
+        /** Focus a requested element. Only selectors elements within the component. */
+        $scope.focusElement = (selector: string): void => {
+            if (!isEmpty(selector)){
+                $timeout(() => {
+                    const elementThis = $element[0]
+                    const elementSelected = elementThis.querySelector(selector)
+                    if (!elementSelected) {
+                        console.warn('unable to find focusable element of', selector)
+                        return
+                    }
+                    (elementSelected as any).focus()
+                }, 100) // Delay to allow angular to process first
             }
         }
 


### PR DESCRIPTION
@stratusjs/idx 0.21.1 published
Changes:
- "Clear Filters" should not to an immediate Search()
- When clicking "Clear Filters" auto focus the Location field

Removes:
- `UnparsedAddress` from `eLocation` searches due to slow regex use