### PR TITLE
@stratusjs/boot 1.2.0 Manual Boot Up paths

### DIFF
--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/boot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This is the boot package for StratusJS.",
   "main": "dist/boot.min.js",
   "scripts": {},

--- a/packages/boot/src/config.ts
+++ b/packages/boot/src/config.ts
@@ -224,6 +224,7 @@
             skrollr: `${boot.deployment}@stratusjs/angularjs-extras/src/normalizers/skrollr.init${boot.suffix}`,
             '@stratusjs/angularjs-extras': stratusjsAngularJsExtrasBundlePath,
             '@stratusjs/angularjs-extras/*': stratusjsAngularJsExtrasBundlePath,
+            'stratus.components.angularjsBoot': stratusjsAngularJsExtrasBundlePath,
             'stratus.components.citation': stratusjsAngularJsExtrasBundlePath,
             'stratus.components.jsonEditor': stratusjsAngularJsExtrasBundlePath,
             'stratus.components.twitterFeed': stratusjsAngularJsExtrasBundlePath,
@@ -271,6 +272,7 @@
             '@stratusjs/calendar/*': stratusjsCalendarBundlePath,
             '@fullcalendar/*': stratusjsCalendarBundlePath,
             'stratus.components.calendar': stratusjsCalendarBundlePath,
+            'stratus.components.calendarBoot': stratusjsCalendarBundlePath, // Forcibly load the Calendar Bundle (non-existent)
 
             /* @stratus/idx Package Paths */
             '@stratusjs/idx': stratusjsIdxBundlePath,
@@ -287,6 +289,7 @@
             'stratus.components.idxPropertyDetailsSubSection': stratusjsIdxBundlePath,
             'stratus.components.idxPropertyList': stratusjsIdxBundlePath,
             'stratus.components.idxPropertySearch': stratusjsIdxBundlePath,
+            'stratus.components.idxBoot': stratusjsIdxBundlePath,
 
             /* @stratusjs/core Package Paths */
             '@stratusjs/core': `${boot.deployment}@stratusjs/core/dist/core.bundle${boot.suffix}`,
@@ -311,6 +314,7 @@
             '@stratusjs/swiper': stratusjsSwiperBundlePath,
             '@stratusjs/swiper/*': stratusjsSwiperBundlePath,
             'stratus.components.swiperCarousel': stratusjsSwiperBundlePath,
+            'stratus.components.swiperBoot': stratusjsSwiperBundlePath,
 
             /* Third Party Libraries */
 


### PR DESCRIPTION
**@stratusjs/boot** 1.2.0 published

Adds
- Boot paths for `<stratus-angularjs-boot/>` (AngularJs Extras), `<stratus-calendar-boot/>`, `<stratus-idx-boot/>`, and `<stratus-swiper-boot/>`
-  - Having these elements on the start of a page will at least load the respective bundles and allow dynamic loading later 