### PR TITLE
@stratusjs/idx 0.26.1 make IDX search component allow searching status of "contract"

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./dist/idx.bundle.js",
   "scripts": {

--- a/packages/idx/src/property/admin/search.filter.component.html
+++ b/packages/idx/src/property/admin/search.filter.component.html
@@ -270,7 +270,7 @@
                 >
                     Sold
                 </md-button>
-                <div data-ng-show="!options.forRent && (_.includes(options.query.where.Status, 'Active') || _.includes(options.query.where.Status, 'Contract'))"
+                <div data-ng-show="!options.forRent || _.includes(options.query.where.Status, 'Contract')"
                      data-layout="row"
                      data-layout-align="left">
                     <md-checkbox

--- a/packages/idx/src/property/search.classic.component.html
+++ b/packages/idx/src/property/search.classic.component.html
@@ -105,7 +105,7 @@
                         </md-button>
                     </div>
 
-                    <div data-ng-show="!options.forRent && _.includes(options.query.where.Status, 'Active')">
+                    <div data-ng-show="!options.forRent">
                         <md-checkbox
                                 class="show-under-contract font-secondary"
                                 data-ng-checked="_.includes(options.query.where.Status, 'Contract')"

--- a/packages/idx/src/property/search.compact.component.html
+++ b/packages/idx/src/property/search.compact.component.html
@@ -151,7 +151,7 @@
                         </md-button>
                     </div>
 
-                    <div data-ng-show="!options.forRent && (_.includes(options.query.where.Status, 'Active') || _.includes(options.query.where.Status, 'Contract'))">
+                    <div data-ng-show="!options.forRent || _.includes(options.query.where.Status, 'Contract')">
                         <md-checkbox
                                 class="show-under-contract font-secondary"
                                 data-ng-checked="_.includes(options.query.where.Status, 'Contract')"


### PR DESCRIPTION
@stratusjs/idx 0.26.1 to be published
Changes:
- Contract is a valid status and should be toggle-able independently of other status (e.g. don't need active checked)