### PR TITLE
@stratusjs/core 0.8.0 @stratusjs/angularjs 0.10.0 @stratusjs/angular 0.10.0

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -54,8 +54,9 @@
     "@angular/platform-browser-dynamic": "^12.2.16",
     "@angular/router": "^12.2.16",
     "@codemirror/lang-html": "^6.4.0",
+    "@stratusjs/angularjs": "^0.10.0",
     "@stratusjs/boot": "^1.2.0",
-    "@stratusjs/core": "^0.6.2",
+    "@stratusjs/core": "^0.8.0",
     "@stratusjs/map": "^0.6.5",
     "@stratusjs/runtime": "^0.12.1",
     "@stratusjs/stripe": "^1.9.0",

--- a/packages/angular/src/selector/selector.component.html
+++ b/packages/angular/src/selector/selector.component.html
@@ -1,6 +1,6 @@
  <!--
 <mat-form-field class="full-width">
-    <input matInput [placeholder]="'Add ' + (_.get(selectedModel, 'contentType.name') || _.get(selectedModel, 'name')) + ': Not Connected Yet!'" aria-label="Selector AutoComplete" [matAutocomplete]="auto" [formControl]="selectCtrl">
+    <input matInput [placeholder]="'Add ' + (get(selectedModel, 'contentType.name') || get(selectedModel, 'name')) + ': Not Connected Yet!'" aria-label="Selector AutoComplete" [matAutocomplete]="auto" [formControl]="selectCtrl">
     <mat-autocomplete #auto="matAutocomplete">
         <mat-option *ngFor="let selectModel of filteredModels | async" [value]="selectModel">
             {{ selectModel.version.title }}
@@ -34,9 +34,9 @@
     <div cdkDropList (cdkDropListDropped)="drop($event)">
         <!--<span class="selectedModels" style="display: none" [textContent]="dataSub | async | json"></span>-->
         <!--<span class="selectedModels" style="display: none" *ngIf="log('selector.ngIf:', dataSub | async)"></span>-->
-        <!-- [cdkDragDisabled]="_.get(selectedModel, 'status') < 1" -->
+        <!-- [cdkDragDisabled]="get(selectedModel, 'status') < 1" -->
         <div cdkDrag class="selected-list-row selected-box"
-             [ngClass]="{'active': _.get(selectedModel, 'status') === 1, 'inactive' : _.get(selectedModel, 'status') !== 1, 'published': _.get(selectedModel, 'version.published') === 1, 'unpublished': _.get(selectedModel, 'version.published') !== 1}"
+             [ngClass]="{'active': get(selectedModel, 'status') === 1, 'inactive' : get(selectedModel, 'status') !== 1, 'published': get(selectedModel, 'version.published') === 1, 'unpublished': get(selectedModel, 'version.published') !== 1}"
              *ngFor="let selectedModel of dataSub | async">
             <div class="custom-ghost-placeholder" *cdkDragPlaceholder></div>
             <div class="selected-list-container">
@@ -51,17 +51,17 @@
                     <!-- This adds stratus-src lazy loading if bestImage isn't a third party service without image sizes, e.g. Video -->
                     <div class="image position-all"
                          *ngIf="has(selectedModel, 'version.bestImage._thumbnailUrl')"
-                         [attr.data-stratus-src]="!_.get(selectedModel, 'version.bestImage.service') ? true : false"
-                         [ngStyle]="{'background': 'url(' + _.get(selectedModel, 'version.bestImage._thumbnailUrl') + ') no-repeat center center', 'background-size': 'cover'}">
+                         [attr.data-stratus-src]="!get(selectedModel, 'version.bestImage.service') ? true : false"
+                         [ngStyle]="{'background': 'url(' + get(selectedModel, 'version.bestImage._thumbnailUrl') + ') no-repeat center center', 'background-size': 'cover'}">
                     </div>
 
                     <!-- Icon for items with no image -->
                     <div class="no-image-icon position-all"
                          *ngIf="!has(selectedModel, 'version.bestImage._thumbnailUrl')"
