### PR TITLE
@stratusjs/angularjs-extras 0.18.3

### DIFF
--- a/packages/angularjs-extras/package.json
+++ b/packages/angularjs-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/angularjs-extras",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "This is the AngularJS Extras package for StratusJS.",
   "scripts": {},
   "repository": {
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@stratusjs/angularjs": "^0.11.0",
-    "@stratusjs/core": "^0.9.0",
-    "@stratusjs/runtime": "^0.14.1",
+    "@stratusjs/core": "^0.9.1",
+    "@stratusjs/runtime": "^0.14.3",
     "js-md5": "^0.7.3",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",

--- a/packages/angularjs-extras/src/directives/tabRouting.ts
+++ b/packages/angularjs-extras/src/directives/tabRouting.ts
@@ -198,7 +198,7 @@ Stratus.Directives.TabRouting = (
                     // Ensure we always start with a / for delimiting.
                     path += '/'
                 }
-                path += `/${$scope.options.urlLabel}/${tabName}/`
+                path += `${$scope.options.urlLabel}/${tabName}/`
 
                 // Set the new url options
                 $rootScope.$applyAsync(() => {


### PR DESCRIPTION
@stratusjs/angularjs-extras 0.18.3 published
Changes:
- Fixes Tab routing adding an extra '/' delimiter