### PR TITLE
AngularJS 0.7.2: Fix Promise and Error Handling

### DIFF
--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {


### PR DESCRIPTION
Adds:

- Model: Controls for Toast Messages
- Model: Notes for Fixing `this.status`
- Collection: Controls for Toast Messages
- Collection Models: Dissemination of Toast Controls

Fixes:

- Model: Chained Promises
- Model: `throw` in `catch`
- Collection: Chained Promises
- Collection: `throw` in `catch`