-                         [ngClass]="_.get(selectedModel, 'contentType.class') + '-background-color'">
+                         [ngClass]="get(selectedModel, 'contentType.class') + '-background-color'">
 
                         <mat-icon class="content-type-icon position-center"
-                                  [svgIcon]="getSvg(Stratus.BaseUrl + (_.get(selectedModel, 'contentType.iconResourcePath') || _.get(selectedModel, 'iconResourcePath'))) | async">
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + (get(selectedModel, 'contentType.iconResourcePath') || get(selectedModel, 'iconResourcePath'))) | async">
                             Icon
                         </mat-icon>
                     </div>
@@ -78,32 +78,32 @@
                         to break away from the div and float to the top of the selector container
                         -->
                         <mat-icon class="content-type-icon"
-                                  [svgIcon]="getSvg(Stratus.BaseUrl + _.get(selectedModel, 'contentType.iconResourcePath')) | async">
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + get(selectedModel, 'contentType.iconResourcePath')) | async">
                             ContentType Icon
                         </mat-icon>
                         <span class="comment content-type-name font-body"
-                              [ngClass]="((_.get(selectedModel, 'contentType.name') || _.get(selectedModel, 'name')) | lowercase) + '-color'"
-                              [textContent]="(_.get(selectedModel, 'contentType.name') || _.get(selectedModel, 'name')) + ((_.get(selectedModel, 'status') !== 1) ? ' (hidden)' : '') + ((_.get(selectedModel, 'version.published') !== 1) ? ' (unpublished)' : '')">
+                              [ngClass]="((get(selectedModel, 'contentType.name') || get(selectedModel, 'name')) | lowercase) + '-color'"
+                              [textContent]="(get(selectedModel, 'contentType.name') || get(selectedModel, 'name')) + ((get(selectedModel, 'status') !== 1) ? ' (hidden)' : '') + ((get(selectedModel, 'version.published') !== 1) ? ' (unpublished)' : '')">
                         </span>
                     </div>
 
                     <!-- This include fallbacks in case a version is not present -->
-                    <h3 [innerHTML]="_.get(selectedModel, 'version.bestIdentifier') || _.get(selectedModel, 'name') || (_.get(selectedModel, 'contentType.controller') === 'Content\\Module' ? _.get(selectedModel, 'version.internalIdentifier') : 'Untitled ' + _.get(selectedModel, 'contentType.name') + ' (' + _.get(selectedModel, 'id') + ')')"></h3>
+                    <h3 [innerHTML]="get(selectedModel, 'version.bestIdentifier') || get(selectedModel, 'name') || (get(selectedModel, 'contentType.controller') === 'Content\\Module' ? get(selectedModel, 'version.internalIdentifier') : 'Untitled ' + get(selectedModel, 'contentType.name') + ' (' + get(selectedModel, 'id') + ')')"></h3>
                     <!-- TODO: make this clickable in new window -->
                     <span class="routing"
-                          [textContent]="(has(selectedModel, 'routing') ? '/' + _.get(selectedModel, 'routing[0].url') : null) || _.get(selectedModel, 'description') || ''">
+                          [textContent]="(has(selectedModel, 'routing') ? '/' + get(selectedModel, 'routing[0].url') : null) || get(selectedModel, 'description') || ''">
                     </span>
                 </div>
                 <div class="column-action">
                     <a mat-button
-                            [matTooltip]="'Delete ' + (_.get(selectedModel, 'contentType.name') || _.get(selectedModel, 'name')) + ' [THIS COLLECTION ONLY]'"
+                            [matTooltip]="'Delete ' + (get(selectedModel, 'contentType.name') || get(selectedModel, 'name')) + ' [THIS COLLECTION ONLY]'"
                             aria-label="Delete Item"
                             class="btn btn-delete"
                             (click)="remove(selectedModel)">
                         <mat-icon svgIcon="selector_delete" aria-hidden="false" aria-label="Delete Item">Delete</mat-icon>
                     </a>
                     <a mat-button
