### PR TITLE
@stratusjs/runtime 0.14.3 @stratusjs/angular 0.12.12

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -55,10 +55,10 @@
     "@codemirror/lang-html": "^6.4.0",
     "@stratusjs/angularjs": "^0.11.0",
     "@stratusjs/boot": "^1.2.0",
-    "@stratusjs/core": "^0.8.1",
+    "@stratusjs/core": "^0.9.0",
     "@stratusjs/map": "^0.6.6",
-    "@stratusjs/runtime": "^0.13.0",
-    "@stratusjs/stripe": "^1.2.3",
+    "@stratusjs/runtime": "^0.14.2",
+    "@stratusjs/stripe": "^2.0.0",
     "angular-froala-wysiwyg": "^3.2.7",
     "codemirror": "^6.0.1",
     "froala-editor": "^3.2.7",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angular",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "description": "This is the angular package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -57,7 +57,7 @@
     "@stratusjs/boot": "^1.2.0",
     "@stratusjs/core": "^0.9.0",
     "@stratusjs/map": "^0.6.6",
-    "@stratusjs/runtime": "^0.14.2",
+    "@stratusjs/runtime": "^0.14.3",
     "@stratusjs/stripe": "^2.0.0",
     "angular-froala-wysiwyg": "^3.2.7",
     "codemirror": "^6.0.1",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/runtime",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "This is the runtime package for StratusJS.",
   "scripts": {},
   "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/runtime",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "This is the runtime package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -25,7 +25,7 @@
     "npm": ">= 8.19.3"
   },
   "dependencies": {
-    "@stratusjs/core": "^0.8.1",
+    "@stratusjs/core": "^0.9.0",
     "bowser-legacy": "npm:bowser@^1.9.4",
     "jquery": "^3.4.1",
     "lodash": "^4.17.21",

--- a/packages/runtime/src/stratus.ts
+++ b/packages/runtime/src/stratus.ts
@@ -760,7 +760,7 @@ Stratus.Internals.Convoy = (convoy: any, query: any) => new Promise((resolve: an
 })
 
 Stratus.Internals.CssLoader = (url: any) => {
-    return new Promise((resolve: any, _reject: any) => {
+    return new Promise((resolve: any, reject: any) => {
         /* Digest Extension */
         /*
          FIXME: Less files won't load correctly due to less.js not being able to parse new stylesheets after runtime
@@ -792,13 +792,16 @@ Stratus.Internals.CssLoader = (url: any) => {
             Stratus.CSS[url] = true
             resolve()
         })
+        Stratus.Events.once(`onerror:${url}`, () => {
+            reject(new Error('Failed to load script: ' + url))
+        })
 
         /* Resolve Promise OnLoad */
         link.onload = () => {
             Stratus.Events.trigger(`onload:${url}`)
         }
         link.onerror = () => {
-            _reject(new Error('Failed to load script: ' + url))
+            Stratus.Events.trigger(`onerror:${url}`)
         }
 
         /* Inject Link into Head */
@@ -810,7 +813,7 @@ Stratus.Internals.CssLoader = (url: any) => {
 }
 
 Stratus.Internals.JsLoader = (url: any) => {
-    return new Promise((resolve: any, _reject: any) => {
+    return new Promise((resolve: any, reject: any) => {
         /* Digest Extension */
         /*
          let extension: any = /\.([0-9a-z]+)$/i;
@@ -841,6 +844,9 @@ Stratus.Internals.JsLoader = (url: any) => {
             Stratus.JS[url] = true
             resolve()
         })
+        Stratus.Events.once('onerror:' + url, () => {
+            reject(new Error('Failed to load script: ' + url))
+        })
 
         /* Resolve Promise OnLoad */
         // NOTE 2025-01-08: this previously had an fallback from 2018 for Stratus.Client.android
@@ -851,7 +857,7 @@ Stratus.Internals.JsLoader = (url: any) => {
             Stratus.Events.trigger('onload:' + url)
         }
         script.onerror = () => {
-            _reject(new Error('Failed to load script: ' + url))
+            Stratus.Events.trigger('onerror:' + url)
         }
 
         /* Inject Link into Head */


### PR DESCRIPTION
**@stratusjs/runtime 0.14.3** published
Changes:
- Update JS/CSS loader to follow Stratus Event workflow
- Update current dependencies

Removes:
- Removes now fixed Android specific css/js loading logic

-----

**@stratusjs/angular 0.12.12** published
Changes:
- Tree dialog Set fetching limit from 20 to 100 for more results
- Update current dependencies


Changes published from https://github.com/Sitetheory/stratus/pull/810