### PR TITLE
fix(@stratusjs/calendar): replace deprecated app004 microCORS proxy with microcors.sitetheory.io

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratusjs/calendar",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "AngularJS Calendar component and iCAL service to be used as an add on to StratusJS. Makes use of fullcalendar and iCAL",
   "scripts": {},
   "repository": {

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -322,12 +322,14 @@ Stratus.Components.Calendar = {
             /*if (fullUrl.startsWith('http')) {
                 fullUrl = `https://cors-anywhere.herokuapp.com/${url}`
             }*/
+            // Use the microCORS proxy to bypass CORS restrictions on external iCal feeds.
+            // Guard: only proxy URLs that are external http(s) and not already proxied.
             if (
                 url.startsWith('http') &&
                 !url.startsWith('/') &&
-                !url.startsWith('https://app004.sitetheory.io/')
+                !url.startsWith('https://microcors.sitetheory.io/')
             ) {
-                url = `https://app004.sitetheory.io/${url}`
+                url = `https://microcors.sitetheory.io/${url}`
             }
 
             const response = await $http.get(url)


### PR DESCRIPTION
## Summary
- Replaces hardcoded `app004.sitetheory.io` CORS proxy with `microcors.sitetheory.io` in `calendar.ts`
- Updates both the guard condition and the proxy URL assignment
- Bumps `@stratusjs/calendar` version to `1.6.2`

## Tested
Verified on dev server — external iCal feeds now proxy through `microcors.sitetheory.io` correctly.