-                       [matTooltip]="'Toggle ' + (_.get(selectedModel, 'contentType.name') || _.get(selectedModel, 'name')) + ' Status ' + (_.get(selectedModel, 'status') ? 'Off' : 'On') + ' [ALL CONTEXTS]'"
+                       [matTooltip]="'Toggle ' + (get(selectedModel, 'contentType.name') || get(selectedModel, 'name')) + ' Status ' + (get(selectedModel, 'status') ? 'Off' : 'On') + ' [ALL CONTEXTS]'"
                        aria-label="Toggle Status"
                        class="btn btn-status"
                        (click)="toggleStatus(selectedModel)">
@@ -111,7 +111,7 @@
                     </a>
                     <a mat-button
                             *ngIf="has(selectedModel, 'contentType.editUrl')"
-                            [matTooltip]="'Edit ' + (_.get(selectedModel, 'contentType.name') || _.get(selectedModel, 'name'))"
+                            [matTooltip]="'Edit ' + (get(selectedModel, 'contentType.name') || get(selectedModel, 'name'))"
                             aria-label="Edit Item in New Window"
                             class="btn btn-edit"
                             (click)="goToUrl(selectedModel, '_blank');">

--- a/packages/angular/src/selector/selector.component.ts
+++ b/packages/angular/src/selector/selector.component.ts
@@ -90,6 +90,7 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
     uid: string
 
     // Registry Attributes
+    @Input() context: string
     @Input() target: string
     @Input() targetSuffix: string
     @Input() id: number
