### PR TITLE
AngularJS 0.8.0: Fix Toast Messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/react-dom": "^18.0.0",
     "@types/stripe-v3": "^3.1.17",
     "@types/systemjs": "^6.1.0",
-    "@types/toastify-js": "^1.11.1",
+    "@types/toastify-js": "^1.12.3",
     "@types/vfile-message": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@stratusjs/core": "^0.6.0",
     "@stratusjs/runtime": "^0.12.1",
+    "@types/toastify-js": "^1.12.3",
     "angular": "1.8.3",
     "angular-animate": "1.7.9",
     "angular-aria": "1.7.9",
@@ -36,6 +37,7 @@
     "angular-paging": "2.2.2",
     "angular-resource": "1.7.9",
     "angular-sanitize": "1.7.9",
+    "toastify-js": "^1.12.0",
     "tslib": "^2.4.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -92,6 +92,7 @@ export default [
     },
     external: [
       'lodash',
+      'toastify-js',
       'angular',
       '@stratusjs',
       'angular-material',


### PR DESCRIPTION
Adds:

- Toastify Messages
- Toast Error Messages

Changes:

- Enable Model Toast by Default
- Enable Collection Toast by Default

Removes:

- Collection `$mdToast` Messages
- Collection `angular-material` Dependency
- Collection `getInjector()` Workaround
- Model `$mdToast` Messages
- Model `angular-material` Dependency

Fixes:

- Collection Toast Messages
- Model Toast Messages