### PR TITLE
@stratusjs/angularjs-extras 0.15.2 add file types for stratus-src

### DIFF
--- a/packages/angular/src/tree/tree-dialog.component.ts
+++ b/packages/angular/src/tree/tree-dialog.component.ts
@@ -160,7 +160,7 @@ export class TreeDialogComponent extends ResponsiveComponent implements OnInit, 
     basicContentQueryAttributes = 'options[isContent]=null&options[isCollection]=null&options[showRoutable]=true&options[showRouting]=true'
      */
     basicContentQueryAttributesObject: LooseObject = {
-        isContent:true,
+        isContent: true,
         isCollection: null,
         showRoutable: true,
         showRouting: true

--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -20,16 +20,18 @@
     "javascript",
     "typescript",
     "angularjs",
+    "luxon",
     "moment"
   ],
   "engines": {
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.9.0",
-    "@stratusjs/core": "^0.6.2",
+    "@stratusjs/angularjs": "^0.10.0",
+    "@stratusjs/core": "^0.8.0",
     "@stratusjs/runtime": "^0.12.1",
     "js-md5": "^0.7.3",
+    "lodash": "^4.17.21",
     "luxon": "^3.4.4",
     "moment": "^2.24.0",
     "moment-range": "^4.0.2",

--- a/packages/angularjs-extras/src/directives/src.ts
+++ b/packages/angularjs-extras/src/directives/src.ts
@@ -54,10 +54,13 @@ Stratus.Directives.Src = (
         Stratus.Instances[safeUniqueId(packageName, moduleName, directiveName)] = $scope
 
         $scope.whitelist = [
+            'apng',
+            'avif',
+            'gif',
             'jpg',
             'jpeg',
             'png',
-            'gif'
+            'webp'
         ]
         $scope.filter = null
 

--- a/packages/angularjs-extras/src/filters/moment.ts
+++ b/packages/angularjs-extras/src/filters/moment.ts
@@ -23,6 +23,7 @@ type MomentOptions = {
 }
 
 /**
+ * @deprecated for Stratus.Filters.Luxon https://github.com/Sitetheory/stratus/wiki/AngularJS-Extras-Package-Filters-Usage#user-content-luxon
  * @author https://github.com/petebacondarwin/angular-toArrayFilter
  */
 Stratus.Filters.Moment = () => {

--- a/packages/angularjs-extras/src/filters/moment.ts
+++ b/packages/angularjs-extras/src/filters/moment.ts
@@ -23,7 +23,7 @@ type MomentOptions = {
 }
 
 /**
- * @deprecated for Stratus.Filters.Luxon https://github.com/Sitetheory/stratus/wiki/AngularJS-Extras-Package-Filters-Usage#user-content-luxon
+ * @deprecated for Luxon https://github.com/Sitetheory/stratus/wiki/AngularJS-Extras-Package-Filters-Usage#user-content-luxon
  * @author https://github.com/petebacondarwin/angular-toArrayFilter
  */
 Stratus.Filters.Moment = () => {


### PR DESCRIPTION
@stratusjs/angularjs-extras 0.15.2 published

Adds
- `stratus-src` add all "common" web-base image types (apng, avif, webp)
- Missing Dependencies (lodash)

Changes
- Deprecates Stratus.Filters.Moment
- Formatting fix for (purely typing standards)
- Updates all local dependencies to latest