### PR TITLE
@stratusjs/angular 0.9.1 timezone-selector include local time labelling

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angular/src/timezone-selector/timezone-selector.component.html
+++ b/packages/angular/src/timezone-selector/timezone-selector.component.html
@@ -1,7 +1,7 @@
-<mat-form-field>
-    <mat-label>Select Timezone</mat-label>
+<mat-form-field [style.width.px]=330>
+    <mat-label>{{label}}</mat-label>
     <input type="text"
-           placeholder="Timezone"
+           placeholder="Select Timezone"
            matInput
            [formControl]="inputTimezone"
            [matAutocomplete]="auto">


### PR DESCRIPTION
@stratusjs/angular 0.9.1 published
Changes
- timezone-selector include local time labelling

![Screen Shot 2024-02-01 at 9 41 45 AM](https://github.com/Sitetheory/stratus/assets/626727/d3a0400e-e95e-40c6-9a20-7564a255fd6b)
![Screen Shot 2024-02-01 at 9 40 32 AM](https://github.com/Sitetheory/stratus/assets/626727/d19db0d3-d505-43fc-97f5-af012e0e8bfb)
