### PR TITLE
@stratusjs/idx 0.27.1 Fix Featured Property Images

### DIFF
--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/idx",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "AngularJS idx/property Service and Components bundle to be used as an add on to StratusJS",
   "main": "./dist/idx.bundle.js",
   "scripts": {

--- a/packages/idx/src/property/list.component.html
+++ b/packages/idx/src/property/list.component.html
@@ -62,6 +62,7 @@
                             </div>
                             <a data-ng-click="displayModelDetails(property, $event)" data-ng-href="{{::getDetailsURL(property)}}" target="popup">
                                 <div class="image-wrapper"
+                                     data-init-now="true"
                                      data-stratus-src-version="{{::(property.Images[0].Lazy == 'stratus-src' ? 'best' : 'false')}}"
                                      data-stratus-src="{{::property.Images[0].MediaURL || 'false'}}"
                                      aria-label="Main Image of Listing"


### PR DESCRIPTION
@stratusjs/idx 0.27.1 published
Changes
- Fix Featured Property Images when loaded into a fixed height container
- - force all images to load without stratus-spy due to not being detected as a scroll event to auto load