### PR TITLE
Fix references to deprecated underscore mixins

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -27,9 +27,9 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/angularjs": "^0.10.0",
-    "@stratusjs/core": "^0.8.0",
-    "@stratusjs/runtime": "^0.12.3",
+    "@stratusjs/angularjs": "^0.11.0",
+    "@stratusjs/core": "^0.8.1",
+    "@stratusjs/runtime": "^0.13.0",
     "js-md5": "^0.7.3",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",

--- a/packages/angularjs-extras/src/components/deprecated-reference/selector-deprecated-reference.js
+++ b/packages/angularjs-extras/src/components/deprecated-reference/selector-deprecated-reference.js
@@ -55,8 +55,17 @@
       Stratus.Instances[$scope.uid] = $scope
       $scope.elementId = $attrs.elementId || $scope.uid
 
+      const isJSON = function (str) {
+        try {
+          JSON.parse(str)
+        } catch (e) {
+          return false
+        }
+        return true
+      }
+
       // Hydrate Settings
-      $scope.api = _.isJSON($attrs.api) ? JSON.parse($attrs.api) : false
+      $scope.api = isJSON($attrs.api) ? JSON.parse($attrs.api) : false
       $scope.property = $attrs.property || null
       $scope.model = null
       $scope.collection = null
@@ -68,7 +77,7 @@
           decouple: true,
           api: {
             options: this.options ? this.options : {},
-            limit: _.isJSON($attrs.limit) ? JSON.parse($attrs.limit) : 40
+            limit: isJSON($attrs.limit) ? JSON.parse($attrs.limit) : 40
           }
         }
         if ($scope.api && angular.isObject($scope.api)) {
@@ -79,7 +88,7 @@
 
       // Store Toggle Options for Custom Actions
       $scope.toggleOptions = {
-        multiple: _.isJSON($attrs.multiple)
+        multiple: isJSON($attrs.multiple)
           ? JSON.parse($attrs.multiple)
           : true
       }

--- a/packages/angularjs-extras/src/directives/masonry.ts
+++ b/packages/angularjs-extras/src/directives/masonry.ts
@@ -87,7 +87,7 @@ Stratus.Directives.Masonry = (): StratusDirective => ({
         // let initNow = true
         // if (Object.prototype.hasOwnProperty.call($attrs.$attr, 'initNow')) {
         //   // TODO: This needs better logic to determine what is acceptably initialized
-        //   initNow = _.isJSON($attrs.initNow) ? JSON.parse($attrs.initNow) : false
+        //   initNow = isJSON($attrs.initNow) ? JSON.parse($attrs.initNow) : false
         // }
         //
         // if (initNow) {

--- a/packages/angularjs-extras/src/loaders/angular.bind.js
+++ b/packages/angularjs-extras/src/loaders/angular.bind.js
@@ -1,7 +1,5 @@
 /* global Stratus, _, jQuery, angular, boot */
 
-import { camelCase, kebabCase } from 'lodash'
-
 /**
  * @constructor
  */

--- a/packages/angularjs-extras/src/loaders/angular.bind.js
+++ b/packages/angularjs-extras/src/loaders/angular.bind.js
@@ -200,7 +200,7 @@ Stratus.Loaders.Angular = () => {
             tabMode: 'space',
             tabSize: 4
           },
-          fileUploadURL: 'https://app.sitetheory.io:3000/?session=' + _.cookie('SITETHEORY'),
+          fileUploadURL: 'https://app.sitetheory.io:3000/?session=' + Stratus.Internals.Cookie('SITETHEORY'),
           htmlAllowedAttrs: ['.*'],
           htmlAllowedEmptyTags: [
             'textarea', 'a', '.fa',

--- a/packages/angularjs-extras/src/loaders/angular.bind.js
+++ b/packages/angularjs-extras/src/loaders/angular.bind.js
@@ -1,5 +1,7 @@
 /* global Stratus, _, jQuery, angular, boot */
 
+import { camelCase, kebabCase } from 'lodash'
+
 /**
  * @constructor
  */
@@ -18,10 +20,10 @@ Stratus.Loaders.Angular = () => {
   // TODO: Add references to this prototype in the tree builder, accordingly
   const injector = function (injection) {
     injection = injection || {}
-    _.each(injection, function (element, attribute) {
+    _.forEach(injection, function (element, attribute) {
       container[attribute] = container[attribute] || []
       if (_.isArray(element)) {
-        _.each(element, function (value) {
+        _.forEach(element, function (value) {
           container[attribute].push(value)
         })
       } else {
@@ -30,14 +32,14 @@ Stratus.Loaders.Angular = () => {
     })
   }
 
-  _.each(Stratus.Roster, function (element, key) {
+  _.forEach(Stratus.Roster, function (element, key) {
     if (typeof element === 'object' && element) {
       // sanitize roster fields without selector attribute
       if (_.isUndefined(element.selector) && element.namespace) {
         element.selector = _.filter(
           _.map(boot.configuration.paths, function (path, key) {
             // if (_.isString(key)) console.log(key.match(/([a-zA-Z]+)/g));
-            return _.startsWith(key, element.namespace) ? (element.type === 'attribute' ? '[' : '') + _.camelToKebab(key.replace(element.namespace, 'stratus-')) + (element.type === 'attribute' ? ']' : '') : null
+            return _.startsWith(key, element.namespace) ? (element.type === 'attribute' ? '[' : '') + _.kebabCase(key.replace(element.namespace, 'stratus-')) + (element.type === 'attribute' ? ']' : '') : null
           })
         )
       }
@@ -45,18 +47,18 @@ Stratus.Loaders.Angular = () => {
       // digest roster
       if (_.isArray(element.selector)) {
         element.length = 0
-        _.each(element.selector, function (selector) {
+        _.forEach(element.selector, function (selector) {
           nodes = document.querySelectorAll(selector)
           element.length += nodes.length
           if (nodes.length) {
             const name = selector.replace(/^\[/, '').replace(/]$/, '')
-            requirement = element.namespace + _.lcfirst(_.kebabToCamel(name.replace(/^stratus/, '').replace(/^ng/, '')))
+            requirement = element.namespace + _.lowerFirst(_.camelCase(name.replace(/^stratus/, '').replace(/^ng/, '')))
             if (_.has(boot.configuration.paths, requirement)) {
               injection = {
                 requirement: requirement
               }
               if (element.module) {
-                injection.module = _.isString(element.module) ? element.module : _.lcfirst(_.kebabToCamel(name + (element.suffix || '')))
+                injection.module = _.isString(element.module) ? element.module : _.lowerFirst(_.camelCase(name + (element.suffix || '')))
               }
               injector(injection)
             }
@@ -68,10 +70,10 @@ Stratus.Loaders.Angular = () => {
         if (nodes.length) {
           const attribute = element.selector.replace(/^\[/, '').replace(/]$/, '')
           if (attribute && element.namespace) {
-            _.each(nodes, function (node) {
+            _.forEach(nodes, function (node) {
               const name = node.getAttribute(attribute)
               if (name) {
-                requirement = element.namespace + _.lcfirst(_.kebabToCamel(name.replace('Stratus', '')))
+                requirement = element.namespace + _.lowerFirst(_.camelCase(name.replace('Stratus', '')))
                 if (_.has(boot.configuration.paths, requirement)) {
                   injector({
                     requirement: requirement
@@ -84,7 +86,7 @@ Stratus.Loaders.Angular = () => {
             container.requirement = _.union(container.requirement, element.require)
             injection = {}
             if (element.module) {
-              injection.module = _.isString(element.module) ? element.module : _.lcfirst(_.kebabToCamel(attribute + (element.suffix || '')))
+              injection.module = _.isString(element.module) ? element.module : _.lowerFirst(_.camelCase(attribute + (element.suffix || '')))
             }
             if (element.stylesheet) {
               injection.stylesheet = element.stylesheet
@@ -98,7 +100,7 @@ Stratus.Loaders.Angular = () => {
 
   // Ensure Modules enabled are in the requirements
   container.requirement.push('angular-material')
-  _.each(container, function (element, key) {
+  _.forEach(container, function (element, key) {
     container[key] = _.uniq(element)
   })
   window.container = container
@@ -107,7 +109,7 @@ Stratus.Loaders.Angular = () => {
   if (container.requirement.length) {
     // Deprecated the use of the 'froala' directive for stratus-froala
     /* *
-    if (_.contains(container.requirement, 'angular-froala')) {
+    if (_.includes(container.requirement, 'angular-froala')) {
       [
         'codemirror/mode/htmlmixed/htmlmixed',
         'codemirror/addon/edit/matchbrackets',
@@ -159,7 +161,7 @@ Stratus.Loaders.Angular = () => {
         ]
         if (boot.host) {
           if (_.startsWith(boot.host, '//')) {
-            _.each(['https:', 'http:'], function (proto) {
+            _.forEach(['https:', 'http:'], function (proto) {
               whitelist.push(proto + boot.host + '/**')
             })
           } else {
@@ -228,27 +230,27 @@ Stratus.Loaders.Angular = () => {
       }
 
       // Services
-      _.each(Stratus.Services, function (service) {
+      _.forEach(Stratus.Services, function (service) {
         angular.module('stratusApp').config(service)
       })
 
       // Components
-      _.each(Stratus.Components, function (component, name) {
-        angular.module('stratusApp').component('stratus' + _.ucfirst(name), component)
+      _.forEach(Stratus.Components, function (component, name) {
+        angular.module('stratusApp').component('stratus' + _.upperFirst(name), component)
       })
 
       // Directives
-      _.each(Stratus.Directives, function (directive, name) {
-        angular.module('stratusApp').directive('stratus' + _.ucfirst(name), directive)
+      _.forEach(Stratus.Directives, function (directive, name) {
+        angular.module('stratusApp').directive('stratus' + _.upperFirst(name), directive)
       })
 
       // Filters
-      _.each(Stratus.Filters, function (filter, name) {
-        angular.module('stratusApp').filter(_.lcfirst(name), filter)
+      _.forEach(Stratus.Filters, function (filter, name) {
+        angular.module('stratusApp').filter(_.lowerFirst(name), filter)
       })
 
       // Controllers
-      _.each(Stratus.Controllers, function (controller, name) {
+      _.forEach(Stratus.Controllers, function (controller, name) {
         angular.module('stratusApp').controller(name, controller)
       })
 
@@ -258,7 +260,7 @@ Stratus.Loaders.Angular = () => {
       const cssLoaded = Stratus('link[satisfies]').map(function (node) {
         return node.getAttribute('satisfies')
       })
-      if (!_.contains(cssLoaded, 'angular-material.css') && 'angular-material' in boot.configuration.paths) {
+      if (!_.includes(cssLoaded, 'angular-material.css') && 'angular-material' in boot.configuration.paths) {
         css.push(
           Stratus.BaseUrl + boot.configuration.paths['angular-material'].replace(/\.[^.]+$/, '.css')
         )
@@ -266,7 +268,7 @@ Stratus.Loaders.Angular = () => {
       if (Stratus.Directives.Froala || Stratus('[froala]').length) {
         // eslint-disable-next-line dot-notation
         const froalaPath = boot.configuration.paths['froala'].replace(/\/[^/]+\/?[^/]+\/?$/, '')
-        _.each([
+        _.forEach([
         // FIXME this is sitetheory only
           Stratus.BaseUrl + 'sitetheorycore/css/sitetheory.codemirror.css',
           // eslint-disable-next-line dot-notation

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "This is the AngularJS package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -25,8 +25,8 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/core": "^0.8.0",
-    "@stratusjs/runtime": "^0.12.1",
+    "@stratusjs/core": "^0.8.1",
+    "@stratusjs/runtime": "^0.13.0",
     "@types/toastify-js": "^1.12.3",
     "angular": "1.8.3",
     "angular-animate": "1.7.9",

--- a/packages/angularjs/src/components/base.ts
+++ b/packages/angularjs/src/components/base.ts
@@ -5,8 +5,8 @@
 import {Stratus} from '@stratusjs/runtime/stratus'
 
 // Libraries
-import _ from 'lodash'
-import * as angular from 'angular'
+import {isEqual} from 'lodash'
+import {IAttributes, IScope} from 'angular'
 
 // Angular 1 Modules
 import 'angular-material'
@@ -25,7 +25,7 @@ import {Registry} from '../services/registry'
 // Stratus Utilities
 import {
     LooseFunction,
-    LooseObject
+    LooseObject, safeUniqueId
 } from '@stratusjs/core/misc'
 import {cookie} from '@stratusjs/core/environment'
 
@@ -35,7 +35,7 @@ const name = 'base'
 const localPath = '@stratusjs/angularjs/src/components'
 
 // This is a typed scope for the component below
-export type BaseScope = angular.IScope & LooseObject<LooseFunction> & {
+export type BaseScope = IScope & LooseObject<LooseFunction> & {
     initialized: boolean
     uid: string
     model: Model
@@ -82,16 +82,16 @@ Stratus.Components.Base = {
     },
     controller(
         $scope: BaseScope,
-        $attrs: angular.IAttributes
+        $attrs: IAttributes
     ) {
         // Initialize
         // const $ctrl = this
-        $scope.uid = _.uniqueId(_.snakeCase(name) + '_')
+        $scope.uid = safeUniqueId(name)
         Stratus.Instances[$scope.uid] = $scope
         $scope.elementId = $attrs.elementId || $scope.uid
         Stratus.Internals.CssLoader(
             `${Stratus.BaseUrl + Stratus.BundlePath + localPath}/${name}${min}.css`
-        )
+        ).then()
         $scope.initialized = false
 
         // Hoist Attributes
@@ -105,7 +105,7 @@ Stratus.Components.Base = {
         // Registry Connectivity
         if ($attrs.target) {
             $scope.registry = $scope.registry || new Registry()
-            $scope.registry.fetch($attrs, $scope)
+            $scope.registry.fetch($attrs, $scope).then()
         }
 
         // Symbiotic Data Connectivity
@@ -136,7 +136,7 @@ Stratus.Components.Base = {
 
         // Model Watcher
         $scope.$watch('$scope.model.completed', (newVal: any, oldVal: any) => {
-            if (!newVal || _.isEqual(newVal, oldVal)) {
+            if (!newVal || isEqual(newVal, oldVal)) {
                 return
             }
             $scope.initialize()
@@ -144,7 +144,7 @@ Stratus.Components.Base = {
 
         // Collection Watcher
         $scope.$watch('$scope.collection.completed', (newVal: any, oldVal: any) => {
-            if (!newVal || _.isEqual(newVal, oldVal)) {
+            if (!newVal || isEqual(newVal, oldVal)) {
                 return
             }
             $scope.initialize()

--- a/packages/angularjs/src/controllers/generic.ts
+++ b/packages/angularjs/src/controllers/generic.ts
@@ -2,12 +2,13 @@
 // ------------------
 
 // Runtime
-import _ from 'lodash'
+import _, {forEach, head, isArray, isDate, isElement, isEmpty, isFunction, isNumber, isObject, isString, isUndefined} from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
-import * as angular from 'angular'
+import {ICompiledExpression, ILogService, IParseService, ISCEService, IScope, IWindowService} from 'angular'
 import {cookie} from '@stratusjs/core/environment'
 
 // Forced Runtime Load
+// tslint:disable-next-line:no-duplicate-imports
 import 'angular'
 
 // Modules
@@ -21,6 +22,7 @@ import {Collection} from '../services/collection'
 // Stratus Dependencies
 import {
     isJSON,
+    safeUniqueId,
     setUrlParams
 } from '@stratusjs/core/misc'
 
@@ -38,16 +40,16 @@ Stratus.Controllers.Generic = [
     '$window',
     'Registry',
     async (
-        $scope: angular.IScope|any,
+        $scope: IScope|any,
         $element: JQLite,
-        $log: angular.ILogService,
-        $sce: angular.ISCEService,
-        $parse: angular.IParseService,
-        $window: angular.IWindowService,
+        $log: ILogService,
+        $sce: ISCEService,
+        $parse: IParseService,
+        $window: IWindowService,
         R: Registry
     ) => {
         // Store Instance
-        $scope.uid = _.uniqueId('controller_generic_')
+        $scope.uid = safeUniqueId('controller_generic_')
         Stratus.Instances[$scope.uid] = $scope
 
         // Registry
@@ -74,15 +76,15 @@ Stratus.Controllers.Generic = [
         $scope.Math = Math
 
         // Type Checks
-        $scope.isArray = _.isArray
-        $scope.isDate = _.isDate
-        $scope.isDefined = (value: any) => !_.isUndefined(value)
-        $scope.isElement = _.isElement
-        $scope.isFunction = _.isFunction
-        $scope.isNumber = _.isNumber
-        $scope.isObject = _.isObject
-        $scope.isString = _.isString
-        $scope.isUndefined = _.isUndefined
+        $scope.isArray = isArray
+        $scope.isDate = isDate
+        $scope.isDefined = (value: any) => !isUndefined(value)
+        $scope.isElement = isElement
+        $scope.isFunction = isFunction
+        $scope.isNumber = isNumber
+        $scope.isObject = isObject
+        $scope.isString = isString
+        $scope.isUndefined = isUndefined
 
         // Angular Wrappers
         $scope.getHTML = $sce.trustAsHtml
@@ -112,11 +114,11 @@ Stratus.Controllers.Generic = [
          * concurrently.
          */
         $scope.scrollToAnchor = (anchor?: string, inUrl?: boolean, delay?: number) => {
-            if (!anchor || _.isEmpty(anchor)) {
+            if (!anchor || isEmpty(anchor)) {
                 $log.warn('anchor id not set!')
                 return false
             }
-            if (_.isUndefined(inUrl)) {
+            if (isUndefined(inUrl)) {
                 inUrl = false
             }
             if (inUrl && anchor !== $scope.getAnchor()) {
@@ -153,7 +155,7 @@ Stratus.Controllers.Generic = [
         // TODO: Consider moving the R.fetch() here
 
         // Bind Redraw to all Change Events
-        if ($scope.data && _.isFunction($scope.data.on)) {
+        if ($scope.data && isFunction($scope.data.on)) {
             $scope.data.on('change', () => $scope.$applyAsync())
         }
 
@@ -164,13 +166,13 @@ Stratus.Controllers.Generic = [
         const selected: {
             raw: string;
             id: string,
-            model?: Model|angular.ICompiledExpression,
+            model?: Model|ICompiledExpression,
             value?: any
         } = {
             id: $element.attr('data-selected'),
             raw: $element.attr('data-raw')
         }
-        if (!selected.id || !_.isString(selected.id)) {
+        if (!selected.id || !isString(selected.id)) {
             return
         }
         if (isJSON(selected.id)) {
@@ -179,7 +181,7 @@ Stratus.Controllers.Generic = [
                 if ($scope.selected || $scope.selectedInit) {
                     return
                 }
-                _.forEach(models, (model: Model) => {
+                forEach(models, (model: Model) => {
                     if (selected.id !== model.getIdentifier()) {
                         return
                     }
@@ -190,14 +192,14 @@ Stratus.Controllers.Generic = [
         } else {
             selected.model = $parse(selected.id)
             selected.value = selected.model($scope.$parent)
-            if (!_.isArray(selected.value)) {
+            if (!isArray(selected.value)) {
                 return
             }
             selected.value = selected.value.filter((n: any) => n)
             if (selected.value.length) {
                 return
             }
-            $scope.selected = _.first(selected.value)
+            $scope.selected = head(selected.value)
         }
     }
 ]

--- a/packages/angularjs/src/controllers/generic.ts
+++ b/packages/angularjs/src/controllers/generic.ts
@@ -5,6 +5,7 @@
 import _ from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import * as angular from 'angular'
+import {cookie} from '@stratusjs/core/environment'
 
 // Forced Runtime Load
 import 'angular'
@@ -20,7 +21,6 @@ import {Collection} from '../services/collection'
 // Stratus Dependencies
 import {
     isJSON,
-    getUrlParams,
     setUrlParams
 } from '@stratusjs/core/misc'
 
@@ -65,6 +65,7 @@ Stratus.Controllers.Generic = [
         $scope.ctrlParent = $scope.$parent
         $scope.Stratus = Stratus
         $scope._ = _
+        $scope.cookie = cookie
         $scope.$window = $window
         $scope.setUrlParams = setUrlParams
         $scope.$log = $log
@@ -103,9 +104,12 @@ Stratus.Controllers.Generic = [
             return url.substring(anchor + 1, url.length)
         }
         /**
-         * @param anchor - The anchor you'd like to smooth scroll to.  You can use the getAnchor() function if you'd like to point to the anchor in the URL.
-         * @param inUrl  - This flags whether the anchor needs to be present in the URL to continue.  If you're using the getAnchor() call above, this isn't necessary.
-         * @param delay  - This gives a delay of only 1ms, but is enough to lower the priority of this calculation, since javascript runs concurrently.
+         * @param anchor - The anchor you'd like to smooth scroll to.  You can use the getAnchor() function if you'd like to point to the
+         * anchor in the URL.
+         * @param inUrl  - This flags whether the anchor needs to be present in the URL to continue.  If you're using the getAnchor() call
+         * above, this isn't necessary.
+         * @param delay  - This gives a delay of only 1ms, but is enough to lower the priority of this calculation, since javascript runs
+         * concurrently.
          */
         $scope.scrollToAnchor = (anchor?: string, inUrl?: boolean, delay?: number) => {
             if (!anchor || _.isEmpty(anchor)) {

--- a/packages/angularjs/src/directives/base.ts
+++ b/packages/angularjs/src/directives/base.ts
@@ -2,7 +2,6 @@
 // --------------
 
 // Runtime
-import _ from 'lodash'
 import {Stratus} from '@stratusjs/runtime/stratus'
 import {IAttributes, IScope} from 'angular'
 
@@ -11,6 +10,7 @@ import 'angular-material'
 
 // Stratus Dependencies
 import {cookie} from '@stratusjs/core/environment'
+import {safeUniqueId} from '@stratusjs/core/misc'
 
 // Environment
 const min = !cookie('env') ? '.min' : ''
@@ -28,12 +28,12 @@ Stratus.Directives.Base = function () {
         link: ($scope: IScope|any, $element: JQLite|any, $attrs: IAttributes|any) => {
             // Initialize
             const $ctrl: any = this
-            $scope.uid = _.uniqueId(_.snakeCase(name) + '_')
+            $scope.uid = safeUniqueId(name)
             Stratus.Instances[$scope.uid] = $scope
             $scope.elementId = $element.elementId || $scope.uid
             Stratus.Internals.CssLoader(
                 Stratus.BaseUrl + Stratus.BundlePath + localPath + name + min + '.css'
-            )
+            ).then()
             $scope.initialized = false
 
             // Begin

--- a/packages/angularjs/src/injector.ts
+++ b/packages/angularjs/src/injector.ts
@@ -1,6 +1,6 @@
-import * as angular from 'angular'
+import {auto, element} from 'angular'
 
-export const getInjector = (): angular.auto.IInjectorService|null => {
-    const $root = angular.element(document.documentElement)
+export const getInjector = (): auto.IInjectorService|null => {
+    const $root = element(document.documentElement)
     return (!$root || !$root.injector) ? null : $root.injector()
 }

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -21,7 +21,7 @@ import {
     throttle,
     reduce, clone, has
 } from 'lodash'
-import angular from 'angular'
+import {auto} from 'angular'
 import {Stratus} from '@stratusjs/runtime/stratus'
 
 // Stratus Core
@@ -614,7 +614,7 @@ export class Collection<T = LooseObject> extends EventManager {
 // registered collections and models
 Stratus.Services.Collection = [
     '$provide',
-    ($provide: angular.auto.IProvideService) => {
+    ($provide: auto.IProvideService) => {
         $provide.factory('Collection', [() => Collection])
     }
 ]

--- a/packages/angularjs/src/services/model.ts
+++ b/packages/angularjs/src/services/model.ts
@@ -26,7 +26,7 @@ import {
     set,
     throttle
 } from 'lodash'
-import angular from 'angular'
+import {IRootScopeService} from 'angular'
 import {Stratus} from '@stratusjs/runtime/stratus'
 
 // Stratus Core
@@ -69,8 +69,8 @@ import Toastify from 'toastify-js'
 let injector = getInjector()
 
 // Angular Services
-// let $rootScope: angular.IRootScopeService = injector ? injector.get('$rootScope') : null
-let $rootScope: angular.IRootScopeService
+// let $rootScope: IRootScopeService = injector ? injector.get('$rootScope') : null
+let $rootScope: IRootScopeService
 
 // Service Verification Function
 const serviceVerify = async () => {
@@ -791,7 +791,9 @@ export class Model<T = LooseObject> extends ModelBase<T> {
         }
         // Sanity Checks for Persisted Entities
         if (!this.isNew() && (this.pending || !this.completed || isEmpty(this.toPatch()))) {
-            console.warn(`Blocked attempt to save ${isEmpty(this.toPatch()) ? 'an empty payload' : 'a duplicate XHR'} to a persisted model.`)
+            console.warn(
+                `Blocked attempt to save ${isEmpty(this.toPatch()) ? 'an empty payload' : 'a duplicate XHR'} to a persisted model.`
+            )
             return new Promise((resolve, _reject) => {
                 this.saving = false
                 resolve(this.data)
@@ -1189,7 +1191,7 @@ Stratus.Services.Model = [
         $provide.factory('Model', [
             // '$rootScope',
             (
-                // $r: angular.IRootScopeService
+                // $r: IRootScopeService
             ) => {
                 // $rootScope = $r
                 return Model

--- a/packages/angularjs/src/services/registry.ts
+++ b/packages/angularjs/src/services/registry.ts
@@ -3,7 +3,7 @@
 
 // Runtime
 import {forEach, get, kebabCase, isNumber, isObject, isUndefined, set, size, union} from 'lodash'
-import angular, {IScope} from 'angular'
+import {auto, IInterpolateService, IScope} from 'angular'
 import {Stratus} from '@stratusjs/runtime/stratus'
 
 // Stratus Core
@@ -23,8 +23,8 @@ import {EventManager} from '@stratusjs/core/events/eventManager'
 let injector = getInjector()
 
 // Angular Services
-// let $interpolate: angular.IInterpolateService = injector ? injector.get('$interpolate') : null
-let $interpolate: angular.IInterpolateService
+// let $interpolate: IInterpolateService = injector ? injector.get('$interpolate') : null
+let $interpolate: IInterpolateService
 
 // Interfaces
 export interface RegistryOptions extends CollectionOptions, ModelOptions {
@@ -293,13 +293,13 @@ export class Registry {
 // This Registry Service handles data binding for an element
 Stratus.Services.Registry = [
     '$provide',
-    ($provide: angular.auto.IProvideService) => {
+    ($provide: auto.IProvideService) => {
         $provide.factory('Registry', [
             // '$interpolate',
             // 'Collection',
             // 'Model',
             (
-                // $i: angular.IInterpolateService,
+                // $i: IInterpolateService,
                 // C: Collection,
                 // M: Model
             ) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "This is the core package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -2,7 +2,7 @@
 import {seconds} from './conversion'
 
 // External
-import _ from 'lodash'
+import {extend} from 'lodash'
 
 // Cookie Getter & Setter
 export function cookie(name: any, value?: any, expires?: any, path?: any, domain?: any, secure?: any, sameSite?: any): string|null {
@@ -16,7 +16,7 @@ export function cookie(name: any, value?: any, expires?: any, path?: any, domain
         sameSite
     }
     if (name && typeof name === 'object') {
-        _.extend(request, name)
+        extend(request, name)
     }
     let data
     if (typeof request.value === 'undefined') {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/runtime",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "This is the runtime package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -25,7 +25,7 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/core": "^0.8.0",
+    "@stratusjs/core": "^0.8.1",
     "bowser-legacy": "npm:bowser@^1.9.4",
     "jquery": "^3.4.1",
     "lodash": "^4.17.21",

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -3,8 +3,8 @@
 
 // Runtime
 import {
-    camelCase,every,extend,filter,find,findKey,flowRight,forEach,get,has,head,includes,isArray,isEmpty,isUndefined,
-    isString,kebabCase,keyBy,map,mapValues,max,mixin,once,size,snakeCase,some,startsWith,toPairs,uniq,uniqueId,union,zipObject
+    camelCase,every,extend,filter,findKey,forEach,get,has,head,includes,isArray,isEmpty,isUndefined,
+    isString,kebabCase,map,max,mixin,once,size,startsWith,uniq,uniqueId,union
 } from 'lodash'
 import jQuery from 'jquery'
 import bowser from 'bowser-legacy'
@@ -12,29 +12,15 @@ import bowser from 'bowser-legacy'
 // Stratus Core
 import {cookie} from '@stratusjs/core/environment'
 import {
-    allTrue,
-    converge,
     dehydrate,
-    extendDeep,
-    functionName,
-    getAnchorParams,
-    getUrlParams,
     hydrate,
-    hydrateString,
-    isAngular,
-    isjQuery,
     isJSON,
     lcfirst,
     LooseObject,
-    patch,
-    poll,
-    repeat,
     setUrlParams,
-    strcmp,
     ucfirst
 } from '@stratusjs/core/misc'
 import {
-    seconds,
     titleCase,
 } from '@stratusjs/core/conversion'
 import {
@@ -396,23 +382,6 @@ mixin({
 
     // Underscore Compatibility References: https://github.com/lodash/lodash/wiki/Migrating
     // TODO: Remove once phased out completely
-    any: some,
-    all: every,
-    compose: flowRight,
-    contains: includes,
-    findWhere: find,
-    indexBy: keyBy,
-    mapObject: mapValues,
-    object: zipObject,
-    pairs: toPairs,
-    pluck: map,
-    where: filter,
-
-    // This function simply extracts the name of a function from code directly
-    functionName,
-
-    // This function simply capitalizes the first letter of a string.
-    ucfirst,
 
     // This function simply changes the first letter of a string to a lower case.
     lcfirst,
@@ -421,63 +390,17 @@ mixin({
     // Note: Delete with `cookie(name, '', -1)`
     cookie,
 
-    // Converge a list and return the prime key through specified method.
-    converge,
-
-    // This synchronously repeats a function a certain number of times
-    // FIXME: This overwrites the core one
-    repeat,
-
-    // This function dehydrates an Object, Boolean, or Null value, to a string.
-    dehydrate,
-
-    // This function hydrates a string into an Object, Boolean, or Null value, if
-    // applicable.
-    hydrate,
-
-    // This is an alias to the hydrate function for backwards compatibility.
-    hydrateString,
-
-    // This function utilizes tree building to clone an object.
-    extendDeep,
-
-    // Get more params which is shown after anchor '#' anchor in the url.
-    getAnchorParams,
-
-    // Get a specific value or all values located in the URL
-    getUrlParams,
-
     // This function digests URLs into an object containing their respective
     // values, which will be merged with requested parameters and formulated
     // into a new URL.
-    setUrlParams,
-
-    // Ensure all values in an array or object are true
-    allTrue,
+    setUrlParams, // 1 reference in menu autocomplete
 
     // Determines whether or not the string supplied is in a valid JSON format
     isJSON,
 
-    // Determines whether or not the element was selected from Angular
-    isAngular,
-
-    // Determines whether or not the element was selected from Angular
-    isjQuery,
-
-    seconds,
-
     // Case Switchers
-    titleCase,
+    titleCase, // _.startCase
 
-    // Legacy Case Switchers
-    camelToKebab: kebabCase,
-    kebabToCamel: camelCase,
-    camelToSnake: snakeCase,
-    snakeToCamel: camelCase,
-
-    patch,
-    poll,
-    strcmp,
 })
 
 // Client Information

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -115,6 +115,7 @@ interface StratusRuntime {
     Client: bowser.IBowser | any
     Internals: {
         [key: string]: any
+        Cookie: (name: any, value?: any, expires?: any, path?: any, domain?: any, secure?: any, sameSite?: any) => string|null
         CssLoader?: (url: any) => Promise<void>
         JsLoader?: (url: any) => Promise<void>
         LoadCss?: (urls?: string|string[]|LooseObject) => Promise<void>
@@ -267,6 +268,7 @@ export const Stratus: StratusRuntime = {
     History: {},
     Instances: {},
     Internals: {
+        Cookie: cookie,
         XHR: (request?: XHRRequest) => (new XHR(request)).send()
     },
     Loaders: {},

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -21,9 +21,6 @@ import {
     ucfirst
 } from '@stratusjs/core/misc'
 import {
-    titleCase,
-} from '@stratusjs/core/conversion'
-import {
     DOM,
     DOMType
 } from '@stratusjs/core/dom'
@@ -383,16 +380,9 @@ mixin({
     // Underscore Compatibility References: https://github.com/lodash/lodash/wiki/Migrating
     // TODO: Remove once phased out completely
 
-    // This function simply changes the first letter of a string to a lower case.
-    lcfirst,
-
     // This function allows creation, edit, retrieval and deletion of cookies.
     // Note: Delete with `cookie(name, '', -1)`
     cookie,
-
-    // Case Switchers
-    titleCase, // _.startCase
-
 })
 
 // Client Information

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -390,14 +390,6 @@ mixin({
     // Note: Delete with `cookie(name, '', -1)`
     cookie,
 
-    // This function digests URLs into an object containing their respective
-    // values, which will be merged with requested parameters and formulated
-    // into a new URL.
-    setUrlParams, // 1 reference in menu autocomplete
-
-    // Determines whether or not the string supplied is in a valid JSON format
-    isJSON,
-
     // Case Switchers
     titleCase, // _.startCase
 

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -378,9 +378,7 @@ if (cookie('env')) {
 // ------------------
 
 mixin({
-
-    // Underscore Compatibility References: https://github.com/lodash/lodash/wiki/Migrating
-    // TODO: Remove once phased out completely
+    // FIXME: mixins are no longer accessible Remove at later version
 
     // This function allows creation, edit, retrieval and deletion of cookies.
     // Note: Delete with `cookie(name, '', -1)`


### PR DESCRIPTION
**@stratusjs/runtime 0.13.0** published
Adds:
- Stratus.Internals.Cookie() reference for older implementations
Removes:
- Inaccessible deprecated underscore references

**@stratusjs/core 0.8.1** published
Changes:
- modernized formatting

**@stratusjs/angularjs 0.11.0** published
Adds:
- cookie to Generic controller scope
Changes:
- update deprecated underscore mixins
- modernized formatting

**@stratusjs/angularjs-extras 0.16.0** published
Changes:
- update deprecated underscore mixins