### PR TITLE
Follow-up: enforce positive whole page values in Collection pagination

### DIFF
--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -527,12 +527,18 @@ export class Collection<T = LooseObject> extends EventManager {
         const validPage = this.normalizePositiveWholeNumber(page)
         this.paginate = !isUndefined(validPage)
         if (isUndefined(validPage)) {
-            delete this.meta.get('api').p
+            const api = this.meta.get('api')
+            if (isObject(api)) {
+                delete api.p
+            }
             return
         }
         this.meta.set('api.p', validPage)
         this.fetch().then()
-        delete this.meta.get('api').p
+        const api = this.meta.get('api')
+        if (isObject(api)) {
+            delete api.p
+        }
     }
 
     private normalizePositiveWholeNumber(value: any): number | undefined {

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -527,23 +527,24 @@ export class Collection<T = LooseObject> extends EventManager {
         const validPage = this.normalizePositiveWholeNumber(page)
         this.paginate = !isUndefined(validPage)
         if (isUndefined(validPage)) {
-            const api = this.meta.get('api')
-            if (isObject(api)) {
-                delete api.p
-            }
+            this.clearApiPage()
             return
         }
         this.meta.set('api.p', validPage)
         this.fetch().then()
-        const api = this.meta.get('api')
-        if (isObject(api)) {
-            delete api.p
-        }
+        this.clearApiPage()
     }
 
     private normalizePositiveWholeNumber(value: any): number | undefined {
         const page = Number(value)
         return Number.isFinite(page) && Number.isInteger(page) && page >= 1 ? page : undefined
+    }
+
+    private clearApiPage(): void {
+        const api = this.meta.get('api')
+        if (isObject(api) && Object.prototype.hasOwnProperty.call(api, 'p')) {
+            delete api.p
+        }
     }
 
     toJSON() {

--- a/packages/angularjs/src/services/collection.ts
+++ b/packages/angularjs/src/services/collection.ts
@@ -309,6 +309,14 @@ export class Collection<T = LooseObject> extends EventManager {
                 withCredentials: this.withCredentials,
             }
             if (!isUndefined(data)) {
+                if (isObject(data) && Object.prototype.hasOwnProperty.call(data, 'p')) {
+                    const validPage = this.normalizePositiveWholeNumber((data as LooseObject).p)
+                    if (isUndefined(validPage)) {
+                        delete (data as LooseObject).p
+                    } else {
+                        (data as LooseObject).p = validPage
+                    }
+                }
                 if (action === 'GET') {
                     if (isObject(data) && Object.keys(data).length) {
                         request.url += request.url.includes('?') ? '&' : '?'
@@ -516,10 +524,20 @@ export class Collection<T = LooseObject> extends EventManager {
     }
 
     page(page: any) {
-        this.paginate = !isEmpty(page)
-        this.meta.set('api.p', page)
+        const validPage = this.normalizePositiveWholeNumber(page)
+        this.paginate = !isUndefined(validPage)
+        if (isUndefined(validPage)) {
+            delete this.meta.get('api').p
+            return
+        }
+        this.meta.set('api.p', validPage)
         this.fetch().then()
         delete this.meta.get('api').p
+    }
+
+    private normalizePositiveWholeNumber(value: any): number | undefined {
+        const page = Number(value)
+        return Number.isFinite(page) && Number.isInteger(page) && page >= 1 ? page : undefined
     }
 
     toJSON() {


### PR DESCRIPTION
### Motivation

- Prevent invalid page values from user-controlled query parameters (e.g. `-1`, `1.5`, `Infinity`, `NaN`) being forwarded to the API via `api.p` and causing incorrect pagination.
- Centralize page-number validation so all pagination entry points behave consistently and defensively.

### Description

- Added a private helper `normalizePositiveWholeNumber()` that returns a finite integer `>= 1` or `undefined` for invalid inputs.
- In `sync()` added defensive handling for `data.p` so `p` is normalized and removed when invalid before serializing the request.
- Updated `page(page)` to validate the incoming `page` value, short-circuit on invalid input, and only set `meta.api.p` when the value is a valid whole positive number.

### Testing

- Ran `git diff --check` to validate there are no whitespace/patch issues and it passed.
- Inspected the changes with `git diff` to verify the intended edits to `packages/angularjs/src/services/collection.ts` were applied as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5c212dec832a900e1bafc93ff87e)