@@ -271,7 +272,9 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
             url: '/Api/Content/' + model.id,
             data: {
                 route: {},
-                meta: {},
+                meta: {
+                    forceContext: this.context
+                },
                 payload: {
                     status: model.status
                 }

--- a/packages/angular/src/selector/selector.component.ts
+++ b/packages/angular/src/selector/selector.component.ts
@@ -31,7 +31,10 @@ import {IconOptions, MatIconRegistry} from '@angular/material/icon'
 
 // External Dependencies
 import {Stratus} from '@stratusjs/runtime/stratus'
-import _ from 'lodash'
+import _, {
+    get,
+    isUndefined
+} from 'lodash'
 import {keys} from 'ts-transformer-keys'
 import {cookie} from '@stratusjs/core/environment'
 
@@ -90,7 +93,6 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
     uid: string
 
     // Registry Attributes
-    @Input() context: string
     @Input() target: string
     @Input() targetSuffix: string
     @Input() id: number
@@ -264,6 +266,10 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
         // model is not directly a model, but just a sub entity of content.version.modules
         // so we have to create a special API call to update just this one model
         // 'Content/' + model.id
+        let meta = {}
+        if (!isUndefined(this.data)) {
+            meta = get(this.data, 'meta.data.api')
+        }
         const statusOriginal = model.status
         model.status = statusOriginal === 1 ? 0 : 1
         // Create a direct XHR
@@ -272,9 +278,7 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
             url: '/Api/Content/' + model.id,
             data: {
                 route: {},
-                meta: {
-                    forceContext: this.context
-                },
+                meta,
                 payload: {
                     status: model.status
                 }
@@ -289,7 +293,7 @@ export class SelectorComponent extends RootComponent { // implements OnInit, OnC
                     this.refresh()
                     return
                 }
-                console.log('success[toggleStatus]:', response)
+                // console.log('success[toggleStatus]:', response)
             })
             .catch((error: any) => {
                 console.error('error[toggleStatus]:', error)

--- a/packages/angular/src/tree/tree-dialog.component.html
+++ b/packages/angular/src/tree/tree-dialog.component.html
@@ -94,8 +94,8 @@
 
                         <!-- Content Type Icon -->
                         <mat-icon aria-hidden="true"
-                                  *ngIf="_.get(model, 'contentType.iconResourcePath')"
-                                  [svgIcon]="getSvg(Stratus.BaseUrl + _.get(model, 'contentType.iconResourcePath')) | async">
+                                  *ngIf="get(model, 'contentType.iconResourcePath')"
+                                  [svgIcon]="getSvg(Stratus.BaseUrl + get(model, 'contentType.iconResourcePath')) | async">
                             Icon
                         </mat-icon>
 

--- a/packages/angular/src/tree/tree-dialog.component.ts
+++ b/packages/angular/src/tree/tree-dialog.component.ts
@@ -39,7 +39,7 @@ import {
 } from 'rxjs/operators'
 
 // External
-import _ from 'lodash'
+import _, {assignIn} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {cookie} from '@stratusjs/core/environment'
 
@@ -67,6 +67,7 @@ import {
 import {
     ResponsiveComponent
 } from '../core/responsive.component'
+import {serializeUrlParams} from '@stratusjs/core/misc'
 
 // Data Types
 export interface DialogData {
@@ -80,6 +81,7 @@ export interface DialogData {
     level: string
     content: any
     url: string
+    api: object
     model: Model
     collection: Collection
     parent: any
@@ -142,7 +144,15 @@ export class TreeDialogComponent extends ResponsiveComponent implements OnInit, 
     isContentLoading = false
     isContentLoaded = false
     lastContentSelectorQuery: string
+    /*
     basicContentQueryAttributes = 'options[isContent]=null&options[isCollection]=null&options[showRoutable]=true&options[showRouting]=true'
+     */
+    basicContentQueryAttributesObject: LooseObject = {
+        isContent:true,
+        isCollection: null,
+        showRoutable: true,
+        showRouting: true
+    }
     contentEntity: ContentEntity
 
     // Normalized Data
@@ -423,9 +433,10 @@ export class TreeDialogComponent extends ResponsiveComponent implements OnInit, 
     }
 
     getQueryUrl(query?: string, id?: string|number): string {
+        const fullApiOptions = { options: assignIn(this.basicContentQueryAttributesObject, this.data.api)}
         query = (!_.isString(query) || _.isEmpty(query)) ? '' : query
         id = !_.isString(id) && !_.isNumber(id) ? '' : `/${id}`
-        return `${this.apiBase}${id}?limit=${this.limit}&${this.basicContentQueryAttributes}&q=${query}`
+        return `${this.apiBase}${id}?limit=${this.limit}&${serializeUrlParams(fullApiOptions)}&q=${query}`
     }
 
     selectedOnTop(list?: Array<ContentEntity>, selected?: ContentEntity): Array<ContentEntity> {

--- a/packages/angular/src/tree/tree-node.component.ts
+++ b/packages/angular/src/tree/tree-node.component.ts
@@ -238,6 +238,7 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
                 id: this.node.model.data.id || null,
                 name: this.node.model.data.name || '',
                 target: this.node.model.data.url ? 'url' : 'content',
+                api: this.tree.api,
                 // level: this.node.model.data.nestParent === null ? 'top' : 'child',
                 content: this.node.model.data.content || null,
                 url: this.node.model.data.url || null,

--- a/packages/angular/src/tree/tree-node.component.ts
+++ b/packages/angular/src/tree/tree-node.component.ts
@@ -16,6 +16,7 @@ import {
 
 // Components
 // TODO: We may want to move these imports to interface files to avoid circular references
+// being a bundled import, circular references are generally not an issue
 import {
     Node,
     TreeComponent
@@ -34,7 +35,14 @@ import {
 } from '@stratusjs/angularjs/services/model'
 
 // External
-import _ from 'lodash'
+import {
+    get,
+    has,
+    isEmpty,
+    max,
+    snakeCase,
+    uniqueId
+} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {cookie} from '@stratusjs/core/environment'
 import {IconOptions} from '@angular/material/icon'
@@ -74,7 +82,6 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
     isStyled = false
 
     // Dependencies
-    _ = _
     Stratus = Stratus
 
     // Inputs
@@ -105,7 +112,7 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
 
     ngOnInit() {
         // Initialization
-        this.uid = _.uniqueId(`sa_${_.snakeCase(moduleName)}_component_`)
+        this.uid = uniqueId(`sa_${snakeCase(moduleName)}_component_`)
         Stratus.Instances[this.uid] = this
 
         // TODO: Assess & Possibly Remove when the System.js ecosystem is complete
@@ -113,13 +120,13 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
         Stratus.Internals.CssLoader(`${localDir}/${parentModuleName}/${moduleName}.component${min}.css`)
             .then(() => {
                 this.isStyled = true
-                this.refresh()
+                this.refresh().then()
             })
             .catch((err: any) => {
                 console.warn('Issue detected in CSS Loader for Component:', this)
                 console.error(err)
                 this.isStyled = true
-                this.refresh()
+                this.refresh().then()
             })
 
         // Attach Component to Node Meta
@@ -129,7 +136,7 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
         this.isInitialized = true
 
         // Force UI Redraw
-        this.refresh()
+        this.refresh().then()
 
         // Handle Post-Persist
         this.onPostPersist()
@@ -180,7 +187,7 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
                 if (!this.node || !this.node.model) {
                     return
                 }
-                this.node.model.destroy()
+                this.node.model.destroy().then()
             })
         return dialog
     }
@@ -202,7 +209,7 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
             return
         }
         this.node.meta.expanded = !this.node.meta.expanded
-        this.refresh()
+        this.refresh().then()
     }
 
     public toggleExpandedClick(): void {
@@ -222,7 +229,7 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
 
     // TODO: Move things like toggle to this TreeNodeComponent, so it can be used in the template as well as the Dialog
     public openDialog(): void {
-        if (!this.node.model || !_.has(this.node.model, 'data')) {
+        if (!this.node.model || !has(this.node.model, 'data')) {
             return
         }
         const dialogRef = this.dialog.open(TreeDialogComponent, {
@@ -250,11 +257,11 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
                 nestParent: this.node.model.data.nestParent || null,
             }
         })
-        this.refresh()
+        this.refresh().then()
 
         const that = this
         dialogRef.afterClosed().subscribe((result: DialogData) => {
-            if (!result || _.isEmpty(result)) {
+            if (!result || isEmpty(result)) {
                 return
             }
             // Disable Listeners
@@ -269,23 +276,23 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
             ]
             // Persist to Model
             attrs.forEach(attr => {
-                if (!_.has(result, attr)) {
+                if (!has(result, attr)) {
                     return
                 }
                 // Normalize Content
                 if ('content' === attr) {
-                    const value = _.get(result, attr)
-                    this.node.model.set(attr, !value ? null : {id: _.get(value, 'id')})
+                    const value = get(result, attr)
+                    this.node.model.set(attr, !value ? null : {id: get(value, 'id')})
                     return
                 }
-                this.node.model.set(attr, _.get(result, attr))
+                this.node.model.set(attr, get(result, attr))
             })
             // Refresh Component
-            that.refresh()
+            that.refresh().then()
             // Refresh Parent Tree
-            that.tree.refresh()
+            that.tree.refresh().then()
             // Start XHR
-            this.node.model.save()
+            this.node.model.save().then()
             // Enable Listeners
             this.tree.unsettled = false
         })
@@ -316,13 +323,13 @@ export class TreeNodeComponent extends ResponsiveComponent implements OnInit, On
         }
         const model = this.node.model
         model.set('status', model.get('status') ? 0 : 1)
-        model.save()
+        model.save().then()
     }
 
     // TODO: Have this spawn off a new Tree Dialog with a new function addChild() on the TreeDialogComponent Class
     // TODO: Use the tree map to call node.openDialog after creating the new item
     public addChild(): void {
-        let priority = _.max(
+        let priority = max(
             this.tree.collection.models.filter(
                 (model: Model) => {
                     const nestParent = model.get('nestParent')

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -16,7 +16,6 @@
   "keywords": [
     "sitetheory",
     "stratus",
-    "underscore",
     "lodash",
     "javascript",
     "typescript",
@@ -26,7 +25,7 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/core": "^0.6.2",
+    "@stratusjs/core": "^0.8.0",
     "@stratusjs/runtime": "^0.12.1",
     "@types/toastify-js": "^1.12.3",
     "angular": "1.8.3",
@@ -37,6 +36,7 @@
     "angular-paging": "2.2.2",
     "angular-resource": "1.7.9",
     "angular-sanitize": "1.7.9",
+    "lodash": "^4.17.21",
     "toastify-js": "^1.12.0",
     "tslib": "^2.4.0"
   }

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -532,7 +532,7 @@ export class Model<T = LooseObject> extends ModelBase<T> {
                 withCredentials: this.withCredentials,
             }
             if (!isUndefined(data)) {
-                if (action === 'GET') {
+                if (['GET','DELETE'].includes(action)) {
                     if (isObject(data) && Object.keys(data).length) {
                         request.url += request.url.includes('?') ? '&' : '?'
                         request.url += this.serialize(data)
@@ -1146,7 +1146,11 @@ export class Model<T = LooseObject> extends ModelBase<T> {
             })
         }
         return new Promise(async (_resolve: any, reject: any) => {
-            this.sync('DELETE', {})
+            let deleteData = {}
+            if (!isEmpty(this.meta.get('api'))) {
+                deleteData = this.meta.get('api')
+            }
+            this.sync('DELETE', deleteData)
                 .then((_data: any) => {
                     // TODO: This should not need an error check in the success portion of the Promise, but I'm going to leave it here
                     //       until we are certain there isn't any code paths relying on this rejection.

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -39,6 +39,7 @@ import {
     isJSON,
     LooseObject,
     patch,
+    serializeUrlParams,
     setUrlParams,
     strcmp,
     ucfirst
@@ -476,29 +477,8 @@ export class Model<T = LooseObject> extends ModelBase<T> {
         return url
     }
 
-    serialize(obj: any, chain?: any) {
-        const str: any = []
-        obj = obj || {}
-        forEach(obj, (value: any, key: any) => {
-            if (isObject(value)) {
-                if (chain) {
-                    key = chain + '[' + key + ']'
-                }
-                str.push(this.serialize(value, key))
-            } else {
-                let encoded = ''
-                if (chain) {
-                    encoded += chain + '['
-                }
-                encoded += key
-                if (chain) {
-                    encoded += ']'
-                }
-                str.push(encoded + '=' + value)
-            }
-        })
-        return str.join('&')
-    }
+    /** @deprecated use @stratusjs/core/misc serializeUrlParams() instead */
+    serialize(obj: any, chain?: any) { return serializeUrlParams(obj, chain)}
 
     // TODO: Abstract this deeper
     sync(action?: string, data?: LooseObject, options?: ModelSyncOptions): Promise<any> {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "This is the core package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/core/src/misc.ts
+++ b/packages/core/src/misc.ts
@@ -322,6 +322,33 @@ export function safeUniqueId(...names: string[]): string {
 }
 
 /**
+ * Convert an object or ArrayLike into a URL usable string
+ */
+export function serializeUrlParams(obj: any, chain?: any) {
+    const str: any = []
+    obj = obj || {}
+    forEach(obj, (value: any, key: any) => {
+        if (isObject(value)) {
+            if (chain) {
+                key = chain + '[' + key + ']'
+            }
+            str.push(serializeUrlParams(value, key))
+        } else {
+            let encoded = ''
+            if (chain) {
+                encoded += chain + '['
+            }
+            encoded += key
+            if (chain) {
+                encoded += ']'
+            }
+            str.push(encoded + '=' + value)
+        }
+    })
+    return str.join('&')
+}
+
+/**
  * _.truncate() is faster if target doesn't contain html
  * https://lodash.com/docs/4.17.15#truncate
  *


### PR DESCRIPTION
@stratusjs/core 0.8.0 published
Adds:
- add serializeUrlParams() to reuse Model functionality

@stratusjs/angularjs 0.10.0 published
Changes:
- Model.destroy() and Model.sync() make use of supplied/meta options to pass needed functionality
- Moved Model.serialize() moved to @stratusjs/core/misc as serializeUrlParams()

@stratusjs/angular 0.10.0 published
Changes:
- sa-selector.toggleStatus(): make use of the needed meta/context of the parent