### PR TITLE
AngularJS 0.9.3: Suppress Server Errors

### DIFF
--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -19,7 +19,7 @@ import {
     map,
     set,
     throttle,
-    reduce, clone
+    reduce, clone, has
 } from 'lodash'
 import angular from 'angular'
 import {Stratus} from '@stratusjs/runtime/stratus'
@@ -598,6 +598,10 @@ export class Collection<T = LooseObject> extends EventManager {
         }
         const message = get(digest, 'meta.status[0].message') || get(digest, 'error.exception[0].message') || null
         if (!message) {
+            return null
+        }
+        if (!cookie('env') && has(digest, 'error.exception[0].message')) {
+            console.error('[xhr] server:', message)
             return null
         }
         return message

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -848,6 +848,7 @@ export class Model<T = LooseObject> extends ModelBase<T> {
                         reject(error)
                         return
                     }
+                    // TODO: Detect why we're getting internal messages outside of Dev Mode!
                     const errorMessage = this.errorMessage(error)
                     const formatMessage = errorMessage ? `: ${errorMessage}` : '.'
                     Toastify({
@@ -1194,6 +1195,10 @@ export class Model<T = LooseObject> extends ModelBase<T> {
         }
         const message = get(digest, 'meta.status[0].message') || get(digest, 'error.exception[0].message') || null
         if (!message) {
+            return null
+        }
+        if (!cookie('env') && has(digest, 'error.exception[0].message')) {
+            console.error('[xhr] server:', message)
             return null
         }
         return message


### PR DESCRIPTION
Changes:

- [Model] Server Errors send only to Console in Production
- [Collection] Server Errors send only to Console in Production